### PR TITLE
Release v0.14.3 build fix

### DIFF
--- a/build/cpanfile
+++ b/build/cpanfile
@@ -1,3 +1,4 @@
+requires 'Cwd';
 requires 'Devel::Size';
 requires 'File::Spec';
 requires 'Getopt::Long';
@@ -7,6 +8,7 @@ requires 'Term::ANSIColor';
 requires 'Term::ReadKey';
 requires 'Text::CSV';
 requires 'Text::CSV_PP';
+requires 'Text::ParseWords';
 requires 'Time::HiRes';
 requires 'Time::Local';
 requires 'Time::Piece';

--- a/build/cpanfile.windows
+++ b/build/cpanfile.windows
@@ -1,3 +1,4 @@
+requires 'Cwd';
 requires 'Devel::Size';
 requires 'File::Spec';
 requires 'Getopt::Long';
@@ -7,7 +8,8 @@ requires 'Term::ANSIColor';
 requires 'Term::ReadKey';
 requires 'Text::CSV';
 requires 'Text::CSV_PP';
+requires 'Text::ParseWords';
 requires 'Time::HiRes';
 requires 'Time::Local';
 requires 'Time::Piece';
-requires 'Win32::Process::Info';
+requires 'Win32::API';

--- a/build/generate-cpanfile.sh
+++ b/build/generate-cpanfile.sh
@@ -26,7 +26,7 @@ cd "$REPO_ROOT"
 
 # Platform-specific modules that should be excluded from cross-platform builds
 UNIX_ONLY_MODULES="Proc::ProcessTable"
-WINDOWS_ONLY_MODULES="Win32::Process::Info"
+WINDOWS_ONLY_MODULES="Win32::Process::Info\|Win32::API"
 
 generate_cpanfile() {
     local exclude_pattern="$1"


### PR DESCRIPTION
## Summary
- Fix Ubuntu build failure: add Win32::API to Windows-only module exclusions in generate-cpanfile.sh
- Regenerated cpanfiles