### PR TITLE
Fix format_number regex mangling values with trailing zeros (#108)

### DIFF
--- a/ltl
+++ b/ltl
@@ -1183,7 +1183,7 @@ sub format_bytes {
     }
 
     $formatted_value = sprintf("%.1f", $formatted_value);
-    $formatted_value =~ s/\.[0]+(\s|\w|$)/$1/;       # remove trailing .0 if present
+    $formatted_value =~ s/\.0+(?=\s|$)//;             # remove trailing .0 if followed by space or end of string
 
     return "$formatted_value $formatted_unit";
 }
@@ -1283,7 +1283,7 @@ sub format_number {
     }
 
     $formatted_value = sprintf("%.${decimals}f%s%s", $formatted_value, defined($space) ? " " : "", $formatted_unit eq "1" ? "" : $formatted_unit );
-    $formatted_value =~ s/\.[0]+(\s|\w|$)/$1/;       # remove trailing .0 if present
+    $formatted_value =~ s/\.0+(?=\s|$)//;             # remove trailing .0 if followed by space or end of string
 
     return $formatted_value;
 }
@@ -1327,7 +1327,7 @@ sub format_time {
     }
 
     $formatted_value = sprintf("%.1f", $formatted_value);
-    $formatted_value =~ s/\.[0]+(\s|\w|$)/$1/;                                              # remove trailing .0 if present
+    $formatted_value =~ s/\.0+(?=\s|$)//;                                                    # remove trailing .0 if followed by space or end of string
     
 
     my $unit_name = $unit_names{$formatted_unit}{$format};                                  # Get the appropriate unit name based on format


### PR DESCRIPTION
## Summary

- Fix regex `s/\.[0]+(\s|\w|$)/$1/` in `format_number`, `format_bytes`, and `format_time` that incorrectly matched partial zero sequences (e.g. `.0` in `64.09 k` → `649 k`)
- Replaced with `s/\.0+(?=\s|$)//` which only strips `.0+` when followed by space or end of string

Fixes #108