### PR TITLE
Fix kB unit to use SI base-1000 instead of base-1024 (#63)

### DIFF
--- a/ltl
+++ b/ltl
@@ -1093,16 +1093,16 @@ sub convert_bytes {
     my %units = (
         'B'  => 1,
         'b'  => 1,
-        'kB' => 1024,
-        'KB' => 1024,
-        'k' => 1024,
-        'K' => 1024,
-        'MB' => 1024**2,
-        'M' => 1024**2,
-        'GB' => 1024**3,
-        'G' => 1024**3,
-        'TB' => 1024**4,
-        'T' => 1024**4,
+        'kB' => 1000,
+        'k'  => 1000,
+        'MB' => 1000**2,
+        'M'  => 1000**2,
+        'GB' => 1000**3,
+        'G'  => 1000**3,
+        'TB' => 1000**4,
+        'T'  => 1000**4,
+        'KB'  => 1024,
+        'K'   => 1024,
         'KiB' => 1024,
         'MiB' => 1024**2,
         'GiB' => 1024**3,
@@ -1119,10 +1119,10 @@ sub format_bytes {
     my %units = (
         'b'  => 1,
         'B'  => 1,
-        'kB' => 1024,
-        'MB' => 1024**2,
-        'GB' => 1024**3,
-        'TB' => 1024**4,
+        'KiB' => 1024,
+        'MiB' => 1024**2,
+        'GiB' => 1024**3,
+        'TiB' => 1024**4,
     );
 
     return undef unless defined $value;
@@ -1130,7 +1130,7 @@ sub format_bytes {
     my $bytes = $value * $units{$unit};
     my $bytes_int = int($bytes);  # Use integer for unit comparison to avoid float string length issues
 
-    my @unit_order = ('B', 'kB', 'MB', 'GB', 'TB');
+    my @unit_order = ('B', 'KiB', 'MiB', 'GiB', 'TiB');
     my $formatted_value = $bytes;
     my $formatted_unit = 'B';
 


### PR DESCRIPTION
## Summary
- SI units (`kB`, `k`, `MB`, `M`, `GB`, `G`, `TB`, `T`) now use base-1000 in `convert_bytes()`
- IEC units (`KiB`, `MiB`, `GiB`, `TiB`) and legacy `KB`/`K` stay base-1024
- `format_bytes()` display units changed from `kB`/`MB`/`GB`/`TB` to `KiB`/`MiB`/`GiB`/`TiB`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)