### PR TITLE
Fix Windows character rendering (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 <!-- Add dated entries here as patterns are noticed -->
 - 2026-02-01: GitHub issue updates were missed during v0.9.1 development, requiring 11% session usage for retroactive updates. Root cause: documentation step existed but wasn't prominent/mandatory enough. Fix: Added explicit "GitHub Issue Updates (MANDATORY)" section with specific triggers and commands.
 - 2026-02-01: Made code changes for issue #13 while on branch `25-histogram-charts`. Root cause: didn't verify branch before starting work. Fix: Added "Branch Verification (MANDATORY - FIRST STEP)" section requiring branch check before any code changes.
+- 2026-02-01: Version number in `ltl` (line 73) was not updated for v0.9.1 release. Root cause: Release Checklist exists but version update step not enforced. Fix: Added verification step to release process.
 
 ## Project Overview
 
@@ -172,13 +173,14 @@ git push origin v0.8.2-rc1
 ```
 
 ### Release Checklist
-- [ ] Version number updated in `ltl` (line 75)
+- [ ] Version number updated in `ltl` (line 73: `$version_number`) - **VERIFY with `grep version_number ltl | head -1`**
 - [ ] Release notes created at `releases/v{version}.md`
 - [ ] All tests pass locally
 - [ ] Feature documentation updated in `features/`
 - [ ] CLAUDE.md updated if architecture changed
 - [ ] PR created, reviewed, and merged to `main`
 - [ ] Tag created and pushed from `main` branch
+- [ ] After tagging, verify version matches: `./ltl -version` should show the tagged version
 
 ### Verifying a Release
 After the workflow completes:

--- a/ltl
+++ b/ltl
@@ -70,7 +70,7 @@ if ($^O eq 'MSWin32') {                                                         
 }
 
 ## GLOBALS ##
-my $version_number = "0.9.0";
+my $version_number = "0.9.2";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @rolling_window, @ORIGINAL_ARGV, @files_processed );

--- a/releases/v0.9.2.md
+++ b/releases/v0.9.2.md
@@ -1,0 +1,17 @@
+## What's New
+
+- Improved Windows terminal compatibility for bar graphs and heatmaps
+
+## Bug Fixes
+
+- Fixed character rendering on Windows terminals: uses black square (■) instead of full block (█) for better visibility and background color support
+- Fixed heatmap rendering to use platform-appropriate block characters instead of hardcoded full block
+- Fixed bar graph rendering to consistently use the same block character across all log types (removed special case for HTTP status codes)
+
+## Breaking Changes
+
+None
+
+## Upgrade Notes
+
+No special steps required. Windows users will automatically see improved rendering.


### PR DESCRIPTION
## Summary
- Fix character rendering on Windows terminals by using black square (■) instead of full block (█)
- Remove hardcoded block characters from heatmap and bar graph code
- Add mandatory branch verification step to development workflow
- Prepare v0.9.2 release

## Changes
- `$default_chart_block` now platform-aware: uses 'G' (■) on Windows, 'A' (█) elsewhere
- Heatmap `print_heatmap_row()` uses `$blocks{$default_chart_block}` instead of hardcoded █
- Bar graph rendering consistently uses `$blocks{$default_chart_block}` for all log types
- Removed Java GC log specific block override

## Test plan
- [x] Bar graph rendering verified with access logs
- [x] Heatmap rendering verified
- [x] Perl syntax check passed
- [x] Windows testing performed by developer

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)