### PR TITLE
Issues #34 / #187: requirements feature files

### DIFF
--- a/features/187-bin-counter-percentiles.md
+++ b/features/187-bin-counter-percentiles.md
@@ -1,0 +1,277 @@
+# Feature: Bin-counter-based percentile calculation with dual-mode accuracy
+
+## Overview
+
+ltl's summary table reports per-message latency percentiles (P1, P5, P25, P50, P75, P90, P95, P99, P99.9). Today these are computed by retaining every individual metric value in an in-memory array, sorting it, and indexing. The algorithm requires `O(n)` memory in the number of values.
+
+This feature introduces a dual-mode percentile path:
+
+- **Exact mode** — today's array-based, exact percentile values. Unchanged.
+- **Approximate mode** — quantile estimation via a sketch or bin-derived interpolation, with `O(state)` memory bounded by the chosen algorithm's parameters and not growing with input size.
+
+Mode is decided at start of run by criteria modelled after #34's eligibility gate. The exact algorithm, the accuracy bound the algorithm must meet, and the precise gating criteria are research outcomes; this spec commits to the dual-mode foundation, the observability contract, and the research that must be completed before production implementation.
+
+## GitHub Issue
+
+[#187](https://github.com/gregeva/logtimeline/issues/187)
+
+## Motivation
+
+For multi-GB runs the per-message percentile arrays are typically the largest single memory consumer in the summary path — comparable in scale to the heatmap/histogram raw arrays that #34 addresses. With #179 reading bounds at start-up and #34 introducing the bin-counter accumulation pattern, the percentile arrays become the remaining target.
+
+Unlike heatmap and histogram (where counts per bin are sufficient for rendering), percentile values require *estimating a position* in the value distribution. Multiple credible algorithms exist (t-digest, KLL sketch, Greenwald-Khanna, q-digest, bin-derived interpolation) with different accuracy / memory / CPU profiles. The right choice for ltl is not obvious from prior art alone — it depends on the value distributions actually observed in ltl's log datasets, which are heavy-tailed in ways that affect tail-quantile accuracy substantially. This feature therefore prioritizes research before locking in algorithm and accuracy.
+
+## Requirements
+
+### R1 — Two percentile-computation modes
+
+The system supports two percentile-computation paths for the summary-table latency percentiles:
+
+- **Exact mode** — the existing array-based computation, producing exact percentile values for the matched data. Behavior unchanged from today.
+- **Approximate mode** — quantile estimation from a bounded-state estimator, producing the required percentile values within a documented accuracy bound (R4).
+
+The selected mode is decided at run start.
+
+### R2 — Mode-selection gate
+
+The selection between exact and approximate mode must be governed by criteria evaluated at run start. The criteria must include at minimum:
+
+1. Index pre-seed active (`index_used: yes` per #179).
+2. Tier matches filter context (filtered → Tier-1 required; unfiltered → Tier-2 acceptable). Gaps are owed to #179 and recorded for follow-up there, not patched here.
+3. Input criteria suitable for approximate mode. The specific input criteria (file size, selection line count, presence of bounds, etc.) are research outputs (R8/R9); the requirement is that at least one such input criterion is evaluated and reported.
+
+When any criterion fails, exact mode runs.
+
+### R3 — Required percentile values
+
+Approximate mode must produce all of: P1, P5, P25, P50, P75, P90, P95, P99, P99.9.
+
+### R4 — Documented accuracy bound
+
+Approximate mode must operate within a documented accuracy bound. The bound is a research output (R9), expressed per quantile, and may differ across quantiles (P99.9 typically has wider bounds than P50). The bound must:
+
+- Be derivable either from the chosen algorithm's theoretical guarantees, or from an empirical calibration against representative ltl datasets, or both.
+- Be reported in `-V` (see R7).
+
+The acceptance criterion is that for any input in the representative-dataset set (R8), every required quantile from approximate mode falls within the documented bound around the exact-mode value.
+
+### R5 — Degenerate-input behavior
+
+Approximate mode must handle the following inputs without crashing and without producing nonsensical values:
+
+- Zero matched values — percentiles emit `-` (today's behavior).
+- All-same value — every percentile equals that value.
+- Single value — every percentile equals that value.
+- Small N (single-digit to low-hundreds) — output remains correct under R4; if the chosen algorithm degrades, the gate (R2) must steer small-N runs to exact mode and that decision must be reported in `-V`.
+
+### R6 — Determinism
+
+Approximate mode must be deterministic for a given input: the same input file, filters, and gate decision produce the same percentile values across runs. If the chosen algorithm is randomized, it must be seeded reproducibly such that this requirement holds.
+
+### R7 — `-V` observability
+
+A dedicated `=== PERCENTILE MODE ===` section reports:
+
+- **Layer 1**: `percentile_mode` (`exact` or `approximate`) and `percentile_mode_reason` (see R10).
+- **Layer 2 (approximate mode)**: `algorithm` (the chosen estimator), `algorithm_version` where applicable, `state_budget_bytes`, and a per-quantile `accuracy_estimate` block reporting the bound applied to each required quantile.
+- **Layer 3 (exact mode)**: `n` (the value count consumed) and a `sorted: yes` line for confirmation.
+
+Section name and all labels are part of the feature contract.
+
+### R8 — Representative-dataset set
+
+The accuracy bound (R4) is verified against a curated set of datasets representative of ltl's actual usage. The set must include at minimum:
+
+- A heavy-tailed access log (Tomcat / Apache style).
+- A ThingWorx mixed-traffic log.
+- A high-cardinality DEBUG-heavy log.
+- A small-N case (a few hundred values).
+- A degenerate case (all-same values).
+- A pathological case relevant to ltl users (selection determined during research; e.g., a log with extreme outliers).
+
+These datasets are referenced from `logs/` where existing files apply and curated into the test suite where new files are needed.
+
+### R9 — Research outputs that bind production behavior
+
+Before production implementation, the following research outputs must be produced and recorded (see **Research deliverables** below for the structure):
+
+- **Algorithm choice** — which estimator(s) ltl ships.
+- **Accuracy bound** — the per-quantile error bound that satisfies R4 for the R8 dataset set.
+- **Input criteria for R2** — the specific input thresholds that govern when approximate mode activates.
+- **State-budget configuration** — the parameter (e.g., t-digest compression, KLL `k`) the implementation uses.
+
+Production implementation must report these outputs as fixed values in `-V` (R7) and must not deviate from them without re-running the relevant research.
+
+### R10 — Reason codes
+
+When exact mode runs, `-V` must report why. The vocabulary is at minimum:
+
+- `approximate_eligible` — approximate mode active.
+- `exact_default` — no eligibility (catch-all when no specific gate failed).
+- `no_index` — R2.1 failed.
+- `tier_mismatch` — R2.2 failed.
+- `input_criteria_failed` — R2.3 failed (one or more input criteria below the threshold determined by R9).
+- `feature_not_active` — no values were matched.
+
+Additional reason codes may be added by implementation provided each maps to a single, testable cause.
+
+### R11 — No regression in exact mode
+
+When exact mode runs for any reason, percentile output is byte-identical to the pre-feature implementation. The existing regression suite must pass byte-identically.
+
+### R12 — Heatmap and histogram unaffected
+
+Heatmap and histogram bin counters (#34) are a separate data structure with separate eligibility. This feature must not alter their behavior. A run may have `percentile_mode: approximate` and `heatmap_mode: raw_value`, or any other combination, depending on each feature's independent gate.
+
+### R13 — Boundaries with other features
+
+- Heatmap and histogram bin counters — owned by #34.
+- Highlight-data accumulation (including per-highlight percentile arrays if introduced) — owned by #51.
+- Index read-back, tier correctness, and drift refresh — owned by #179.
+- Within-run bound-discovery passes — not a topic of either this feature or #34.
+
+When an eligibility gap traces to one of those features, it is filed against the owning issue, not patched here.
+
+## Considerations for implementation
+
+The spec is intentionally agnostic about the mechanisms below. Each must be addressed during prototype and implementation; the choice of mechanism is the implementer's, informed by research outcomes.
+
+- **Algorithm choice as a research output (R9).** The candidate set named in **Research deliverables** is the prior art the implementer evaluates; the spec does not pre-select. The implementer may surface additional candidates if their literature review identifies more relevant work.
+- **Detection methodology for mode selection.** R2 names the categories of criteria; the precise thresholds and how they are evaluated are determined in research and implementation. Consider: clarity of the decision, ordering for reason-code stability, cost of the checks relative to the run.
+- **Memory behavior across modes.** The approximate-mode estimator state replaces the exact-mode value array. Consider how peak memory composes in mixed scenarios (e.g., approximate mode for the primary metric, exact mode for a highlight subset), and whether estimator state is freed at the same lifecycle point as the array is today.
+- **`-V` accuracy unit.** R4 requires the bound to be reported per quantile. The unit (percentage-of-value error, absolute value error, percentile-rank distance) is decided in research and locked at R9-time. Consider which unit is most actionable for the user.
+- **Surfacing of accuracy to the user.** The bound is in `-V` (R7). Whether the rendered summary table itself should annotate that approximate values are in use (e.g., a footnote, a marker on the percentile row) is implementation-defined. Consider the user's need to know vs. visual clutter.
+- **Highlight subsets.** When a run uses a highlight pattern, percentiles are typically computed twice — once over all matched messages, once over highlighted. Whether both subsets can use approximate mode, whether they share estimator state, and how their accuracy bounds compose are decisions that must be reached during implementation, coordinated with #51 if highlight optimization is in flight at the same time.
+- **Mode-selection criteria not yet identified.** R2 lists the minimum; additional criteria may be needed (e.g., behavior under memory pressure, behavior when bounds drift mid-run). If introduced, they must be reported under a new reason code (R10).
+- **State lifecycle and reset.** When a run completes and percentile values are materialized, the estimator state is no longer needed. Consider when it is freed and whether the lifecycle composes cleanly with #23 Phase 2's named-stage memory model.
+
+## Edge cases
+
+| Case | Required behavior |
+|---|---|
+| No matched messages | Percentiles emit `-`; no estimator runs; `-V` reports `feature_not_active`. |
+| All matched values are identical | Every percentile equals that value (exact and approximate modes agree). |
+| Single matched value | Every percentile equals that value. |
+| Very small N below R9's threshold | Gate (R2.3) steers to exact mode; `reason: input_criteria_failed`. |
+| Stale or missing index | R2.1 fails; exact mode runs; `reason: no_index`. |
+| Filtered run with only Tier-2 pre-seed | R2.2 fails; exact mode runs; `reason: tier_mismatch`; gap recorded against #179. |
+| Highlight pattern present | Both subsets evaluated by R2 independently; each may be in exact or approximate mode; `-V` reports both. |
+| Bounds drift mid-run | Exact-mode output unchanged. Approximate-mode behavior under drift is determined by R9; the accuracy bound (R4) must still hold or the gate must have excluded the run. |
+| Concurrent ltl processes | Inherited from #179; out of this feature's concern. |
+
+## Acceptance criteria
+
+- [ ] R1–R13 hold across the representative-dataset set (R8).
+- [ ] Research deliverables are complete: algorithm choice, accuracy bound, input criteria, state-budget configuration are recorded and referenced from this spec (R9).
+- [ ] For every input in the R8 set, each required quantile from approximate mode falls within the R9 accuracy bound around the exact value.
+- [ ] When approximate mode runs, R3, R4, R5, R6, and R7 hold; `state_budget_bytes` reported in `-V` matches the actual memory occupied by the estimator state.
+- [ ] When exact mode runs for any reason (R10), output satisfies R11 (byte-identical to pre-feature).
+- [ ] `-V` emits the section described in R7, with reason codes per R10 distinguishing every failure mode of R2.
+- [ ] Heatmap and histogram behavior is unchanged (R12).
+- [ ] All test scenarios in **Validation** pass.
+- [ ] Any eligibility gap traced to #179 is filed against #179 (R13).
+
+## Validation
+
+Three layers, modelled after #34 and #179.
+
+### Existing regression suite
+
+`tests/validate-regression.sh` must pass byte-identically. Validates R11.
+
+### New scenario suite
+
+Mirrors #34's pattern: orchestrate `ltl-index.csv` state, run ltl with `-V`, assert against the `=== PERCENTILE MODE ===` section.
+
+| Scenario | Setup | Action | Assertions |
+|---|---|---|---|
+| `cold-no-index-exact` | No `ltl-index.csv`. | `ltl <F> -V`. | `percentile_mode: exact`, `reason: no_index`. |
+| `warm-eligible-approximate` | Fresh index pre-seed; input meets all R9 criteria. | `ltl <F> -V`. | `percentile_mode: approximate`, `reason: approximate_eligible`, `algorithm` populated, `accuracy_estimate` per quantile populated. |
+| `warm-input-criteria-failed` | Fresh index pre-seed; input below the R9 threshold. | `ltl <F> -V`. | `percentile_mode: exact`, `reason: input_criteria_failed`. |
+| `warm-tier-mismatch` | Filtered run, only Tier-2 pre-seed. | `ltl -dmin=50 <F> -V`. | `percentile_mode: exact`, `reason: tier_mismatch`. |
+| `approximate-zero-values` | Eligible run; all messages filtered out. | `ltl -i nonexistent <F> -V`. | Percentiles emit `-`; `reason: feature_not_active`; no crash. |
+| `approximate-all-same` | Eligible run; all matched values identical. | Crafted log file. | All percentiles equal that value. |
+| `approximate-single-value` | Eligible run; single matched value. | Crafted log file. | All percentiles equal that value. |
+| `accuracy-within-bound` | Eligible run; representative dataset. | Run twice — once forcing exact via gate-failure, once approximate. | Per-quantile absolute and relative errors fall within R9's bound. |
+| `state-budget-reported` | Eligible run. | `ltl <F> -V`. | `state_budget_bytes` non-zero; matches the estimator's configured parameter (R9). |
+
+### Accuracy-comparison test harness
+
+A dedicated harness compares approximate-mode output against exact-mode output across the R8 dataset set. For each dataset:
+
+1. Run ltl twice (once forced exact, once approximate).
+2. Compute per-quantile absolute and relative error.
+3. Assert each error within R9's bound.
+
+The harness is part of this feature's deliverable.
+
+## Research deliverables
+
+Production implementation does not commence until the following deliverables are complete and recorded. The deliverables are requirements on the *work*, not prescriptions of the *mechanism*.
+
+### D1 — Comparative algorithm study
+
+Evaluate the following candidate algorithms against the R8 dataset set:
+
+- **t-digest** — Dunning's structure; recognized for tail-quantile accuracy in heavy-tailed data.
+- **KLL sketch** — deterministic-error succinct quantile sketch.
+- **Greenwald-Khanna (GK)** — classic deterministic quantile sketch.
+- **q-digest** — tree-based deterministic quantile sketch.
+- **Bin-derived interpolation** — compute percentiles by interpolating within the bins produced by #34's bin-counter mode (reuses heatmap/histogram bins; no separate estimator state).
+
+For each algorithm and each dataset:
+
+- Per-quantile absolute error (raw-value units).
+- Per-quantile relative error (percent of exact value).
+- 95% confidence intervals over multiple sub-samples.
+- Estimator state size.
+- Per-update CPU cost.
+- Per-finalize CPU cost.
+- Determinism characteristic.
+
+The implementer may add candidates if literature review surfaces relevant alternatives.
+
+### D2 — Accuracy report
+
+A written report summarizing D1 results across the R8 dataset set:
+
+- Table of per-algorithm, per-quantile, per-dataset error metrics.
+- Memory and CPU comparison.
+- Qualitative discussion of which algorithm performs best for which dataset shape.
+- Identification of any algorithm that is strictly dominated.
+
+### D3 — Recommendation memo
+
+A written recommendation:
+
+- The algorithm (or algorithms, if multiple) ltl ships.
+- The accuracy bound (R4) the implementation commits to.
+- The input criteria for R2 (the thresholds that gate approximate-mode activation).
+- The state-budget configuration (R9).
+- Rationale connecting the recommendation to D2.
+
+### D4 — Prototype
+
+A working prototype in `prototype/187-percentile-sketch.pl` (or similar). The prototype:
+
+- Implements the recommended algorithm(s).
+- Runs against the R8 datasets and produces D2-style output reproducibly.
+- Is runnable independently of ltl proper so algorithm changes can be validated without touching production code.
+
+### D5 — Production gate
+
+Production implementation references D1–D4 as prerequisites and treats their outputs as the binding values for R4, R9, and the R7 `accuracy_estimate` block.
+
+## Related issues
+
+- **#34** — bin-counter accumulation for heatmap and histogram (sibling; same gating pattern).
+- **#179** — index read-back (R2.1 / R2.2 dependency).
+- **#51** — highlight-data optimization (R13).
+- **#41** — unified binning (D1 evaluates bin-derived interpolation, which composes with #41 if recommended).
+- **#23 Phase 2 (#59)** — adopts this feature's memory model.
+- **#180** — named pipeline stages.
+- **#46** — index file (closed; foundation that #179 reads back).
+
+## Spec stability
+
+The behavior contract (R1–R13, edge cases, `-V` format) is intended to be stable across implementation. The research deliverables (D1–D5) are expected to grow as research lands; their outputs become the bound values for R4, R9, and the `accuracy_estimate` block. When that happens, a **Locked decisions from research** subsection records the values.

--- a/features/34-bin-counter-mode.md
+++ b/features/34-bin-counter-mode.md
@@ -1,0 +1,225 @@
+# Feature: Bin-counter accumulation for heatmap and histogram
+
+## Overview
+
+Heatmap and histogram today retain every per-line metric value in memory (`%heatmap_raw{$time_bucket}` and `%histogram_values{$metric}`) so that bin boundaries can be computed from the observed min/max **after** the file is fully read. This feature introduces an alternative accumulation path in which per-bin integer counters replace those per-line value structures when the bin boundaries can be known **before** the read pass begins.
+
+The condition that makes that possible is index read-back (#179): when a prior run's bounds are pre-seeded into in-memory state at start-up, ltl can compute logarithmic bin boundaries up front and tally each parsed value directly into a bin counter. No per-line values are retained.
+
+The feature is therefore a conditional gate: bin-counter mode activates per-feature (heatmap independently of histogram) when pre-seeded bounds are available for the metric in question; otherwise the current raw-value implementation runs unchanged.
+
+## GitHub Issue
+
+[#34](https://github.com/gregeva/logtimeline/issues/34)
+
+## Motivation
+
+For multi-GB log analysis runs (chained daily files, long-window investigations), the raw-value arrays dominate peak memory. The bounds those arrays exist to discover are stable properties of the file (or filter selection) — once captured by the index, they do not need to be re-discovered on subsequent runs. With #179 reading them back at start-up, the raw-value retention has no remaining purpose for those runs.
+
+## Requirements
+
+### R1 — Two accumulation modes per metric
+
+For each metric tracked by heatmap and histogram (duration, bytes, count, and any user-defined metric), the system supports two accumulation paths:
+
+- **Raw-value mode** — today's behavior, unchanged. Per-line values accumulate; bin boundaries are derived at end of pass; rendering uses the resulting bins.
+- **Bin-counter mode** — bin boundaries are computed at start of run from pre-seeded bounds; per-line values increment a bin counter directly during the read pass; no per-line value array is allocated.
+
+The selected mode is decided independently per feature (heatmap, histogram) and per metric.
+
+### R2 — Mode-selection gate
+
+A given (feature, metric) pair is eligible for bin-counter mode iff all of the following hold:
+
+1. Index pre-seed is active for this run (`index_used: yes` per #179).
+2. The pre-seed tier matches filter context: filtered runs require Tier-1 (`selection`) pre-seed; unfiltered runs accept Tier-2 (`file`) pre-seed or Tier-1 with `filters = -`. Tier correctness is owed by #179. If a filtered run reaches this gate with only Tier-2 pre-seed, the metric is treated as ineligible (`reason: tier_mismatch`) and the gap is recorded for follow-up against #179 rather than patched at this layer.
+3. Both `min` and `max` pre-seed values are present (non-placeholder) for the metric.
+
+When any criterion fails, raw-value mode runs for that metric.
+
+### R3 — Bin boundary computation in bin-counter mode
+
+When eligible, the boundary array is computed once at start of run using the existing logarithmic formula `min * (max/min)^(i/num_buckets)` for `i in 0..num_buckets`, with the same `num_buckets` value used today. The formula, bucket count, and resulting bin semantics are identical to today's post-hoc computation; only the timing of computation moves earlier.
+
+### R4 — Per-line accumulation in bin-counter mode
+
+During the existing single read pass, each parsed value for an eligible metric is assigned to a bin index against the pre-computed boundary array and the corresponding counter is incremented. No per-line value array is allocated or appended for that metric.
+
+### R5 — Out-of-range handling
+
+Values falling outside the pre-seeded bounds are tallied into out-of-range counters:
+
+- Values below the pre-seeded `min` increment `out_of_range_low` (per metric for histogram; per metric per time bucket for heatmap).
+- Values above the pre-seeded `max` increment `out_of_range_high` analogously.
+
+Out-of-range tallies must:
+
+- Be reported in `-V` (see R8).
+- Propagate to #179's drift detection so the index entry is refreshed at end of run.
+- Not retroactively widen the in-memory boundary array during the current run. The rendered axis for the current run remains the pre-seeded one.
+
+### R6 — Live bound capture continues in bin-counter mode
+
+The live `min` / `max` capture that #179 relies on for drift detection must continue running alongside bin-counter accumulation. Only the per-line value array allocation is eliminated.
+
+### R7 — Render equivalence
+
+When pre-seeded bounds match observed live values exactly, rendered heatmap and histogram output in bin-counter mode is identical to raw-value mode for the same input.
+
+When raw-value mode runs (any ineligible scenario), rendered output is byte-identical to today's pre-feature implementation.
+
+### R8 — `-V` observability of mode selection and out-of-range activity
+
+A dedicated section in `-V` output, named `=== HISTOGRAM BIN COUNTER MODE ===`, reports:
+
+- **Layer 1 — Run-level summary**: `heatmap_mode` and `histogram_mode`, each taking values `bin_counter`, `raw_value`, or `not_active` (when the feature itself was not requested).
+- **Layer 2 — Per-feature, per-metric detail**: for each active feature, one block per metric reporting `mode`, `reason` (see R9), `boundary_min`, `boundary_max`, `num_buckets`.
+- **Layer 3 — Out-of-range report**: emitted whenever any metric is in `bin_counter` mode. Reports `out_of_range_low` and `out_of_range_high` per metric (totals). For heatmap, additionally reports per-time-bucket breakdown for any time bucket where out-of-range counts are non-zero.
+- **Layer 4 — Drift cross-reference**: a single line pointing to #179's drift section, since drift detail is owned there.
+
+The section name and all labels are part of the feature contract and stable across implementations.
+
+### R9 — Reason codes
+
+When a metric runs in raw-value mode under the bin-counter feature, `-V` must report why. The reason values reported must be sufficient for an external test to distinguish each failure of R2. The vocabulary is at minimum:
+
+- `index_pre_seed_ok` — bin-counter mode active.
+- `no_index` — R2.1 failed.
+- `tier_mismatch` — R2.2 failed.
+- `missing_bound` — R2.3 failed (including degenerate `min == max` and non-positive values that make logarithmic boundaries undefined).
+- `feature_not_active` — feature itself was not requested.
+
+Additional reason codes may be added by implementation provided each maps to a single, testable cause.
+
+### R10 — Per-feature and per-metric independence
+
+The eligibility decision must be made per (feature, metric) pair. A run may have heatmap in bin-counter mode and histogram in raw-value mode, or have one histogram metric in bin-counter mode and another in raw-value mode, depending on which bounds were pre-seeded.
+
+### R11 — Memory behavior under bin-counter mode
+
+When R2 is satisfied for a metric, that metric's per-line memory footprint must not grow with line count:
+
+- Heatmap per-metric memory must be bounded by `num_buckets × num_time_buckets`.
+- Histogram per-metric memory must be bounded by `num_buckets`.
+
+Constant per-bucket per-time-bucket overhead is acceptable; growth proportional to input size is not.
+
+### R12 — No regression in raw-value mode
+
+When any metric runs in raw-value mode for any reason, behavior is byte-identical to the pre-feature implementation. The existing regression suite (`tests/validate-regression.sh`) must pass byte-identically.
+
+### R13 — Per-message percentile arrays unaffected
+
+The per-message latency percentile arrays used by the summary table (P1..P99.9) are a separate data structure from `%heatmap_raw` and `%histogram_values`. This feature must not alter their behavior in either direction. The dual-mode percentile path is owned by sibling issue #187.
+
+### R14 — Boundaries with other features (this feature does not own)
+
+- Highlight-data optimization (`%heatmap_raw_hl` and equivalents) — owned by #51.
+- Per-message latency percentile dual-mode — owned by #187.
+- Shared boundary-array unification between heatmap and histogram — owned by #41.
+- Index read-back, tier correctness, and drift refresh — owned by #179.
+
+When an eligibility gap traces to one of those features, it is recorded and filed against the owning issue rather than patched here.
+
+## Considerations for implementation
+
+The spec is intentionally agnostic about the mechanisms below. Each must be addressed during prototype and implementation; the choice of mechanism is the implementer's, informed by what the gate actually needs in practice.
+
+- **Detection methodology for ineligible runs.** R2 lists the eligibility criteria. How those criteria are checked at run start, how reason codes are derived, and how `-V` instrumentation is produced are implementation-defined. Consider: clarity of the gate (so future readers can audit the decision), order of checks (so reason reporting is unambiguous), and cost of the checks (should be negligible relative to the read pass).
+- **Memory behavior across mixed-mode runs.** A run may have some metrics in bin-counter mode and others in raw-value mode (R10). The implementer should consider how peak memory composes in mixed cases, whether any structures are shared across metrics, and whether allocating one structure freezes the other into a less efficient layout.
+- **Out-of-range rendering.** R5 requires out-of-range tallies to be reported in `-V`. Whether and how out-of-range counts surface on the rendered heatmap or histogram itself (a labeled marker at the axis edge, an inline annotation, or silent) is implementation-defined. Consider: visibility for the user, conformance with the existing visual style, and behavior when the count is non-zero but small.
+- **Mode-selection criteria beyond the gate.** R2 defines the minimum eligibility criteria. Additional criteria — for example, whether very small selections benefit from bin-counter mode, or whether memory pressure on the host should influence the decision — may be needed in practice. If introduced, they must be reported in `-V` with a new reason code (R9). Whether to expose any of them to the user via a CLI surface is an implementation decision and is not constrained by this spec.
+- **Boundary computation precision.** R3 mandates the existing logarithmic formula. Implementation must verify that bin assignment from pre-seeded boundaries produces identical bin indices to today's post-hoc computation, with no off-by-one at boundary edges, across all supported metrics.
+- **Heatmap-vs-histogram structural symmetry.** Both features apply the same accumulation pattern over different keying (time-bucketed vs. global). Implementation should consider whether a shared helper is warranted now or whether shared structure is deferred to #41.
+- **Live bound capture cost.** R6 requires live `min` / `max` capture to continue running in bin-counter mode. The cost is small but non-zero; implementation should confirm that retaining it does not erase the memory benefit of bin-counter mode in any realistic scenario.
+
+## Edge cases
+
+| Case | Required behavior |
+|---|---|
+| Feature not requested (`-hm` absent, `-hg` absent) | `-V` reports the relevant `*_mode: not_active`. No per-metric blocks emitted. |
+| Pre-seeded `min == max` for a metric | Metric is ineligible (`reason: missing_bound`); raw-value mode runs and handles the degenerate case as today. |
+| Pre-seeded `min` is zero or negative for a duration/bytes metric | Logarithmic boundaries undefined. Metric ineligible (`reason: missing_bound`). |
+| Pre-seeded bounds match live exactly | No out-of-range counts, no drift, render identical to raw-value mode. |
+| Pre-seeded bounds wider than live | Bins at extremes empty; legitimate; render uses the wider axis. |
+| Pre-seeded bounds narrower than live | Out-of-range counts accumulate; render uses the pre-seeded axis; #179 refreshes the index; next run observes no out-of-range counts. |
+| Heatmap eligible, histogram missing a bound | Heatmap in bin-counter mode; histogram in raw-value mode for the missing-bound metric. `-V` reflects both independently. |
+| One histogram metric eligible, another not | Eligible metric uses bin counters; ineligible metric uses raw-value. Both render identically to today. |
+| Multi-file run, mixed pre-seed (one file fresh, one not) | #179's multi-file rule already blocks pre-seed; this feature observes `no_index` and runs raw-value mode for both features. |
+| Multi-file run, all fresh, same tier | Per-file bounds aggregated per #179 (min-of-mins, max-of-maxes); boundary array uses aggregated values. |
+| Filter signature never seen before | No Tier-1 match; filtered run is ineligible (`reason: tier_mismatch`); next run with same filters will be eligible. |
+| `-hm count` requested, pre-seed has only `duration` bounds | Heatmap active metric is `count`; ineligible (`reason: missing_bound`). |
+| Stale or malformed `ltl-index.csv` | #179 produces no pre-seed; this feature observes `no_index`; raw-value mode. |
+| Concurrent ltl processes | Inherited from #179; out of this feature's concern. |
+
+## Acceptance criteria
+
+- [ ] R1–R13 hold for all supported (feature, metric) combinations.
+- [ ] When R2 is satisfied for a metric, that metric's memory growth respects R11.
+- [ ] When R2 fails for any reason, behavior satisfies R12.
+- [ ] `-V` emits the section described in R8, with reason codes per R9, sufficient to distinguish every failure mode of R2.
+- [ ] Out-of-range counts (R5) propagate to #179's drift refresh; after refresh, the next run with the same input observes zero out-of-range counts.
+- [ ] All test scenarios in **Validation** pass.
+- [ ] `tests/validate-regression.sh` passes byte-identically against the pre-feature baseline.
+- [ ] Any eligibility gap traced to #179 is filed against #179, not patched here (R14).
+
+## Validation
+
+Three layers, modelled after #179.
+
+### Existing regression suite
+
+`tests/validate-regression.sh` — all existing tests must pass byte-identically. Validates R12 and confirms that bin-counter mode does not alter rendered output when bounds are matched.
+
+### New scenario suite
+
+A new test runner orchestrates `ltl-index.csv` state directly (mirroring #179's pattern), runs ltl with `-V`, and asserts against the `=== HISTOGRAM BIN COUNTER MODE ===` section.
+
+`<F>` denotes a test input file with known content. `<F1>`, `<F2>` denote two distinct files with known distinct values.
+
+| Scenario | Setup | Action | Assertions |
+|---|---|---|---|
+| `cold-no-index-heatmap` | No `ltl-index.csv`. | `ltl -hm duration <F> -V`. | `heatmap_mode: raw_value`, `reason: no_index`. Render byte-identical to pre-feature. |
+| `cold-no-index-histogram` | No `ltl-index.csv`. | `ltl -hg <F> -V`. | `histogram_mode: raw_value`, `reason: no_index` for each metric. |
+| `warm-unfiltered-heatmap-eligible` | Fresh file row, bounds populated. | `ltl -hm duration <F> -V`. | `heatmap_mode: bin_counter`, `reason: index_pre_seed_ok`, `boundary_min` / `boundary_max` match the row. Render identical to `cold-no-index-heatmap`. |
+| `warm-unfiltered-histogram-eligible` | Same file row, all metric bounds populated. | `ltl -hg <F> -V`. | `histogram_mode: bin_counter` for each metric. Render identical to cold. |
+| `warm-filtered-tier1-eligible` | Fresh selection row for `(<F>, -dmin=50;)` with bounds covering live filtered range. | `ltl -hm duration -dmin=50 <F> -V`. | `heatmap_mode: bin_counter`, `reason: index_pre_seed_ok`. Pre-seed values match the selection row. |
+| `warm-filtered-tier2-fallback` | Fresh file row only; no matching selection row. | `ltl -hm duration -dmin=50 <F> -V`. | `heatmap_mode: raw_value`, `reason: tier_mismatch`. Render byte-identical to pre-feature. |
+| `missing-bound-column-heatmap` | File row with `duration_max=-`. | `ltl -hm duration <F> -V`. | `heatmap_mode: raw_value`, `reason: missing_bound`. |
+| `missing-bound-column-histogram-partial` | File row, `duration` bounds populated, `bytes_max=-`. | `ltl -hg <F> -V`. | `metric: duration` → `bin_counter`; `metric: bytes` → `raw_value`, `reason: missing_bound`. |
+| `out-of-range-low` | File row with `duration_min=100` (live values 10–500). | `ltl -hm duration <F> -V`. | `bin_counter`, `out_of_range_low > 0`, `out_of_range_high: 0`. Per-time-bucket breakdown present. #179's `drift_detected: yes` for `duration_min`. After re-run with refreshed index: `out_of_range_low: 0`. |
+| `out-of-range-high` | File row with `duration_max=200` (live values up to 500). | `ltl -hm duration <F> -V`. | Symmetric: `out_of_range_high > 0`, `out_of_range_low: 0`. |
+| `mixed-feature-eligibility` | File row, `duration` bounds populated, `bytes` bounds as `-`. | `ltl -hm duration -hg <F> -V`. | `heatmap_mode: bin_counter`. `histogram` block: `duration` → `bin_counter`, `bytes` → `raw_value` with `missing_bound`. |
+| `multi-file-all-eligible` | Fresh file rows for `<F1>` and `<F2>`. | `ltl -hm duration <F1> <F2> -V`. | `heatmap_mode: bin_counter`. Pre-seed uses aggregated bounds. |
+| `multi-file-mixed-eligibility` | `<F1>` fresh, `<F2>` stale mtime. | `ltl -hm duration <F1> <F2> -V`. | `heatmap_mode: raw_value`, `reason: no_index` (inherited from #179's multi-file blocking rule). |
+| `boundary-exact-match` | File row with `min` / `max` matching live exactly. | `ltl -hm duration <F> -V`. | `bin_counter`, no out-of-range, no drift. Render byte-identical to a raw-value re-run. |
+| `wider-than-live-bounds` | File row with bounds wider than live. | `ltl -hm duration <F> -V`. | `bin_counter`, no out-of-range. Render uses the wider axis. |
+| `feature-not-active` | Fresh file row; no `-hm`, no `-hg`. | `ltl <F> -V`. | `heatmap_mode: not_active`, `histogram_mode: not_active`. No per-metric blocks. |
+| `degenerate-min-equals-max` | File row with `duration_min = duration_max`. | `ltl -hm duration <F> -V`. | `raw_value`, `reason: missing_bound`. |
+
+#### Assertion mechanics
+
+Tests parse the `=== HISTOGRAM BIN COUNTER MODE ===` section from `-V` output and assert keys against expected values. They do not assert against rendered output (that is the existing regression suite's job); they assert against the bin-counter section and, for out-of-range scenarios, against #179's drift block.
+
+### `-V` instrumentation as the validation surface
+
+The labels and structure defined in R8 and R9 are the test contract. Without that level of detail in `-V`, scenarios like `mixed-feature-eligibility` and `out-of-range-low` (which must assert *which* metric was affected and *why*) are not assertable from rendered output alone.
+
+## Related issues
+
+- **#179** — index read-back (provides pre-seed primitive that R2 depends on).
+- **#51** — highlight-data accumulation (R14).
+- **#187** — bin-counter-based percentile calculation (sibling; R13).
+- **#41** — unified binning for heatmap and histogram (R14).
+- **#23 Phase 2 (#59)** — core engine rewrite; the memory model defined by R10–R11 is intended to be inherited unchanged.
+- **#180** — named pipeline stages.
+- **#46** — index file (closed; foundation that #179 reads back).
+
+## Spec stability
+
+This document is intended to be stable across the implementation cycle. Two categories of post-merge change are expected:
+
+1. Clarifications when an unspecified case is encountered during implementation (move from "unspecified" to "specified" in **Edge cases**).
+2. Updates when sibling features (#51, #187, #41) land — at that point this doc may add a brief subsection per consumer recording what each reads from or composes with this feature's mode contract.
+
+The spec does not track implementation status, code locations, or commit history. Those live in commit messages and the issue itself.


### PR DESCRIPTION
## Summary

Adds requirements-only feature specifications for two related performance features:

- `features/34-bin-counter-mode.md` — bin-counter accumulation for heatmap and histogram, gated on #179 index pre-seed availability. Defines the mode contract, eligibility gate, out-of-range handling, `-V` observability (`=== HISTOGRAM BIN COUNTER MODE ===`), edge cases, and orchestrated test scenarios.
- `features/187-bin-counter-percentiles.md` — sibling feature for dual-mode percentile calculation (exact vs. approximate). Defines the mode contract, `-V` observability (`=== PERCENTILE MODE ===`), accuracy reporting, representative-dataset set, and research deliverables (D1–D5) that bind production behavior.

Both files follow a strict requirements format: Requirements (R1..Rn) + Considerations for implementation + Edge cases + Acceptance criteria + Validation. No mechanism prescriptions (CLI options, thresholds, algorithms) are imposed by the spec; the implementation is free to introduce mechanisms as needed provided they are observable via `-V` with stable reason codes.

## Companion issue changes

- Issue #34 renamed (was: *Performance: Memory-optimized mode for histogram and heatmap (two-pass streaming)*; now: *Performance: Bin-counter accumulation for heatmap and histogram*). Body rewritten to match the new framing; previously overspecified content removed.
- Issue #187 created as the sibling for percentile dual-mode.

## Scope

Documentation only — no source code changes. `ltl` and other code are untouched.

## Test plan

- [x] `git diff --stat` shows only the two new `.md` files; `ltl` unchanged.
- [x] Pre-commit hook passed (no staged secrets / `.claude/` content).
- [ ] User review of the requirements framing.
- [ ] User review of issue #34 / #187 bodies on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)