### PR TITLE
Replace external Perl action with Homebrew Perl setup script (#93)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,18 +27,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Perl
-        uses: shogo82148/actions-setup-perl@v1
-        with:
-          perl-version: '5.38'
-
-      - name: Install PAR::Packer
-        run: cpanm --notest PAR::Packer
-
-      - name: Generate and install dependencies
-        run: |
-          cd build && ./generate-cpanfile.sh
-          cpanm --notest --installdeps .
+      - name: Setup build environment
+        run: ./build/macos-setup.sh
 
       - name: Build static binary
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,8 @@ The repository contains three tools:
 
 ### Install Dependencies
 ```bash
-# macOS
-brew install cpanminus && cpanm PAR::Packer
-cd build && ./generate-cpanfile.sh && cpanm --notest --installdeps .
+# macOS (uses Homebrew Perl — do NOT use macOS system Perl)
+./build/macos-setup.sh
 
 # Ubuntu/Linux
 sudo apt-get install build-essential perl perl-base perl-modules libperl-dev cpanminus

--- a/build/macos-setup.sh
+++ b/build/macos-setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# macOS Build Environment Setup Script
+# Installs Homebrew Perl, cpanminus, PAR::Packer, and project dependencies
+#
+# Requirements:
+#   - Homebrew (https://brew.sh)
+#
+# Usage:
+#   ./build/macos-setup.sh
+#
+# Note: macOS system Perl is known to be problematic — this script installs
+#       Homebrew Perl to ensure a reliable build environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=========================================="
+echo "macOS Build Environment Setup"
+echo "=========================================="
+
+# Verify Homebrew is available
+if ! command -v brew &>/dev/null; then
+    echo "[error] Homebrew not found. Install from https://brew.sh"
+    exit 1
+fi
+
+echo "[1/4] Installing Homebrew Perl..."
+brew install perl
+
+# Ensure Homebrew Perl is first on PATH (not macOS system Perl)
+BREW_PREFIX="$(brew --prefix)"
+export PATH="${BREW_PREFIX}/opt/perl/bin:${PATH}"
+
+# Persist PATH for subsequent GitHub Actions steps
+if [ -n "${GITHUB_PATH:-}" ]; then
+    echo "${BREW_PREFIX}/opt/perl/bin" >> "$GITHUB_PATH"
+fi
+
+echo "[info] Using Perl: $(which perl) ($(perl -v | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+'))"
+
+echo "[2/4] Installing cpanminus..."
+brew install cpanminus
+
+echo "[3/4] Installing PAR::Packer..."
+cpanm --notest PAR::Packer
+
+echo "[4/4] Generating cpanfile and installing dependencies..."
+cd "$SCRIPT_DIR"
+if [ ! -f cpanfile ]; then
+    ./generate-cpanfile.sh
+fi
+cpanm --notest --installdeps .
+
+echo ""
+echo "=========================================="
+echo "macOS build environment ready"
+echo "=========================================="


### PR DESCRIPTION
## Summary
- Drop `shogo82148/actions-setup-perl@v1` which fails attestation verification on GitHub runners
- Add `build/macos-setup.sh` that installs Homebrew Perl, cpanminus, PAR::Packer, and project dependencies
- CI and local macOS builds now use the identical setup process
- Update CLAUDE.md build docs to reference the setup script

## Test plan
- [ ] Trigger workflow dispatch to verify macOS build succeeds on GitHub Actions
- [x] Local: `build/macos-setup.sh` installs Homebrew Perl and dependencies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)