### PR TITLE
Disable Windows memory tracking by default (#143)

### DIFF
--- a/ltl
+++ b/ltl
@@ -1495,8 +1495,10 @@ sub get_memory_usage {
             }
         }
     } elsif ($^O eq 'MSWin32') {                                # Windows
+        # Memory tracking disabled by default on Windows — use -mem to opt in.
         # Direct kernel32.dll syscall via Win32::API — replaces Win32::Process::Info
         # which used WMI (extremely slow, ~15-20s per call). See #143.
+        return 0 unless $show_memory;
         eval {
             require Win32::API;
             my $get_current = Win32::API->new('kernel32', 'GetCurrentProcess', [], 'N');


### PR DESCRIPTION
## Summary
- Disable memory tracking on Windows by default — `get_memory_usage()` returns 0 on Windows unless `-mem` is explicitly passed
- New Win32::API implementation is untested on real Windows; this gates it behind opt-in until validated

Follow-up to PR #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)