### PR TITLE
Fix benchmark terminal dependency and add --options passthrough (#167)

### DIFF
--- a/tests/baseline/run-benchmark.sh
+++ b/tests/baseline/run-benchmark.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # run-benchmark.sh — Run ltl benchmark test cases and capture results as TSV
-# Usage: ./run-benchmark.sh [target] [--label <name>]
+# Usage: ./run-benchmark.sh [target] [--label <name>] [--options "<ltl options>"]
 #
 # Targets:
 #   quick — single test case for dev/testing (twx-unique-errors-standard)
@@ -24,12 +24,17 @@ LOGS_DIR="$SCRIPT_DIR/../../logs"
 # Default label is timestamp
 LABEL="$(date +%Y%m%d-%H%M%S)"
 TARGET="full"
+EXTRA_OPTIONS=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --label)
             LABEL="$2"
+            shift 2
+            ;;
+        --options)
+            EXTRA_OPTIONS="$2"
             shift 2
             ;;
         *)
@@ -114,7 +119,7 @@ run_test() {
         benchmark_defaults="$benchmark_defaults -bs 60"
     fi
     local output
-    if ! output=$($LTL --disable-progress -V -mem $benchmark_defaults $options $file_args 2>&1); then
+    if ! output=$($LTL --disable-progress -V -mem $benchmark_defaults $options $EXTRA_OPTIONS $file_args 2>&1); then
         echo "FAIL: $test_name — ltl returned non-zero" >&2
         return 1
     fi


### PR DESCRIPTION
## Summary
- Pass `--terminal-width 200` and `-bs 60` (when not explicitly set) for consistent benchmark results across terminal environments
- Add `--options "<ltl options>"` for injecting additional options into all benchmark runs

## Test plan
- [x] Quick benchmark: `terminal_width=200`, `time_bucket_size=60`, `max_log_message_length=200`
- [x] Explicit `-bs 480` preserved when set by test profile
- [x] `--options` passthrough tested

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)