### PR TITLE
Constrain CV display to 4 characters max (#152)

### DIFF
--- a/ltl
+++ b/ltl
@@ -4913,7 +4913,17 @@ sub calculate_statistics {
     my $max = max(@sorted);
     my $variance = ($bucket_data->{sum_of_squares} / $duration_count) - ($mean ** 2);
     my $std_dev = sprintf("%.3f", sqrt($variance));
-    my $cv = $mean != 0 ? sprintf("%.2f", $std_dev / $mean ) : undef;
+    my $cv = undef;
+    if ($mean != 0) {
+        my $cv_raw = $std_dev / $mean;
+        if ($cv_raw >= 100) {
+            $cv = sprintf("%d", $cv_raw);
+        } elsif ($cv_raw >= 10) {
+            $cv = sprintf("%.1f", $cv_raw);
+        } else {
+            $cv = sprintf("%.2f", $cv_raw);
+        }
+    }
 
     # Percentile calculations must use duration_count, not occurrences
     # to correctly index into the sorted durations array


### PR DESCRIPTION
## Summary
- Adapt CV decimal places based on magnitude: <10 → 2 decimals, 10-99 → 1 decimal, >=100 → no decimals
- Prevents values like "131.52" (6 chars) from overflowing the 4-char CV field and wrapping the line

## Test plan
- [x] All 19 regression tests pass
- [x] CV values display correctly in bar graph output (e.g., "7.76", "9.74")

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)