### PR TITLE
Fix consolidation performance and tracking invariant (#131)

### DIFF
--- a/features/fuzzy-message-consolidation.md
+++ b/features/fuzzy-message-consolidation.md
@@ -1360,9 +1360,9 @@ When both `-V` and `-g` are active, ltl outputs a consolidation summary block in
 
   --- plain|WARN: 8782 unique keys seen, 2 checkpoints, 36 patterns ---
     S1 Inline match:       6101
-    S2 Ceiling filter:     8  (occurrences >= 3)
+    S2 Ceiling filter:     8  (occurrences >= 3, remaining after all passes)
     S3 Checkpoint match:   0
-    S4 Pairwise discovery: 2555
+    S4 Pairwise discovery: 2668
     S5 Unmatched:          5
     Reduction: 8782 → 49 (99.4%)
 
@@ -1371,11 +1371,11 @@ When both `-V` and `-g` are active, ltl outputs a consolidation summary block in
     S1 Inline match:       17613
     S2 Ceiling filter:     29
     S3 Checkpoint match:   0
-    S4 Pairwise discovery: 5603
+    S4 Pairwise discovery: 5728
     S5 Unmatched:          19
     Checkpoints:           6
     Patterns:              79
-    find_candidates calls: 262
+    find_candidates calls: 285
     Reduction: 23389 → 127 (99.5%)
 ```
 
@@ -1403,6 +1403,8 @@ S1 + S2 + S3 + S4 + S5 = keys_seen
 ```
 
 If this invariant fails, a `[WARN] Tracking mismatch` line appears with the delta. This indicates a counting bug in the stage tracking — the consolidation itself may still be functionally correct, but the diagnostic counters are not reliable until the mismatch is resolved.
+
+**Counting approach:** S1, S3, and S4 are accumulated during processing. S2 and S5 are computed at report time by partitioning the remaining `%consolidation_unmatched` keys: keys with `occurrences >= ceiling` are S2, the rest are S5. This avoids double-counting ceiling keys that survive multiple checkpoints. Final pass absorptions (ceiling keys matched by pairwise discovery) are added to S4.
 
 #### What to Look For
 
@@ -1470,6 +1472,7 @@ After firing, the counter resets to 0 and accumulation resumes.
 | File | Size | Keys Seen | S1% | Reduction | Time (no -g) | Time (-g) | Notes |
 |------|------|-----------|-----|-----------|-------------|-----------|-------|
 | `ScriptLog.2025-04-09.4.log` | 72MB | ~223K | ~97% | ~99.9% | ~4s | ~9s | ThingWorx script log, many unique thread names |
+| `ScriptLog.2025-*` (5 files) | 463MB | ~499K | ~96% | ~99.9% | — | ~30s | Multi-file scale test; 1.53M lines |
 | `HundredsOfThousandsOfUniqueErrors.log` | 102MB | ~286K | >99% | >99% | — | — | Primary prototype test file |
 
 ### Common Issues and Fixes
@@ -1478,7 +1481,7 @@ After firing, the counter resets to 0 and accumulation resumes.
 |---------|-------------|-----|
 | `-g` makes execution 10x+ slower | Checkpoint trigger per-cat_gk instead of per-category | Fixed in #131: trigger is now per-category |
 | Too many small groups, hundreds of checkpoints | Grouping key includes thread/object names | Fixed in #131: grouping key is level-only |
-| Tracking mismatch in verbose output | Stage counter not incremented for some absorption path | Debug: check `run_consolidation_pass` and `run_consolidation_checkpoint` for uncounted paths |
+| Tracking mismatch in verbose output | Stage counter not incremented for some absorption path | Fixed in #131: S2/S5 computed at report time (not accumulated per checkpoint); final pass absorptions tracked in S4 |
 | S3 always 0 | No patterns discovered early enough in a checkpoint for re-scan to absorb keys | Normal for small files; at scale with multiple checkpoints, S3 may contribute |
 | High S5 count | Threshold too high for the data's variation | Lower `-g` threshold |
 | `gk_prefix` errors or missing prefixes | Legacy code from pre-#131 grouping key design | Removed in #131: canonical form is the full `$log_key` |

--- a/ltl
+++ b/ltl
@@ -1644,6 +1644,9 @@ sub group_similar_messages {
                 delete $consolidation_key_message_cat_gk{$key};
             }
 
+            # Track final pass absorptions in S4
+            $consolidation_cat_stats{$cat_gk}{s4_pairwise} += $messages_absorbed;
+
             # Free trigram data from final pass
             delete $consolidation_ngram_index{$cat_gk};
             delete $consolidation_posting_size{$cat_gk};
@@ -7349,14 +7352,14 @@ unless( $group_similar_sensitivity eq "none" ) {
             my $checkpoints = $s->{checkpoints} // 0;
             my $patterns = $s->{patterns_final} // 0;
 
-            # S2: ceiling-excluded keys remaining in unmatched (occurrences >= ceiling)
-            my $ceiling_remaining = 0;
+            # S2 and S5: partition remaining unmatched keys by occurrence ceiling
+            my ($category_part) = split(/\|/, $cat_gk, 2);
+            my $ceiling_filtered = 0;
             my $genuinely_unmatched = 0;
-            my ($category) = split(/\|/, $cat_gk, 2);
-            for my $key (keys %{$consolidation_unmatched{$cat_gk}}) {
-                my $occ = $log_messages{$category}{$key}{occurrences} // 1;
+            for my $key (keys %{$consolidation_unmatched{$cat_gk} // {}}) {
+                my $occ = $log_messages{$category_part}{$key}{occurrences} // 1;
                 if ($occ >= $consolidation_occurrence_ceiling) {
-                    $ceiling_remaining++;
+                    $ceiling_filtered++;
                 } else {
                     $genuinely_unmatched++;
                 }
@@ -7366,25 +7369,25 @@ unless( $group_similar_sensitivity eq "none" ) {
             push @verbose_output, sprintf("  --- %s: %d unique keys seen, %d checkpoints, %d patterns ---",
                 $cat_gk, $keys_seen, $checkpoints, $patterns);
             push @verbose_output, sprintf("    S1 Inline match:       %d", $s->{s1_inline} // 0);
-            push @verbose_output, sprintf("    S2 Ceiling filter:     %d  (occurrences >= %d)", $ceiling_remaining, $consolidation_occurrence_ceiling);
+            push @verbose_output, sprintf("    S2 Ceiling filter:     %d  (occurrences >= %d, remaining after all passes)", $ceiling_filtered, $consolidation_occurrence_ceiling);
             push @verbose_output, sprintf("    S3 Checkpoint match:   %d", $s->{s3_checkpoint} // 0);
             push @verbose_output, sprintf("    S4 Pairwise discovery: %d", $s->{s4_pairwise} // 0);
             push @verbose_output, sprintf("    S5 Unmatched:          %d", $genuinely_unmatched);
 
             # Sanity check: all 5 stages must sum to keys_seen
-            my $accounted = ($s->{s1_inline} // 0) + $ceiling_remaining + ($s->{s3_checkpoint} // 0) + ($s->{s4_pairwise} // 0) + $genuinely_unmatched;
+            my $accounted = ($s->{s1_inline} // 0) + $ceiling_filtered + ($s->{s3_checkpoint} // 0) + ($s->{s4_pairwise} // 0) + $genuinely_unmatched;
             if ($accounted != $keys_seen) {
                 push @verbose_output, sprintf("    [WARN] Tracking mismatch: %d accounted vs %d seen (delta %d)",
                     $accounted, $keys_seen, $keys_seen - $accounted);
             }
 
             push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
-                $keys_seen, $genuinely_unmatched + $ceiling_remaining + $patterns,
-                (1 - ($genuinely_unmatched + $ceiling_remaining + $patterns) / ($keys_seen || 1)) * 100);
+                $keys_seen, $genuinely_unmatched + $ceiling_filtered + $patterns,
+                (1 - ($genuinely_unmatched + $ceiling_filtered + $patterns) / ($keys_seen || 1)) * 100);
 
             $grand_keys += $keys_seen;
             $grand_s1 += ($s->{s1_inline} // 0);
-            $grand_s2 += $ceiling_remaining;
+            $grand_s2 += $ceiling_filtered;
             $grand_s3 += ($s->{s3_checkpoint} // 0);
             $grand_s4 += ($s->{s4_pairwise} // 0);
             $grand_s5 += $genuinely_unmatched;


### PR DESCRIPTION
## Summary
- Fix `-g` consolidation being 26x slower than expected (3.8 min → 8.6 sec on 72MB file)
- Fix tracking invariant mismatch (S1+S2+S3+S4+S5 = keys_seen)
- Add verbose consolidation diagnostics to `-V` output
- Add validation/debugging section to feature documentation

## Root Causes
1. Checkpoint trigger was per-cat_gk instead of per-category — no checkpoints fired during parsing
2. Grouping key included thread/object names — created hundreds of tiny groups
3. S2 accumulated per checkpoint (double-counting ceiling keys); final pass absorptions untracked

## Test Results
- 72MB single file: 3.8 min → 8.6 sec, 149 MiB → 89 MiB
- 463MB (5 files): 30.1 sec, 185 MiB, invariant clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)