### PR TITLE
Fix highlighted message count mismatch for nested brackets in thread names (#62)

### DIFF
--- a/ltl
+++ b/ltl
@@ -1824,7 +1824,7 @@ sub read_and_process_logs {
                 $match_type = 13;
 
             ## ThingWorx Standard Log Format (ApplicationLog, ErrorLog, ScriptLog, ...) ##
-            } elsif ( ($timestamp_str, $category_bucket, $object, $instance, $user, $session, $platform, $thread, $message ) = $_ =~ /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})[\+\-]\d{4} \[L: ([^\]]*)\] \[O: ([^\]]*)] \[I: ([^\]]*)] \[U: ([^\]]*)] \[S: ([^\]]*)] \[P: ([^\]]*)] \[T: ([^\]]*)] (.*)/) {
+            } elsif ( ($timestamp_str, $category_bucket, $object, $instance, $user, $session, $platform, $thread, $message ) = $_ =~ /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})[\+\-]\d{4} \[L: ([^\]]*)\] \[O: ([^\]]*)] \[I: ([^\]]*)] \[U: ([^\]]*)] \[S: ([^\]]*)] \[P: ([^\]]*)] \[T: ((?:\](?! )|[^\]])*)] (.*)/) {
                 $is_line_match = 1;
                 $match_type = 1;			# this is matching ThingWorx standard log format 2025-02-04 12:05:57.481+0000 [L: DEBUG] 
 


### PR DESCRIPTION
## Summary
- Fix ThingWorx log parser regex to handle thread names with nested brackets (e.g. C3P0 connection pool managers)
- Changed `[^\]]*` to `(?:\](?! )|[^\]])*` in the `[T: ...]` field capture to allow `]` inside thread names when not followed by a space

## Test plan
- [x] Verified 49 highlighted C3P0 messages now appear in summary table (was 0 before fix)
- [x] All 19 regression tests pass
- [x] Normal ThingWorx logs parse correctly
- [x] Edge cases tested: empty thread, empty message, message containing brackets

🤖 Generated with [Claude Code](https://claude.com/claude-code)