### PR TITLE
Redesign final pass to re-scan %log_messages through full pipeline (#137)

### DIFF
--- a/features/137-final-pass-redesign.md
+++ b/features/137-final-pass-redesign.md
@@ -1,0 +1,219 @@
+# Issue #137: Final Pass Redesign — Design Document
+
+**GitHub Issue:** #137
+**Branch:** `137-final-pass-log-messages`
+**Status:** Design phase
+
+## Problem
+
+The final pass in `group_similar_messages()` (ltl lines 1524-1659) is fundamentally broken. It:
+
+1. Only operates on keys remaining in `%consolidation_unmatched` — misses all keys that left the working set
+2. Further filters to ceiling-excluded keys only — ignores everything else
+3. Runs its own inline pairwise discovery — bypasses the S1→S2→S3→S4 pipeline entirely
+4. Does not reuse `run_consolidation_checkpoint()` or `match_consolidation_patterns()`
+
+This means:
+- **Evicted keys (S6)** from #135 sit in `%log_messages` with no path back to consolidation
+- **All remaining `%log_messages` keys** are never re-tested against the full set of discovered patterns
+- The final pass is a separate mini-pipeline, not the same architecture we've been building and tuning
+
+## Solution
+
+Replace the current final pass with a loop over all `%log_messages` keys that feeds them through the **same** consolidation pipeline used during streaming. The only difference is the data source: instead of parsing log lines from files, the final pass iterates sorted `%log_messages` keys.
+
+## Design Changes
+
+### 1. Extract `consolidation_process_key()` subroutine
+
+The consolidation pipeline logic currently embedded inline in the parsing loop (ltl lines 3882-3942) is extracted into a reusable subroutine. Both the streaming path and the final pass call this subroutine.
+
+**Current inline code (lines 3882-3942):**
+```
+if ($is_new_key) {
+    keys_seen++
+    S1: match_consolidation_patterns() → if hit, accumulate stats into cluster
+    S1 miss: store in consolidation_key_message, consolidation_unmatched
+    Check trigger → fire run_consolidation_checkpoint() if threshold met
+}
+```
+
+**New subroutine interface:**
+```perl
+sub consolidation_process_key {
+    my ($log_key, $category, $cat_gk, $capped_msg, $stats_source) = @_;
+    # Returns: 1 if S1 matched, 0 if not
+}
+```
+
+**`$stats_source` parameter:** A hashref containing stats to merge into the cluster on S1 match. This is how the two callers differ:
+- **Streaming caller:** constructs `{ occurrences => 1, total_duration => $duration, durations => [$duration], total_bytes => $bytes, ... }` from parsed line values
+- **Final pass caller:** passes `$log_messages{$category}{$log_key}` directly — already has aggregated stats (occurrences, durations array, min/max, etc.)
+
+On S1 match, the subroutine calls `merge_consolidation_stats($cluster, $stats_source)`. This replaces the per-field accumulation currently inline at lines 3892-3915. `merge_consolidation_stats()` already handles all fields correctly for both single-line and aggregated data.
+
+**Pipeline steps inside the subroutine:**
+1. Increment `keys_seen` counter (phase-appropriate counter set)
+2. S1: call `match_consolidation_patterns()` — if match, call `merge_consolidation_stats()`, increment S1 counter, return 1
+3. S1 miss: store in `consolidation_key_message`, `consolidation_unmatched`, set generation and checkpoint count
+4. Increment category unmatched count, check trigger, fire `run_consolidation_checkpoint()` if threshold met
+5. Return 0
+
+### 2. Replace final pass in `group_similar_messages()`
+
+Delete the current final pass code (lines 1524-1659). Replace with:
+
+```perl
+if ($consolidation_final_pass) {
+    # 1. Reset transient working state
+    # 2. Swap threshold/ceiling for final pass parameters
+    # 3. Set phase flag
+
+    for my $category (sort keys %log_messages) {
+        for my $log_key (sort keys %{$log_messages{$category}}) {
+            # Extract grouping key from log_key: [LEVEL] or [STATUS_CODE]
+            # Build cat_gk, capped_msg
+            # Call consolidation_process_key()
+            # If S1 matched, delete from %log_messages
+        }
+    }
+
+    # EOF checkpoints for final pass remainder
+    for my $cat_gk (sort keys %consolidation_unmatched) {
+        if (scalar(keys %{$consolidation_unmatched{$cat_gk}}) >= 2) {
+            my ($cat, $gk) = split(/\|/, $cat_gk, 2);
+            run_consolidation_checkpoint($cat, $gk);
+        }
+    }
+
+    # Restore threshold/ceiling, reset phase
+}
+```
+
+**Sorting keys:** `sort keys %{$log_messages{$category}}` naturally groups similar messages together. When a pattern is discovered mid-checkpoint, the immediately following keys are more likely to match via S3 — better checkpoint yield.
+
+**Hash iteration safety:** `sort keys` materializes the key list into an array before iteration. Deleting keys during the loop (via S1 match or checkpoint absorption) is safe.
+
+### 3. Data Merging
+
+Both callers use `merge_consolidation_stats($cluster, $stats_source)` on S1 match — single code path.
+
+`run_consolidation_pass()` already merges from `$log_messages{$category}{$key}` at S3 (line 2265) and S4 (lines 2336, 2384). During the final pass, those entries have aggregated stats; during streaming, they have single-line stats. The merge function handles both correctly — it sums occurrences, concatenates duration arrays, takes min of mins, max of maxes.
+
+No changes needed to `merge_consolidation_stats()`.
+
+### 4. Eviction: DISABLED During Final Pass
+
+Adaptive eviction (#135) must be disabled during the final pass:
+
+1. **No subsequent pass.** The final pass is the last opportunity to consolidate. Evicted keys remain unconsolidated forever. During streaming, eviction is acceptable because the final pass is the safety net. Eviction *in* the safety net defeats its purpose.
+
+2. **Bounded set.** Eviction prevents unbounded growth during streaming (new keys keep arriving). The final pass iterates a fixed, known set — no new keys arrive. The working set is naturally bounded by `%log_messages` size.
+
+**Implementation:** The `$consolidation_phase` flag tells `run_consolidation_checkpoint()` to skip:
+- Fast-path eviction (lines 2472-2500)
+- Survivor culling (lines 2539-2575)
+
+When `$consolidation_phase eq 'final_pass'`, all keys survive checkpoints indefinitely.
+
+### 5. Ceiling During Final Pass
+
+The streaming ceiling (`$consolidation_occurrence_ceiling = 3`) excludes high-occurrence keys from S4 pairwise discovery. In the final pass:
+
+- **S1 matching:** Ceiling doesn't affect S1. All keys are tested against compiled patterns regardless of occurrence count.
+- **S4 discovery:** Use `$consolidation_final_ceiling` (default 1,000,000) instead of streaming ceiling. This allows high-occurrence keys to participate in pairwise discovery.
+
+**Implementation:** Swap `$consolidation_occurrence_ceiling` with `$consolidation_final_ceiling` before the loop, restore after.
+
+### 6. Threshold During Final Pass
+
+Swap `$consolidation_threshold` with `$consolidation_final_threshold` before the loop. Both currently default to 85%, but the separate CLI option (`--final-threshold`) gives users control. Restore after.
+
+### 7. Checkpoint Trigger Size
+
+The streaming trigger (5000 unmatched keys per category) works for the final pass. The remaining `%log_messages` key count is bounded (typically hundreds to low thousands after streaming consolidation), so the trigger may fire 0-2 times. Same cadence is appropriate.
+
+### 8. Extracting Grouping Key from log_key
+
+During streaming, `$grouping_key = $log_level` comes from parsing. In the final pass, extract from the `$log_key`:
+```perl
+my ($grouping_key) = $log_key =~ /^\[([^\]]+)\]/;
+$grouping_key //= "";
+```
+Format: `[$level] ...` for app logs, `[$status_code] ...` for access logs.
+
+### 9. Resetting Transient State Before Final Pass
+
+**Reset** (final pass builds its own working set):
+- `%consolidation_unmatched`
+- `%consolidation_key_message`, `%consolidation_key_message_cat_gk`
+- `%consolidation_key_generation`, `%consolidation_key_checkpoint_count`
+- `%consolidation_ngram_index`, `%consolidation_key_trigrams`, `%consolidation_key_trigrams_norm`, `%consolidation_posting_size`
+- `%consolidation_category_unmatched_count`
+- `%consolidation_absorption_ema` (fresh EMA — though eviction is disabled, useful for observability)
+
+**Preserve** (carry over from streaming):
+- `%consolidation_patterns` — final pass matches against existing patterns and may discover new ones
+- `%consolidation_clusters` — final pass merges into existing clusters
+- `%consolidation_pattern_generation` — carries over for S3 skip optimization
+- `%consolidation_cat_stats` — streaming counters stay; final pass writes to `fp_*` counters
+
+### 10. Separate Observability Counters
+
+`%consolidation_cat_stats` gets parallel counter sets:
+- Streaming: `s1_inline`, `s3_checkpoint`, `s4_pairwise`, `keys_seen`, `checkpoints`, etc. (existing, unchanged)
+- Final pass: `fp_s1_inline`, `fp_s3_checkpoint`, `fp_s4_pairwise`, `fp_keys_seen`, `fp_checkpoints`, etc.
+
+A phase flag (`$consolidation_phase = 'streaming' | 'final_pass'`) tells `consolidation_process_key()` and `run_consolidation_checkpoint()` which counter set to increment.
+
+Verbose output (`-V`) shows both sets separately — streaming contribution vs final pass contribution.
+
+### 11. Streaming Path Refactor
+
+The inline stats accumulation (lines 3892-3915) is replaced with `consolidation_process_key()`. The streaming caller constructs `$stats_source`:
+
+```perl
+my $stats_source = { occurrences => 1 };
+if ($is_access_log) {
+    $stats_source->{total_bytes} = $bytes if defined $bytes;
+    if (defined $duration && !$omit_durations) {
+        $stats_source->{total_duration} = $duration;
+        $stats_source->{total_duration_num} = $duration;
+        $stats_source->{sum_of_squares} = $duration ** 2;
+        $stats_source->{durations} = [$duration];
+    }
+    if (defined $count) {
+        $stats_source->{count_sum} = $count;
+        $stats_source->{count_occurrences} = 1;
+        $stats_source->{count_min} = $count;
+        $stats_source->{count_max} = $count;
+    }
+    foreach my $config (@udm_configs) {
+        my $name = $config->{name};
+        next unless defined $udm_values{$name};
+        $stats_source->{"udm_${name}_sum"} = $udm_values{$name};
+        $stats_source->{"udm_${name}_occurrences"} = 1;
+        $stats_source->{"udm_${name}_min"} = $udm_values{$name};
+        $stats_source->{"udm_${name}_max"} = $udm_values{$name};
+    }
+}
+
+my $matched = consolidation_process_key($log_key, $category, $cat_gk, $capped_msg, $stats_source);
+$consolidation_s1_matched = $matched;
+```
+
+The downstream code (`if (!$consolidation_s1_matched)` at line 3947) continues to control whether stats go to `%log_messages`.
+
+## Files to Modify
+
+- **`ltl`** — extract `consolidation_process_key()`, refactor streaming path, replace final pass in `group_similar_messages()`, disable eviction during final pass, update verbose output for dual-phase reporting
+- **`features/fuzzy-message-consolidation.md`** — update Outstanding Decision 6, update final pass documentation, add lesson learned
+
+## Verification Plan
+
+1. **Tracking invariant**: `S1 + S2 + S3 + S4 + S5 + S6 = keys_seen` must hold for both streaming and final pass phases independently
+2. **Streaming regression**: Run against standard access log with `-g 85 -V --disable-progress` — streaming counters must be unchanged from before the refactor
+3. **Final pass absorption**: Verify final pass `fp_s1_inline` is non-zero on files where eviction occurred during streaming (evicted keys should match patterns)
+4. **XL benchmark**: Time and memory comparison — final pass should add minimal overhead
+5. **Verbose output**: Both streaming and final-pass sections appear separately in `-V` output
+6. **`--no-final-pass`**: Still works (skips the final pass loop entirely)

--- a/features/fuzzy-message-consolidation.md
+++ b/features/fuzzy-message-consolidation.md
@@ -484,9 +484,11 @@ Matching 286K unique messages against 103 compiled regex patterns took 18.4s in 
 
 ### PF-12: Final Pass — Optional High-Similarity Cleanup of Ceiling-Excluded Keys
 
+> **Superseded by #137:** The final pass was redesigned to iterate ALL `%log_messages` keys through the same S1→checkpoint pipeline used during streaming, not just ceiling-excluded keys. The original PF-12 approach (separate inline pairwise discovery on ceiling-excluded keys only) was replaced because it bypassed the S1→S2→S3→S4 architecture, missed evicted keys (S6), and missed non-ceiling keys. The findings below are historical context only.
+
 **Finding:** The occurrence ceiling (default 3) prevents high-occurrence messages from entering discovery. But some high-occurrence messages share patterns (e.g., `CheckHeartbeat` across 16 thread pools, each with 29-47 occurrences). These are obvious consolidation candidates that the ceiling blocks.
 
-**Design decisions:**
+**Design decisions (historical — superseded by #137):**
 - The final pass is a **separate optional process flow** (`--final-pass`), not part of the normal consolidation. It is not always-on — users opt in when they want cleanup of high-occurrence stragglers.
 - The similarity threshold for the final pass is deliberately high (default 95%, configurable via `--final-threshold`). At 95%, only nearly-identical messages consolidate — the only variation allowed is small fields like thread numbers or short IDs. This prevents over-generalization of messages that happen to share common boilerplate.
 - The final pass ceiling (default 100, configurable via `--final-ceiling`) defines the upper bound — messages with more than this many occurrences are left alone even in the final pass.
@@ -1159,6 +1161,8 @@ The core algorithms are sound and proven:
 
 33. **Trigrams are kept while a key is in the unmatched set.** Trigrams are reused across checkpoints — no need to recompute. `build_consolidation_ngram_index` skips keys that already have trigrams. Delete trigrams when key is consumed by consolidation OR evicted. The memory regression (+26.6%) seen in Fixes 1-3 was caused by correctly retaining trigrams for surviving keys (old code wastefully deleted and recomputed them). Per-key eviction naturally resolves this by bounding the surviving set. (#135)
 
+34. **The final pass must use the same pipeline architecture as streaming.** The original final pass (PF-12) was a separate mini-pipeline with its own inline pairwise discovery — it bypassed S1 matching, skipped checkpoint batching, and missed all keys not in `%consolidation_unmatched`. The fix (#137) extracts `consolidation_process_key()` as a shared subroutine and has the final pass iterate sorted `%log_messages` keys through the same S1→checkpoint pipeline. Sorting groups similar messages together for better S3/S4 checkpoint yield. Eviction is disabled during the final pass (bounded set, last opportunity to consolidate). Separate `fp_*` counters track final pass work independently from streaming. (#137)
+
 ### Outstanding Decisions
 
 1. ~~**Acceptable memory overhead**~~ Resolved — on large files (the real use case), the prototype uses LESS memory than ltl: 151 MB vs 256 MB on 3.3 GB access logs. Overhead only applies to small files where trigram cost exceeds S1 savings. (PF-24)
@@ -1166,7 +1170,7 @@ The core algorithms are sound and proven:
 3. ~~**Should Inline::C be a production dependency?**~~ Resolved — NO. Pure Perl is fast enough. See PF-26.
 4. ~~**Final pass integration**~~ Resolved — validated with checkpoint architecture (PF-22).
 5. ~~**Unmatched key eviction (#135)**~~ Resolved — adaptive per-key eviction implemented with EMA-based absorption rate tracking. Survival count scales exponentially with rolling average absorption: <5%→0, 5-50%→1, 50-90%→2, 90-95%→3, 95-99%→4, ≥99%→5. Fast-path eviction skips `run_consolidation_pass` entirely when max_survivals=0 and cp_num>2. Replaces stall detection. XL benchmark: 3.4× faster (55s vs 185s), 47.7% less memory (238 MiB vs 455 MiB). Curve thresholds may need tuning over time (see lesson 32).
-6. **Final pass does not re-scan `%log_messages` (#137)** — The final pass only operates on keys in `consolidation_unmatched`, not all of `%log_messages`. Becomes more important if/when per-key eviction is implemented, since evicted keys return to `%log_messages` with no path back to consolidation.
+6. ~~**Final pass does not re-scan `%log_messages` (#137)**~~ Resolved — Final pass redesigned (#137) to iterate all `%log_messages` keys through the same S1→checkpoint pipeline used during streaming. Extracted `consolidation_process_key()` subroutine shared by both streaming and final pass paths. Eviction disabled during final pass (bounded set, last chance). Sorted key iteration groups similar messages for better checkpoint yield. Separate `fp_*` observability counters. Evicted keys (S6) from streaming are now picked up by the final pass.
 
 ### Next Steps
 

--- a/ltl
+++ b/ltl
@@ -210,6 +210,7 @@ my $consolidation_final_ceiling      = 1_000_000;
 my $consolidation_discriminative_topk = 50;
 my $consolidation_prefilter_ratio    = 0.30;
 my $max_observed_message_length      = 0;
+my $consolidation_phase              = 'streaming';  # 'streaming' or 'final_pass' — controls counter set and eviction behavior
 my $uuid_re = qr/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
 my ( @in_files, @output_columns );
@@ -1520,143 +1521,77 @@ sub get_memory_usage {
 sub group_similar_messages {
     print "\rConsolidating similar messages..." unless $disable_progress;
 
-    # Final pass: consolidate ceiling-excluded keys with higher threshold
+    # Final pass (#137): re-scan all %log_messages keys through the full consolidation pipeline.
+    # Same architecture as streaming — S1 match against compiled patterns, accumulate unmatched,
+    # fire checkpoints at trigger threshold. Keys are sorted to group similar messages together,
+    # improving S3 checkpoint match yield.
+    # Eviction is disabled — this is the last chance to consolidate; the set is bounded.
     if ($consolidation_final_pass) {
-        for my $cat_gk (sort keys %consolidation_unmatched) {
-            my ($category, $grouping_key) = split(/\|/, $cat_gk, 2);
-            my @remaining = sort keys %{$consolidation_unmatched{$cat_gk}};
-            next unless @remaining > 1;
+        # Save streaming S2/S5 before resetting (needed for verbose output)
+        for my $cat_gk (keys %consolidation_unmatched) {
+            my ($category_part) = split(/\|/, $cat_gk, 2);
+            my ($s2, $s5) = (0, 0);
+            for my $key (keys %{$consolidation_unmatched{$cat_gk}}) {
+                my $occ = $log_messages{$category_part}{$key}{occurrences} // 1;
+                if ($occ >= $consolidation_occurrence_ceiling) { $s2++; } else { $s5++; }
+            }
+            $consolidation_cat_stats{$cat_gk}{streaming_s2} = $s2;
+            $consolidation_cat_stats{$cat_gk}{streaming_s5} = $s5;
+        }
 
-            # Select keys that were ceiling-excluded
-            my @candidates;
-            for my $key (@remaining) {
-                my $occ = $log_messages{$category}{$key}{occurrences} // 1;
-                if ($occ >= $consolidation_occurrence_ceiling && $occ < $consolidation_final_ceiling) {
-                    push @candidates, $key;
+        # Reset transient working structures (final pass builds its own working set)
+        %consolidation_unmatched = ();
+        %consolidation_key_message = ();
+        %consolidation_key_message_cat_gk = ();
+        %consolidation_key_generation = ();
+        %consolidation_key_checkpoint_count = ();
+        %consolidation_ngram_index = ();
+        %consolidation_key_trigrams = ();
+        %consolidation_key_trigrams_norm = ();
+        %consolidation_posting_size = ();
+        %consolidation_category_unmatched_count = ();
+        %consolidation_absorption_ema = ();
+        # Preserved: %consolidation_patterns, %consolidation_clusters, %consolidation_pattern_generation, %consolidation_cat_stats
+
+        # Swap threshold and ceiling for final pass parameters
+        my $saved_threshold = $consolidation_threshold;
+        my $saved_ceiling   = $consolidation_occurrence_ceiling;
+        $consolidation_threshold          = $consolidation_final_threshold;
+        $consolidation_occurrence_ceiling = $consolidation_final_ceiling;
+
+        $consolidation_phase = 'final_pass';
+
+        # Iterate all remaining %log_messages keys through the pipeline (sorted for checkpoint efficiency)
+        for my $category (sort keys %log_messages) {
+            for my $log_key (sort keys %{$log_messages{$category}}) {
+                my $capped_msg = substr($log_key, 0, $consolidation_message_length_cap);
+                my ($grouping_key) = $log_key =~ /^\[([^\]]+)\]/;
+                $grouping_key //= "";
+                my $cat_gk = "$category|$grouping_key";
+
+                my $matched = consolidation_process_key(
+                    $log_key, $category, $cat_gk, $capped_msg,
+                    $log_messages{$category}{$log_key}
+                );
+
+                if ($matched) {
+                    delete $log_messages{$category}{$log_key};
                 }
-            }
-            next unless @candidates >= 2;
-
-            # Build n-gram index for candidates
-            delete $consolidation_ngram_index{$cat_gk};
-            delete $consolidation_key_trigrams{$_} for @candidates;
-            build_consolidation_ngram_index($cat_gk, \@candidates);
-
-            my %consumed;
-            my $patterns_discovered = 0;
-            my $messages_absorbed = 0;
-            my $keys_searched = 0;
-            my $max_search = min(500, scalar @candidates);
-
-            for my $key (@candidates) {
-                last if $keys_searched >= $max_search;
-                next if $consumed{$key};
-
-                $keys_searched++;
-                $consolidation_cat_stats{$cat_gk}{fc_calls}++;
-                my @matches = find_consolidation_candidates($cat_gk, $key, $consolidation_final_threshold);
-
-                for my $match (@matches) {
-                    next if $consumed{$match->{key}};
-
-                    my $msg_a = substr($consolidation_key_message{$key} // '', 0, $consolidation_message_length_cap);
-                    my $msg_b = substr($consolidation_key_message{$match->{key}} // '', 0, $consolidation_message_length_cap);
-
-                    my $raw_mask = compute_mask($msg_a, $msg_b);
-                    my $mask = coalesce_mask($raw_mask);
-                    my $canonical = derive_canonical($msg_a, $mask);
-                    my $regex = derive_regex($msg_a, $mask);
-
-                    next unless ($msg_a =~ $regex) && ($msg_b =~ $regex);
-
-                    $consumed{$key} = 1;
-                    $consumed{$match->{key}} = 1;
-
-                    my $new_cluster = {
-                        canonical   => $canonical,
-                        pattern     => $regex,
-                        mask        => $mask,
-                        occurrences => 0,
-                        match_count => 0,
-                    };
-
-                    for my $src_key ($key, $match->{key}) {
-                        if (exists $log_messages{$category}{$src_key}) {
-                            merge_consolidation_stats($new_cluster, $log_messages{$category}{$src_key});
-                            $new_cluster->{match_count}++;
-                            $messages_absorbed++;
-                        }
-                    }
-
-                    # Interleaved re-scan against remaining candidates
-                    for my $ukey (@candidates) {
-                        next if $consumed{$ukey};
-                        my $umsg = $consolidation_key_message{$ukey};
-                        next unless defined $umsg;
-                        if ($umsg =~ $regex) {
-                            $consumed{$ukey} = 1;
-                            if (exists $log_messages{$category}{$ukey}) {
-                                merge_consolidation_stats($new_cluster, $log_messages{$category}{$ukey});
-                                $new_cluster->{match_count}++;
-                                $messages_absorbed++;
-                            }
-                        }
-                    }
-
-                    # Try merge-first into existing patterns
-                    my ($merged_regex, $merged_entry, $merged_cluster) = try_consolidation_merge_into_existing($cat_gk, $canonical, $regex, $mask, $new_cluster);
-                    if ($merged_regex) {
-                        $patterns_discovered++;
-                        # Re-scan remaining candidates against generalized pattern
-                        for my $ukey (@candidates) {
-                            next if $consumed{$ukey};
-                            my $umsg = $consolidation_key_message{$ukey};
-                            next unless defined $umsg;
-                            if ($umsg =~ $merged_regex) {
-                                $consumed{$ukey} = 1;
-                                if (exists $log_messages{$category}{$ukey}) {
-                                    merge_consolidation_stats($merged_cluster, $log_messages{$category}{$ukey});
-                                    $merged_cluster->{match_count}++;
-                                    $merged_entry->{match_count} = $merged_cluster->{match_count};
-                                    $messages_absorbed++;
-                                }
-                            }
-                        }
-                        last;
-                    }
-
-                    # Add as new pattern
-                    $consolidation_clusters{$cat_gk}{$canonical} = $new_cluster;
-                    push @{$consolidation_patterns{$cat_gk}}, {
-                        pattern     => $regex,
-                        cluster_key => $canonical,
-                        canonical   => $canonical,
-                        match_count => $new_cluster->{match_count},
-                    };
-                    $patterns_discovered++;
-                    last;
-                }
-            }
-
-            # Remove consumed keys from %log_messages and tracking structures
-            for my $key (keys %consumed) {
-                delete $consolidation_unmatched{$cat_gk}{$key};
-                delete $log_messages{$category}{$key};
-                delete $consolidation_key_message{$key};
-                delete $consolidation_key_message_cat_gk{$key};
-            }
-
-            # Track final pass absorptions in S4
-            $consolidation_cat_stats{$cat_gk}{s4_pairwise} += $messages_absorbed;
-
-            # Free trigram data from final pass
-            delete $consolidation_ngram_index{$cat_gk};
-            delete $consolidation_posting_size{$cat_gk};
-            for my $key (keys %consumed) {
-                delete $consolidation_key_trigrams{$key};
-                delete $consolidation_key_trigrams_norm{$key};
             }
         }
+
+        # EOF checkpoints for final pass remainder
+        for my $cat_gk (sort keys %consolidation_unmatched) {
+            if (scalar(keys %{$consolidation_unmatched{$cat_gk}}) >= 2) {
+                my ($cat, $gk) = split(/\|/, $cat_gk, 2);
+                run_consolidation_checkpoint($cat, $gk);
+            }
+        }
+
+        # Restore threshold, ceiling, and phase
+        $consolidation_threshold          = $saved_threshold;
+        $consolidation_occurrence_ceiling = $saved_ceiling;
+        $consolidation_phase = 'streaming';
     }
 
     # Inject consolidated clusters back into %log_messages
@@ -2142,6 +2077,52 @@ sub merge_consolidation_stats {
     }
 }
 
+# Process a single key through the consolidation pipeline (S1 match → accumulate → trigger checkpoint)
+# Used by both streaming (parsing) and final pass (group_similar_messages) paths.
+# Returns: 1 if S1 matched (key absorbed into cluster), 0 if not (key stored for checkpoint processing)
+sub consolidation_process_key {
+    my ($log_key, $category, $cat_gk, $capped_msg, $stats_source) = @_;
+    my ($c, $grouping_key) = split(/\|/, $cat_gk, 2);
+
+    # Phase-appropriate counter prefix
+    my $pfx = ($consolidation_phase eq 'final_pass') ? 'fp_' : '';
+
+    $consolidation_total_keys_seen++;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}keys_seen"}++;
+
+    # S1: try matching against existing compiled patterns
+    my $entry = match_consolidation_patterns($category, $grouping_key, $capped_msg);
+    if ($entry) {
+        my $cluster = $consolidation_clusters{$cat_gk}{$entry->{canonical}};
+        if ($cluster) {
+            merge_consolidation_stats($cluster, $stats_source);
+            $consolidation_cat_stats{$cat_gk}{"${pfx}s1_inline"}++;
+            return 1;
+        }
+    }
+
+    # Not matched by S1 — store for checkpoint processing
+    $consolidation_key_message{$log_key} = $capped_msg;
+    $consolidation_key_message_cat_gk{$log_key} = $cat_gk;
+    $consolidation_unmatched{$cat_gk}{$log_key} = 1;
+    $consolidation_key_generation{$log_key} = $consolidation_pattern_generation{$cat_gk} // 0;
+    $consolidation_key_checkpoint_count{$log_key} = 0;
+    $consolidation_category_unmatched_count{$category}++;
+
+    # Check trigger per category — fire checkpoints for all groups in this category
+    if (($consolidation_category_unmatched_count{$category} // 0) >= $consolidation_trigger) {
+        for my $ck (keys %consolidation_unmatched) {
+            next unless $ck =~ /^\Q$category\E\|/;
+            next if scalar(keys %{$consolidation_unmatched{$ck}}) < 2;
+            my ($cc, $gk) = split(/\|/, $ck, 2);
+            run_consolidation_checkpoint($cc, $gk);
+        }
+        $consolidation_category_unmatched_count{$category} = 0;
+    }
+
+    return 0;
+}
+
 # Try to merge new pattern into an existing similar pattern (merge-first strategy)
 sub try_consolidation_merge_into_existing {
     my ($cat_gk, $new_canonical, $new_regex, $new_mask, $new_cluster) = @_;
@@ -2462,8 +2443,11 @@ sub get_consolidation_max_survivals {
 sub run_consolidation_checkpoint {
     my ($category, $grouping_key) = @_;
     my $cat_gk = "$category|$grouping_key";
-    $consolidation_cat_stats{$cat_gk}{checkpoints}++;
-    my $cp_num = $consolidation_cat_stats{$cat_gk}{checkpoints};
+    my $is_final_pass = ($consolidation_phase eq 'final_pass');
+    my $pfx = $is_final_pass ? 'fp_' : '';
+
+    $consolidation_cat_stats{$cat_gk}{"${pfx}checkpoints"}++;
+    my $cp_num = $consolidation_cat_stats{$cat_gk}{"${pfx}checkpoints"};
 
     my @unmatched = sort keys %{$consolidation_unmatched{$cat_gk}};
     my $pre_count = scalar @unmatched;
@@ -2471,32 +2455,33 @@ sub run_consolidation_checkpoint {
 
     # Fast-path eviction: if EMA indicates all keys should be evicted immediately,
     # skip the expensive checkpoint pass entirely (#135).
-    # Require at least 2 prior checkpoints before activating — a single unproductive
-    # checkpoint on a small batch is not representative of the group's consolidation potential.
-    my $current_max_survivals = exists $consolidation_absorption_ema{$cat_gk}
-        ? get_consolidation_max_survivals($consolidation_absorption_ema{$cat_gk})
-        : undef;  # first checkpoint — no EMA yet, must run the pass
+    # Disabled during final pass — eviction is not applicable (bounded set, last chance to consolidate).
+    if (!$is_final_pass) {
+        my $current_max_survivals = exists $consolidation_absorption_ema{$cat_gk}
+            ? get_consolidation_max_survivals($consolidation_absorption_ema{$cat_gk})
+            : undef;  # first checkpoint — no EMA yet, must run the pass
 
-    if (defined $current_max_survivals && $current_max_survivals == 0 && $cp_num > 2) {
-        # All surviving keys would be evicted — skip run_consolidation_pass entirely
-        my $evicted = 0;
-        for my $key (@unmatched) {
-            $consolidation_key_checkpoint_count{$key} = ($consolidation_key_checkpoint_count{$key} // 0) + 1;
-            # Evict: remove from consolidation working set, keep in %log_messages
-            delete $consolidation_key_message{$key};
-            delete $consolidation_key_message_cat_gk{$key};
-            delete $consolidation_key_trigrams{$key};
-            delete $consolidation_key_trigrams_norm{$key};
-            delete $consolidation_key_generation{$key};
-            delete $consolidation_key_checkpoint_count{$key};
-            delete $consolidation_unmatched{$cat_gk}{$key};
-            $evicted++;
-            $consolidation_category_unmatched_count{$category}-- if ($consolidation_category_unmatched_count{$category} // 0) > 0;
+        if (defined $current_max_survivals && $current_max_survivals == 0 && $cp_num > 2) {
+            # All surviving keys would be evicted — skip run_consolidation_pass entirely
+            my $evicted = 0;
+            for my $key (@unmatched) {
+                $consolidation_key_checkpoint_count{$key} = ($consolidation_key_checkpoint_count{$key} // 0) + 1;
+                # Evict: remove from consolidation working set, keep in %log_messages
+                delete $consolidation_key_message{$key};
+                delete $consolidation_key_message_cat_gk{$key};
+                delete $consolidation_key_trigrams{$key};
+                delete $consolidation_key_trigrams_norm{$key};
+                delete $consolidation_key_generation{$key};
+                delete $consolidation_key_checkpoint_count{$key};
+                delete $consolidation_unmatched{$cat_gk}{$key};
+                $evicted++;
+                $consolidation_category_unmatched_count{$category}-- if ($consolidation_category_unmatched_count{$category} // 0) > 0;
+            }
+            $consolidation_cat_stats{$cat_gk}{evicted} = ($consolidation_cat_stats{$cat_gk}{evicted} // 0) + $evicted;
+            $consolidation_cat_stats{$cat_gk}{absorption_ema} = $consolidation_absorption_ema{$cat_gk};
+            $consolidation_cat_stats{$cat_gk}{max_survivals} = 0;
+            return;
         }
-        $consolidation_cat_stats{$cat_gk}{evicted} = ($consolidation_cat_stats{$cat_gk}{evicted} // 0) + $evicted;
-        $consolidation_cat_stats{$cat_gk}{absorption_ema} = $consolidation_absorption_ema{$cat_gk};
-        $consolidation_cat_stats{$cat_gk}{max_survivals} = 0;
-        return;
     }
 
     my ($discovered, $absorbed, $ceiling_skipped, $cap_hit, $g2_absorbed, $fc_calls, $g2_survivors, $consumed_ref, $s3_tested, $s3_skipped) =
@@ -2504,17 +2489,17 @@ sub run_consolidation_checkpoint {
 
     my $post_count = scalar @unmatched;
 
-    # Update per-category accumulators
-    $consolidation_cat_stats{$cat_gk}{s3_checkpoint} += $g2_absorbed;
-    $consolidation_cat_stats{$cat_gk}{s3_calls}      += $s3_tested;
-    $consolidation_cat_stats{$cat_gk}{s3_skipped}    += $s3_skipped;
-    $consolidation_cat_stats{$cat_gk}{s4_pairwise}   += ($absorbed - $g2_absorbed);
-    $consolidation_cat_stats{$cat_gk}{fc_calls}      += $fc_calls;
-    $consolidation_cat_stats{$cat_gk}{patterns_discovered} += $discovered;
-    $consolidation_cat_stats{$cat_gk}{patterns_final} = exists $consolidation_patterns{$cat_gk} ? scalar @{$consolidation_patterns{$cat_gk}} : 0;
+    # Update per-category accumulators (phase-appropriate counters)
+    $consolidation_cat_stats{$cat_gk}{"${pfx}s3_checkpoint"} += $g2_absorbed;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}s3_calls"}      += $s3_tested;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}s3_skipped"}    += $s3_skipped;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}s4_pairwise"}   += ($absorbed - $g2_absorbed);
+    $consolidation_cat_stats{$cat_gk}{"${pfx}fc_calls"}      += $fc_calls;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}patterns_discovered"} += $discovered;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}patterns_final"} = exists $consolidation_patterns{$cat_gk} ? scalar @{$consolidation_patterns{$cat_gk}} : 0;
 
     # Delete absorbed keys — targeted O(consumed) instead of O(all_keys) (#135)
-    $consolidation_cat_stats{$cat_gk}{cleanup_keys_scanned} += scalar keys %$consumed_ref;
+    $consolidation_cat_stats{$cat_gk}{"${pfx}cleanup_keys_scanned"} += scalar keys %$consumed_ref;
     for my $key (keys %$consumed_ref) {
         delete $log_messages{$category}{$key};
         delete $consolidation_key_message{$key};
@@ -2532,11 +2517,14 @@ sub run_consolidation_checkpoint {
     # Cross-cluster merge and pattern generation bump
     if ($discovered > 0) {
         merge_consolidation_overlapping_patterns($cat_gk);
-        $consolidation_cat_stats{$cat_gk}{patterns_final} = exists $consolidation_patterns{$cat_gk} ? scalar @{$consolidation_patterns{$cat_gk}} : 0;
+        $consolidation_cat_stats{$cat_gk}{"${pfx}patterns_final"} = exists $consolidation_patterns{$cat_gk} ? scalar @{$consolidation_patterns{$cat_gk}} : 0;
         $consolidation_pattern_generation{$cat_gk} = ($consolidation_pattern_generation{$cat_gk} // 0) + 1;
     }
 
     # Adaptive eviction (#135): update EMA, increment checkpoint counts, evict stale keys
+    # Disabled during final pass — the final pass is the last chance to consolidate,
+    # and the working set is bounded (no new keys arrive). Eviction here would
+    # permanently lose keys with no subsequent pass to catch them.
     my $absorption_rate = $pre_count > 0 ? $absorbed / $pre_count : 0;
     if (exists $consolidation_absorption_ema{$cat_gk}) {
         $consolidation_absorption_ema{$cat_gk} = $consolidation_eviction_ema_alpha * $absorption_rate
@@ -2545,35 +2533,44 @@ sub run_consolidation_checkpoint {
         $consolidation_absorption_ema{$cat_gk} = $absorption_rate;  # first checkpoint initializes directly
     }
 
-    my $max_survivals = get_consolidation_max_survivals($consolidation_absorption_ema{$cat_gk});
-    $consolidation_cat_stats{$cat_gk}{absorption_ema} = $consolidation_absorption_ema{$cat_gk};
-    $consolidation_cat_stats{$cat_gk}{max_survivals} = $max_survivals;
-
-    # Increment checkpoint count for surviving keys and evict those exceeding threshold
-    my $evicted = 0;
-    my %survivors;
-    for my $key (@unmatched) {
-        next if exists $consumed_ref->{$key};  # already deleted above
-        $consolidation_key_checkpoint_count{$key} = ($consolidation_key_checkpoint_count{$key} // 0) + 1;
-        if ($consolidation_key_checkpoint_count{$key} > $max_survivals) {
-            # Evict: remove from consolidation working set, keep in %log_messages
-            delete $consolidation_key_message{$key};
-            delete $consolidation_key_message_cat_gk{$key};
-            delete $consolidation_key_trigrams{$key};
-            delete $consolidation_key_trigrams_norm{$key};
-            delete $consolidation_key_generation{$key};
-            delete $consolidation_key_checkpoint_count{$key};
-            $evicted++;
-            $consolidation_category_unmatched_count{$category}-- if ($consolidation_category_unmatched_count{$category} // 0) > 0;
-        } else {
+    if ($is_final_pass) {
+        # Final pass: all survivors stay — rebuild unmatched from non-consumed keys
+        my %survivors;
+        for my $key (@unmatched) {
+            next if exists $consumed_ref->{$key};
             $survivors{$key} = 1;
         }
+        %{$consolidation_unmatched{$cat_gk}} = %survivors;
+    } else {
+        # Streaming: evict keys exceeding adaptive survival threshold
+        my $max_survivals = get_consolidation_max_survivals($consolidation_absorption_ema{$cat_gk});
+        $consolidation_cat_stats{$cat_gk}{absorption_ema} = $consolidation_absorption_ema{$cat_gk};
+        $consolidation_cat_stats{$cat_gk}{max_survivals} = $max_survivals;
+
+        my $evicted = 0;
+        my %survivors;
+        for my $key (@unmatched) {
+            next if exists $consumed_ref->{$key};  # already deleted above
+            $consolidation_key_checkpoint_count{$key} = ($consolidation_key_checkpoint_count{$key} // 0) + 1;
+            if ($consolidation_key_checkpoint_count{$key} > $max_survivals) {
+                # Evict: remove from consolidation working set, keep in %log_messages
+                delete $consolidation_key_message{$key};
+                delete $consolidation_key_message_cat_gk{$key};
+                delete $consolidation_key_trigrams{$key};
+                delete $consolidation_key_trigrams_norm{$key};
+                delete $consolidation_key_generation{$key};
+                delete $consolidation_key_checkpoint_count{$key};
+                $evicted++;
+                $consolidation_category_unmatched_count{$category}-- if ($consolidation_category_unmatched_count{$category} // 0) > 0;
+            } else {
+                $survivors{$key} = 1;
+            }
+        }
+
+        # Rebuild %consolidation_unmatched from survivors only
+        %{$consolidation_unmatched{$cat_gk}} = %survivors;
+        $consolidation_cat_stats{$cat_gk}{evicted} = ($consolidation_cat_stats{$cat_gk}{evicted} // 0) + $evicted;
     }
-
-    # Rebuild %consolidation_unmatched from survivors only
-    %{$consolidation_unmatched{$cat_gk}} = %survivors;
-    $consolidation_cat_stats{$cat_gk}{evicted} = ($consolidation_cat_stats{$cat_gk}{evicted} // 0) + $evicted;
-
 }
 
 # Issue #45: Measure all data structures and update high-water marks
@@ -3880,66 +3877,34 @@ sub read_and_process_logs {
                         my $is_new_key = !exists $log_messages{$category}{$log_key};
 
                         if ($is_new_key) {
-                            $consolidation_total_keys_seen++;
-                            $consolidation_cat_stats{$cat_gk}{keys_seen}++;
-
-                            # S1: try matching against existing compiled patterns
-                            my $entry = match_consolidation_patterns($category, $grouping_key, $capped_msg);
-                            if ($entry) {
-                                my $cluster = $consolidation_clusters{$cat_gk}{$entry->{canonical}};
-                                if ($cluster) {
-                                    # Accumulate stats directly into cluster
-                                    $cluster->{occurrences}++;
-                                    if ($is_access_log) {
-                                        $cluster->{total_bytes} = ($cluster->{total_bytes} // 0) + $bytes if defined $bytes;
-                                        if (defined $count) {
-                                            $cluster->{count_sum} = ($cluster->{count_sum} // 0) + $count;
-                                            $cluster->{count_occurrences} = ($cluster->{count_occurrences} // 0) + 1;
-                                            $cluster->{count_min} = $count if !defined $cluster->{count_min} || $count < $cluster->{count_min};
-                                            $cluster->{count_max} = $count if !defined $cluster->{count_max} || $count > $cluster->{count_max};
-                                        }
-                                        foreach my $config (@udm_configs) {
-                                            my $name = $config->{name};
-                                            next unless defined $udm_values{$name};
-                                            my $value = $udm_values{$name};
-                                            $cluster->{"udm_${name}_sum"} = ($cluster->{"udm_${name}_sum"} // 0) + $value;
-                                            $cluster->{"udm_${name}_occurrences"} = ($cluster->{"udm_${name}_occurrences"} // 0) + 1;
-                                            $cluster->{"udm_${name}_min"} = $value if !defined $cluster->{"udm_${name}_min"} || $value < $cluster->{"udm_${name}_min"};
-                                            $cluster->{"udm_${name}_max"} = $value if !defined $cluster->{"udm_${name}_max"} || $value > $cluster->{"udm_${name}_max"};
-                                        }
-                                        if (defined $duration && !$omit_durations) {
-                                            $cluster->{total_duration} = ($cluster->{total_duration} // 0) + $duration;
-                                            $cluster->{total_duration_num} = ($cluster->{total_duration_num} // 0) + $duration;
-                                            $cluster->{sum_of_squares} = ($cluster->{sum_of_squares} // 0) + $duration ** 2;
-                                            push @{$cluster->{durations}}, $duration;
-                                        }
-                                    }
-                                    $consolidation_cat_stats{$cat_gk}{s1_inline}++;
-                                    $consolidation_s1_matched = 1;
+                            # Build stats source from parsed line values for merge_consolidation_stats()
+                            my $stats_source = { occurrences => 1 };
+                            if ($is_access_log) {
+                                $stats_source->{total_bytes} = $bytes if defined $bytes;
+                                if (defined $count) {
+                                    $stats_source->{count_sum} = $count;
+                                    $stats_source->{count_occurrences} = 1;
+                                    $stats_source->{count_min} = $count;
+                                    $stats_source->{count_max} = $count;
+                                }
+                                foreach my $config (@udm_configs) {
+                                    my $name = $config->{name};
+                                    next unless defined $udm_values{$name};
+                                    my $value = $udm_values{$name};
+                                    $stats_source->{"udm_${name}_sum"} = $value;
+                                    $stats_source->{"udm_${name}_occurrences"} = 1;
+                                    $stats_source->{"udm_${name}_min"} = $value;
+                                    $stats_source->{"udm_${name}_max"} = $value;
+                                }
+                                if (defined $duration && !$omit_durations) {
+                                    $stats_source->{total_duration} = $duration;
+                                    $stats_source->{total_duration_num} = $duration;
+                                    $stats_source->{sum_of_squares} = $duration ** 2;
+                                    $stats_source->{durations} = [$duration];
                                 }
                             }
 
-                            # Not matched by S1 — store for checkpoint processing
-                            if (!$consolidation_s1_matched) {
-                                $consolidation_key_message{$log_key} = $capped_msg;
-                                $consolidation_key_message_cat_gk{$log_key} = $cat_gk;
-                                $consolidation_unmatched{$cat_gk}{$log_key} = 1;
-                                $consolidation_key_generation{$log_key} = $consolidation_pattern_generation{$cat_gk} // 0;
-                                $consolidation_key_checkpoint_count{$log_key} = 0;
-                                $consolidation_category_unmatched_count{$category}++;
-
-                                # Check trigger per category — fire checkpoints for all groups in this category
-                                if (($consolidation_category_unmatched_count{$category} // 0) >= $consolidation_trigger) {
-                                    for my $ck (keys %consolidation_unmatched) {
-                                        next unless $ck =~ /^\Q$category\E\|/;
-                                        next if scalar(keys %{$consolidation_unmatched{$ck}}) < 2;
-                                        # Stall detection removed — adaptive eviction (#135) bounds the working set
-                                        my ($c, $gk) = split(/\|/, $ck, 2);
-                                        run_consolidation_checkpoint($c, $gk);
-                                    }
-                                    $consolidation_category_unmatched_count{$category} = 0;
-                                }
-                            }
+                            $consolidation_s1_matched = consolidation_process_key($log_key, $category, $cat_gk, $capped_msg, $stats_source);
                         }
                     }
 
@@ -7431,36 +7396,48 @@ unless( $group_similar_sensitivity eq "none" ) {
         my $grand_checkpoints = 0;
         my $grand_patterns = 0;
 
+        # Total patterns across all cat_gk groups (final count after both phases)
+        my $total_patterns_all = 0;
+        for my $cat_gk (keys %consolidation_patterns) {
+            $total_patterns_all += scalar @{$consolidation_patterns{$cat_gk}};
+        }
+
         for my $cat_gk (sort keys %consolidation_cat_stats) {
             my $s = $consolidation_cat_stats{$cat_gk};
             my $keys_seen = $s->{keys_seen} // 0;
             next unless $keys_seen > 0;
 
+            my ($category_part) = split(/\|/, $cat_gk, 2);
+
+            # --- Streaming phase ---
             my $checkpoints = $s->{checkpoints} // 0;
             my $patterns = $s->{patterns_final} // 0;
+            my $evicted = $s->{evicted} // 0;
 
-            # S2 and S5: partition remaining unmatched keys by occurrence ceiling
-            my ($category_part) = split(/\|/, $cat_gk, 2);
-            my $ceiling_filtered = 0;
-            my $genuinely_unmatched = 0;
-            for my $key (keys %{$consolidation_unmatched{$cat_gk} // {}}) {
-                my $occ = $log_messages{$category_part}{$key}{occurrences} // 1;
-                if ($occ >= $consolidation_occurrence_ceiling) {
-                    $ceiling_filtered++;
-                } else {
-                    $genuinely_unmatched++;
+            # S2/S5: saved before final pass reset (or computed from current unmatched if no final pass)
+            my $ceiling_filtered;
+            my $genuinely_unmatched;
+            if ($consolidation_final_pass && exists $s->{streaming_s2}) {
+                $ceiling_filtered = $s->{streaming_s2};
+                $genuinely_unmatched = $s->{streaming_s5};
+            } else {
+                # No final pass — compute from current %consolidation_unmatched
+                $ceiling_filtered = 0;
+                $genuinely_unmatched = 0;
+                for my $key (keys %{$consolidation_unmatched{$cat_gk} // {}}) {
+                    my $occ = $log_messages{$category_part}{$key}{occurrences} // 1;
+                    if ($occ >= $consolidation_occurrence_ceiling) { $ceiling_filtered++; } else { $genuinely_unmatched++; }
                 }
             }
 
             push @verbose_output, "";
-            push @verbose_output, sprintf("  --- %s: %d unique keys seen, %d checkpoints, %d patterns ---",
-                $cat_gk, $keys_seen, $checkpoints, $patterns);
+            push @verbose_output, sprintf("  --- %s: Streaming Phase ---", $cat_gk);
+            push @verbose_output, sprintf("    Keys seen:             %d  (%d checkpoints, %d patterns)", $keys_seen, $checkpoints, $patterns);
             push @verbose_output, sprintf("    S1 Inline match:       %d", $s->{s1_inline} // 0);
-            push @verbose_output, sprintf("    S2 Ceiling filter:     %d  (occurrences >= %d, remaining after all passes)", $ceiling_filtered, $consolidation_occurrence_ceiling);
+            push @verbose_output, sprintf("    S2 Ceiling filter:     %d  (occurrences >= %d)", $ceiling_filtered, $consolidation_occurrence_ceiling);
             push @verbose_output, sprintf("    S3 Checkpoint match:   %d", $s->{s3_checkpoint} // 0);
             push @verbose_output, sprintf("    S4 Pairwise discovery: %d", $s->{s4_pairwise} // 0);
             push @verbose_output, sprintf("    S5 Unmatched:          %d", $genuinely_unmatched);
-            my $evicted = $s->{evicted} // 0;
             push @verbose_output, sprintf("    S6 Evicted:            %d", $evicted);
             my $ema_pct = ($s->{absorption_ema} // 0) * 100;
             my $ms = $s->{max_survivals} // 0;
@@ -7472,16 +7449,12 @@ unless( $group_similar_sensitivity eq "none" ) {
             push @verbose_output, sprintf("    Cleanup keys scanned:  %d  (cumulative across %d checkpoints)",
                 $s->{cleanup_keys_scanned} // 0, $checkpoints);
 
-            # Sanity check: all 6 stages must sum to keys_seen
+            # Streaming tracking invariant
             my $accounted = ($s->{s1_inline} // 0) + $ceiling_filtered + ($s->{s3_checkpoint} // 0) + ($s->{s4_pairwise} // 0) + $genuinely_unmatched + $evicted;
             if ($accounted != $keys_seen) {
                 push @verbose_output, sprintf("    [WARN] Tracking mismatch: %d accounted vs %d seen (delta %d)",
                     $accounted, $keys_seen, $keys_seen - $accounted);
             }
-
-            push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
-                $keys_seen, $genuinely_unmatched + $evicted + $ceiling_filtered + $patterns,
-                (1 - ($genuinely_unmatched + $evicted + $ceiling_filtered + $patterns) / ($keys_seen || 1)) * 100);
 
             $grand_keys += $keys_seen;
             $grand_s1 += ($s->{s1_inline} // 0);
@@ -7493,11 +7466,61 @@ unless( $group_similar_sensitivity eq "none" ) {
             $grand_fc += ($s->{fc_calls} // 0);
             $grand_checkpoints += $checkpoints;
             $grand_patterns += $patterns;
+
+            # --- Final pass phase ---
+            my $fp_keys = $s->{fp_keys_seen} // 0;
+            if ($fp_keys > 0) {
+                my $fp_checkpoints = $s->{fp_checkpoints} // 0;
+                my $fp_patterns = $s->{fp_patterns_final} // 0;
+
+                # Final pass S2/S5: partition from final pass's %consolidation_unmatched
+                my $fp_ceiling_filtered = 0;
+                my $fp_genuinely_unmatched = 0;
+                for my $key (keys %{$consolidation_unmatched{$cat_gk} // {}}) {
+                    my $occ = $log_messages{$category_part}{$key}{occurrences} // 1;
+                    if ($occ >= $consolidation_final_ceiling) { $fp_ceiling_filtered++; } else { $fp_genuinely_unmatched++; }
+                }
+
+                push @verbose_output, sprintf("  --- %s: Final Pass ---", $cat_gk);
+                push @verbose_output, sprintf("    Keys seen:             %d  (%d checkpoints, %d new patterns)", $fp_keys, $fp_checkpoints, $fp_patterns);
+                push @verbose_output, sprintf("    S1 Inline match:       %d", $s->{fp_s1_inline} // 0);
+                push @verbose_output, sprintf("    S2 Ceiling filter:     %d  (occurrences >= %d)", $fp_ceiling_filtered, $consolidation_final_ceiling);
+                push @verbose_output, sprintf("    S3 Checkpoint match:   %d", $s->{fp_s3_checkpoint} // 0);
+                push @verbose_output, sprintf("    S4 Pairwise discovery: %d", $s->{fp_s4_pairwise} // 0);
+                push @verbose_output, sprintf("    S5 Unmatched:          %d", $fp_genuinely_unmatched);
+                push @verbose_output, sprintf("    find_candidates calls: %d", $s->{fp_fc_calls} // 0);
+
+                # Final pass tracking invariant (no S6 — eviction disabled)
+                my $fp_accounted = ($s->{fp_s1_inline} // 0) + $fp_ceiling_filtered + ($s->{fp_s3_checkpoint} // 0) + ($s->{fp_s4_pairwise} // 0) + $fp_genuinely_unmatched;
+                if ($fp_accounted != $fp_keys) {
+                    push @verbose_output, sprintf("    [WARN] Tracking mismatch: %d accounted vs %d seen (delta %d)",
+                        $fp_accounted, $fp_keys, $fp_keys - $fp_accounted);
+                }
+            }
+
+            # Combined reduction: streaming keys_seen → final remaining (S5 + S2 from last active phase + patterns)
+            my $final_remaining;
+            if ($fp_keys > 0) {
+                my $fp_unmatched_total = 0;
+                for my $key (keys %{$consolidation_unmatched{$cat_gk} // {}}) {
+                    $fp_unmatched_total++;
+                }
+                my $combined_patterns = exists $consolidation_patterns{$cat_gk} ? scalar @{$consolidation_patterns{$cat_gk}} : 0;
+                $final_remaining = $fp_unmatched_total + $combined_patterns;
+                push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
+                    $keys_seen, $final_remaining,
+                    (1 - $final_remaining / ($keys_seen || 1)) * 100);
+            } else {
+                $final_remaining = $genuinely_unmatched + $evicted + $ceiling_filtered + $patterns;
+                push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
+                    $keys_seen, $final_remaining,
+                    (1 - $final_remaining / ($keys_seen || 1)) * 100);
+            }
         }
 
         if (scalar keys %consolidation_cat_stats > 1) {
             push @verbose_output, "";
-            push @verbose_output, "  === Grand Totals ===";
+            push @verbose_output, "  === Grand Totals (Streaming) ===";
             push @verbose_output, sprintf("    Total keys seen:       %d", $grand_keys);
             push @verbose_output, sprintf("    Total S1 Inline:       %d", $grand_s1);
             push @verbose_output, sprintf("    Total S2 Ceiling:      %d", $grand_s2);
@@ -7508,9 +7531,6 @@ unless( $group_similar_sensitivity eq "none" ) {
             push @verbose_output, sprintf("    Total checkpoints:     %d", $grand_checkpoints);
             push @verbose_output, sprintf("    Total patterns:        %d", $grand_patterns);
             push @verbose_output, sprintf("    Total fc calls:        %d", $grand_fc);
-            push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
-                $grand_keys, $grand_s5 + $grand_s6 + $grand_s2 + $grand_patterns,
-                (1 - ($grand_s5 + $grand_s6 + $grand_s2 + $grand_patterns) / ($grand_keys || 1)) * 100);
         }
         push @verbose_output, "";
     }


### PR DESCRIPTION
## Summary

- Redesigned final pass to use the same S1→S2→S3→S4 checkpoint pipeline as streaming, replacing the broken separate mini-pipeline
- Extracted `consolidation_process_key()` subroutine shared by both streaming and final pass paths
- Final pass iterates sorted `%log_messages` keys, with eviction disabled (bounded set, last chance)
- Separate `fp_*` observability counters with dual-phase verbose output
- Access log reduction: 27.5% → 52.3%; app log WARN: 84.8%, ERROR: 74.7%

Fixes #137

## Test plan

- [x] Access log: no tracking mismatches, reduction improved
- [x] App log: no tracking mismatches, reduction improved
- [x] Script log: no tracking mismatches
- [x] `--no-final-pass`: streaming counters identical, no regression
- [x] Evicted keys (S6): correctly re-enter final pass pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)