### PR TITLE
Release v0.12.4

### DIFF
--- a/ltl
+++ b/ltl
@@ -70,7 +70,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.12.3";
+my $version_number = "0.12.4";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @rolling_window, @ORIGINAL_ARGV, @files_processed );

--- a/releases/v0.12.4.md
+++ b/releases/v0.12.4.md
@@ -1,0 +1,6 @@
+# Release v0.12.4
+
+## Bug Fixes
+
+- Fix UDM heatmap/histogram lookup when metric names are disambiguated by aggregation suffix (#104)
+- Fix heatmap legend displaying raw unformatted floats instead of unit-aware values for disambiguated UDM metrics (#104)


### PR DESCRIPTION
## Summary

- Fix UDM heatmap/histogram lookup when metric names are disambiguated by aggregation suffix (#104)
- Fix heatmap legend displaying raw unformatted floats instead of unit-aware values for disambiguated UDM metrics (#104)

🤖 Generated with [Claude Code](https://claude.com/claude-code)