### PR TITLE
Fix uninitialised $scaled_trend_value warning (#86)

### DIFF
--- a/ltl
+++ b/ltl
@@ -4319,7 +4319,7 @@ sub print_bar_graph {
                                 print $col_color->{plain_bg};
                             }
 
-                            if( $i == $scaled_trend_value ) {
+                            if( defined $scaled_trend_value && $i == $scaled_trend_value ) {
                                 print $col_color->{fg};
                             }
 


### PR DESCRIPTION
## Summary
- Add `defined()` guard before numeric comparison on `$scaled_trend_value` at line 4322, matching the existing pattern used for `$scaled_trend_key_highlight` on line 4318
- Fixes warnings when using `-ho -hd -hb` to hide occurrences/duration/bytes columns

## Test plan
- [x] Verified `./ltl -ho -hd -hb` produces zero "uninitialized" warnings
- [x] Verified same with `-hm` heatmap mode

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)