### PR TITLE
Add auto-detection of epoch timestamps in CSV input (#98)

### DIFF
--- a/features/user-defined-metrics.md
+++ b/features/user-defined-metrics.md
@@ -235,6 +235,9 @@ When a CSV file is processed with `-udm`, ltl auto-detects the CSV format from t
 **Limitations:**
 - No support for quoted fields with embedded separators (uses simple `split()`)
 - Timestamp column must be named `timestamp` (case-insensitive) or defaults to column 0
+- Same metric name with different aggregation functions is not supported (#99)
+
+**Epoch timestamps** (Issue #98): Numeric epoch timestamps (e.g., `1771078373.207929`) are auto-detected on the first CSV data line. No new flags needed. The `-du` flag overrides the epoch unit if values aren't seconds (`-du ms` for milliseconds, `-du us` for microseconds, `-du ns` for nanoseconds).
 
 ## Future Enhancements (Out of Scope)
 

--- a/ltl
+++ b/ltl
@@ -163,6 +163,7 @@ my ( @udm_configs, @udm_raw_args, %udm_last_value );
 my ( $csv_separator_override, @udm_csv_message_col_names );
 my ( $csv_detected, $csv_separator, $csv_timestamp_col, %csv_col_index );
 my ( @csv_udm_col_indices, @csv_message_col_indices );
+my $csv_epoch_timestamp = 0;  # 1 if CSV timestamp column contains epoch values
 
 # Pattern file filter options (Issue #19)
 my (@include_files, @exclude_files, @highlight_files);   # File paths from command line (arrays for multiple files)
@@ -1762,6 +1763,7 @@ sub read_and_process_logs {
         my( $file_name ) = $in_file =~ /(.+)(\W\d{4,}).+$/;
         %udm_last_value = () if @udm_configs;  # Reset delta state between files (Issue #22)
         $csv_detected = 0;
+        $csv_epoch_timestamp = 0;
         %csv_col_index = ();
         @csv_udm_col_indices = ();
         @csv_message_col_indices = ();
@@ -1810,6 +1812,11 @@ sub read_and_process_logs {
                 @csv_fields = split(/\Q$csv_separator\E/, $_, -1);
                 $timestamp_str = $csv_fields[$csv_timestamp_col];
                 $timestamp_str =~ s/^\s+|\s+$//g if defined $timestamp_str;
+
+                # Detect epoch timestamps on first data line
+                if ($line_number == 2 && defined $timestamp_str && $timestamp_str =~ /^\d+(\.\d+)?$/) {
+                    $csv_epoch_timestamp = 1;
+                }
 
                 # Build message from -ucm columns or default label
                 if (@csv_message_col_indices) {
@@ -2056,7 +2063,18 @@ sub read_and_process_logs {
 
                 # Extract milliseconds if present (supports . or , separator, 1-6 digits)
                 my $fractional_ms = 0;
-                if ($timestamp_str =~ s/(:\d{2}:\d{2})[.,](\d{1,6})/$1/) {
+                if ($csv_epoch_timestamp) {
+                    # Epoch timestamp: value is already epoch seconds (or other unit via -du)
+                    my $epoch_val = $timestamp_str;
+                    if (defined $duration_unit_override) {
+                        $epoch_val /= 1000         if $duration_unit_override eq 'ms';
+                        $epoch_val /= 1000000      if $duration_unit_override eq 'us';
+                        $epoch_val /= 1000000000   if $duration_unit_override eq 'ns';
+                    }
+                    $timestamp = int($epoch_val);
+                    my $frac = $epoch_val - $timestamp;
+                    $fractional_ms = $frac * 1000 if $frac > 0;
+                } elsif ($timestamp_str =~ s/(:\d{2}:\d{2})[.,](\d{1,6})/$1/) {
                     my $frac_digits = $2;
                     # Normalize to milliseconds (e.g., .1 = 100ms, .12 = 120ms, .123 = 123ms, .123456 = 123.456ms)
                     $fractional_ms = $frac_digits * (10 ** (3 - length($frac_digits)));
@@ -2064,6 +2082,8 @@ sub read_and_process_logs {
 
                 unless (grep { $_ eq $category_bucket } @log_levels) {				# this condition importantly only continues if the read/parsed log category is one of the ones defined
                     next;
+                } elsif ($csv_epoch_timestamp) {
+                    # Epoch already parsed above, skip timegm()
                 } elsif( $match_type == 1 || $match_type == 2 || $match_type == 5 || $match_type == 6 || $match_type == 7 || $match_type == 8 || $match_type == 10 || $match_type == 11 || $match_type == 13 ) {
                     if (exists $timestamp_cache{$timestamp_str}) {
                         $timestamp = $timestamp_cache{$timestamp_str};


### PR DESCRIPTION
## Summary
- Auto-detect numeric epoch timestamps in CSV files on first data line
- Support `-du` override for epoch unit (ms, us, ns)
- Update UDM feature docs with epoch timestamp support and #99 limitation

## Test plan
- [x] Epoch timestamp CSV: `logs/UDM/results_data_idonly-timestampMs.csv`
- [x] ISO timestamp CSV regression: `logs/UDM/connection-server-custom-metrics.csv`
- [x] Non-CSV log file regression: `logs/AccessLogs/localhost_access_log.2025-03-21.txt`