### PR TITLE
Fix macOS build: use perl -S pp (#85)

### DIFF
--- a/build/macos-package.sh
+++ b/build/macos-package.sh
@@ -57,7 +57,7 @@ if [[ "$current_arch" != "$architecture" && "$current_arch" != "aarch64" || "$ar
 fi
 
 echo "[1/2] Building static binary..."
-pp -o ${PACKAGE_NAME} ${SCRIPT_NAME}
+perl -S pp -o ${PACKAGE_NAME} ${SCRIPT_NAME}
 
 # Verify the build
 echo ""


### PR DESCRIPTION
## Summary
- Use `perl -S pp` instead of bare `pp` in macOS build script to ensure the correct PAR::Packer is used
- Matches the approach already used by the Windows build script

## Test plan
- [x] Local macOS build succeeds with `build/macos-package.sh`
- [x] Packed binary runs `-version` successfully (exit code 0)
- [x] Packed binary runs `-mem` successfully (Devel::Size loads correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)