### PR TITLE
Issue #189: === PERCENTILE MODE === -V block (PR #189-2 of three)

### DIFF
--- a/ltl
+++ b/ltl
@@ -1155,6 +1155,77 @@ sub emit_index_readback_verbose {
     }
 }
 
+# Issue #189 (PR #189-2): emit the `=== PERCENTILE MODE ===` section into
+# @verbose_output. Always emitted under -V per the locked stability contract.
+# Field names, consumer-name strings, and the three-value audit enum
+# (none|low|high) are locked at:
+#   features/187-histogram-bin-counter-percentiles.md § Decision 8
+# Tests assert grep-level stability of every field this sub emits; field-name
+# changes require a new locked-decision entry. Field values may evolve freely.
+#
+# In this PR (no consumer migrated yet) the section always reports
+# `consumers_active: none` after the run-level header. The first consumer
+# migration replaces that line with per-consumer blocks in the locked order.
+sub emit_percentile_mode_verbose {
+    return unless $verbose;
+
+    push @verbose_output, "=== PERCENTILE MODE ===";
+
+    # Run-level header — opt_out_active first per the locked example output.
+    my $opt_out = $exact_percentiles_optout ? 'yes' : 'no';
+    push @verbose_output, "opt_out_active: $opt_out";
+    if ($exact_percentiles_optout) {
+        push @verbose_output,
+            "opt_out_notice: --exact-percentiles is set; all migrated consumers reverted to pre-#187 sort-based computation. This flag is deprecated and will be removed in a future release.";
+    }
+
+    # Two fields, two annotation styles per the locked Decision 8 contract:
+    #
+    # `percentile_precision: <LEVEL> (<source>)` — reports the
+    # --percentile-precision side of the story. When --percentile-precision
+    # was specified (with or without -pbpd), <LEVEL> is the requested level
+    # (1..9) and <source> is "--percentile-precision N" or, when -pbpd also
+    # specified, "--percentile-precision N; overridden". When no
+    # --percentile-precision was specified, <LEVEL> falls back to the tier
+    # corresponding to the active bpd if any matches, or the literal "n/a"
+    # for non-tier bpd values (locked at audit A5).
+    #
+    # `buckets_per_decade: <N> (<source>)` — reports the active resolved bpd
+    # with the full conflict-annotated source ("default" | "-pbpd N" |
+    # "--percentile-precision N" | "-pbpd N; --percentile-precision M overridden").
+    #
+    # The two fields can carry different <source> strings; only the
+    # buckets_per_decade field's annotation tracks $percentile_precision_source
+    # verbatim from option parsing.
+    my %bpd_to_level = (4=>1, 8=>2, 16=>3, 32=>4, 53=>5, 80=>6, 115=>7, 256=>8, 616=>9);
+    my ($level_label, $level_source);
+    if (defined $percentile_precision_level) {
+        # User supplied --percentile-precision. Report it even when overridden.
+        $level_label  = $percentile_precision_level;
+        $level_source = $percentile_precision_source =~ /^-pbpd /
+            ? "--percentile-precision $percentile_precision_level; overridden"
+            : "--percentile-precision $percentile_precision_level";
+    } else {
+        $level_label  = exists $bpd_to_level{$percentile_buckets_per_decade}
+            ? $bpd_to_level{$percentile_buckets_per_decade}
+            : 'n/a';
+        $level_source = $percentile_precision_source;
+    }
+
+    # Suffix applied to both source annotations when opt-out is active.
+    my $not_in_effect = $exact_percentiles_optout ? '; not in effect this run' : '';
+
+    push @verbose_output,
+        "percentile_precision: $level_label ($level_source$not_in_effect)";
+    push @verbose_output,
+        "buckets_per_decade: $percentile_buckets_per_decade ($percentile_precision_source$not_in_effect)";
+
+    # PR #189-2 ships no migrated consumer; the section always terminates
+    # here. PR #189-3 onwards will replace this with per-consumer blocks
+    # emitted in the locked order from the consumer-name table.
+    push @verbose_output, "consumers_active: none";
+}
+
 sub write_index_file {
     my ($index_path, $temp_path, $use_absolute_paths) = locate_index_file();
 
@@ -8602,6 +8673,12 @@ $elapsed_total = $elapsed_read_files + $elapsed_initialize_empty_time_windows + 
 # and emit the index read-back section into @verbose_output before flush.
 detect_index_drift();
 emit_index_readback_verbose();
+
+# Issue #189 (PR #189-2): always emit the percentile-mode section under -V.
+# Ordering recommendation locked at:
+#   features/189-bin-counter-primitives-implementation-readiness-audit.md § Bucket C § C8
+# Tests assert per-block contents only, not inter-block ordering.
+emit_percentile_mode_verbose();
 
 print_verbose_output();
 

--- a/tests/validate-percentile-mode.sh
+++ b/tests/validate-percentile-mode.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# validate-percentile-mode.sh — Validate Issue #189 (`=== PERCENTILE MODE ===`
+# `-V` block) behavior.
+# Usage: ./tests/validate-percentile-mode.sh
+#
+# Each scenario invokes ltl with -V plus a specific combination of
+# percentile-mode CLI flags and asserts that the `=== PERCENTILE MODE ===`
+# section emits the locked Decision 8 contract surface — section header,
+# run-level field names, source-annotation forms, n/a rendering for non-tier
+# -pbpd values, opt-out behavior, and `consumers_active: none` line.
+#
+# Departs from validate-regression.sh in assertion style: greps the -V
+# section for expected key/value lines rather than diffing full output
+# against a reference fixture. The two suites are complementary:
+# validate-regression.sh ensures rendered analytical output is byte-identical;
+# this suite ensures the unified-contract -V audit surface holds the
+# stability promises in:
+#   features/187-histogram-bin-counter-percentiles.md § Decision 8
+#
+# PR #189-2 ships only the run-level header + `consumers_active: none`;
+# no consumer is migrated yet so no per-consumer block scenarios exist here.
+# Consumer-block scenarios will be added by each consumer's own migration
+# ticket per the locked stability contract.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LTL="$REPO_DIR/ltl"
+ACCESS_LOG="$REPO_DIR/logs/AccessLogs/localhost_access_log.2025-03-21.txt"
+
+if [[ ! -x "$LTL" ]]; then
+    echo "ERROR: ltl not found or not executable at $LTL"
+    exit 1
+fi
+if [[ ! -f "$ACCESS_LOG" ]]; then
+    echo "ERROR: ACCESS_LOG not found: $ACCESS_LOG"
+    exit 1
+fi
+
+pass=0
+fail=0
+failures=()
+
+# Run ltl with -V and the standard suppression flag, capture combined
+# output to a temp file, echo path. Args after the function name are
+# forwarded verbatim before the input file.
+run_ltl_v() {
+    local outfile
+    outfile=$(mktemp)
+    "$LTL" --disable-progress -V "$@" "$ACCESS_LOG" > "$outfile" 2>&1 || true
+    echo "$outfile"
+}
+
+# Assert a regex matches a line in the captured -V output.
+assert_line() {
+    local name="$1" file="$2" pattern="$3"
+    if grep -qE "$pattern" "$file"; then
+        echo "  PASS  $name :: $pattern"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $name :: $pattern"
+        echo "        (not found in $file)"
+        fail=$((fail + 1))
+        failures+=("$name :: $pattern")
+    fi
+}
+
+# Assert a regex does NOT match any line in the captured -V output.
+assert_no_line() {
+    local name="$1" file="$2" pattern="$3"
+    if grep -qE "$pattern" "$file"; then
+        echo "  FAIL  $name :: !$pattern (unexpectedly present)"
+        fail=$((fail + 1))
+        failures+=("$name :: !$pattern (unexpectedly present)")
+    else
+        echo "  PASS  $name :: !$pattern"
+        pass=$((pass + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: default run — no percentile-mode flags
+# ---------------------------------------------------------------------------
+# Spec example: features/187-...-percentiles.md § Decision 8 (lines 1602-1606)
+scenario_default() {
+    local name="default"
+    local out
+    out=$(run_ltl_v)
+    assert_line    "$name" "$out" '^=== PERCENTILE MODE ===$'
+    assert_line    "$name" "$out" '^opt_out_active: no$'
+    assert_line    "$name" "$out" '^percentile_precision: 5 \(default\)$'
+    assert_line    "$name" "$out" '^buckets_per_decade: 53 \(default\)$'
+    assert_line    "$name" "$out" '^consumers_active: none$'
+    # opt_out_notice is conditional — absent unless opt-out is active.
+    assert_no_line "$name" "$out" '^opt_out_notice:'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: --exact-percentiles opt-out active
+# ---------------------------------------------------------------------------
+# Spec example: features/187-...-percentiles.md § Decision 8 (lines 1556-1560)
+# Locked: opt_out_notice present, both fields suffixed `; not in effect this run`.
+scenario_opt_out() {
+    local name="opt-out"
+    local out
+    out=$(run_ltl_v --exact-percentiles)
+    assert_line "$name" "$out" '^opt_out_active: yes$'
+    assert_line "$name" "$out" '^opt_out_notice: --exact-percentiles is set; .*deprecated'
+    assert_line "$name" "$out" '^percentile_precision: 5 \(default; not in effect this run\)$'
+    assert_line "$name" "$out" '^buckets_per_decade: 53 \(default; not in effect this run\)$'
+    assert_line "$name" "$out" '^consumers_active: none$'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: --percentile-precision 7 (tier override)
+# ---------------------------------------------------------------------------
+# Locked tier table: level 7 -> bpd 115 (features/187-...-percentiles.md § Decision 2).
+scenario_precision_tier() {
+    local name="precision-tier"
+    local out
+    out=$(run_ltl_v --percentile-precision 7)
+    assert_line "$name" "$out" '^percentile_precision: 7 \(--percentile-precision 7\)$'
+    assert_line "$name" "$out" '^buckets_per_decade: 115 \(--percentile-precision 7\)$'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: -pbpd 100 (non-tier value -> literal `n/a` per audit A5)
+# ---------------------------------------------------------------------------
+# Locked: when -pbpd resolves to a non-tier value, percentile_precision
+# renders the literal string `n/a` (locked at
+# features/189-...-audit.md § Bucket A § A5).
+scenario_pbpd_non_tier() {
+    local name="pbpd-non-tier"
+    local out
+    out=$(run_ltl_v -pbpd 100)
+    assert_line "$name" "$out" '^percentile_precision: n/a \(-pbpd 100\)$'
+    assert_line "$name" "$out" '^buckets_per_decade: 100 \(-pbpd 100\)$'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 5: -pbpd + --percentile-precision conflict (-pbpd wins)
+# ---------------------------------------------------------------------------
+# Spec example: features/187-...-percentiles.md § Decision 8 (lines 1574-1577)
+# Locked: percentile_precision reports the *requested* level with
+# "; overridden" annotation; buckets_per_decade reports the *active* bpd
+# with the full "-pbpd N; --percentile-precision M overridden" annotation.
+scenario_flag_conflict() {
+    local name="flag-conflict"
+    local out
+    out=$(run_ltl_v -pbpd 100 --percentile-precision 4)
+    assert_line "$name" "$out" '^percentile_precision: 4 \(--percentile-precision 4; overridden\)$'
+    assert_line "$name" "$out" '^buckets_per_decade: 100 \(-pbpd 100; --percentile-precision 4 overridden\)$'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 6: invalid -pbpd value warns + falls back to default
+# ---------------------------------------------------------------------------
+# Locked range: 4 <= -pbpd <= 616 (features/187-...-percentiles.md § Decision 2).
+# Out-of-range -> warning emitted, value resets to default 53,
+# source annotation resets to 'default'.
+scenario_pbpd_out_of_range() {
+    local name="pbpd-out-of-range"
+    local out
+    out=$(run_ltl_v -pbpd 9999)
+    assert_line "$name" "$out" 'Invalid -pbpd: 9999'
+    assert_line "$name" "$out" '^percentile_precision: 5 \(default\)$'
+    assert_line "$name" "$out" '^buckets_per_decade: 53 \(default\)$'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 7: section is always present under -V even when no percentile
+# feature is in use
+# ---------------------------------------------------------------------------
+# Decision 8 stability contract: section is always present under -V; consumer
+# blocks appear only when a consumer is migrated AND active. In PR #189-2 no
+# consumer is migrated, so `consumers_active: none` is unconditional.
+scenario_always_present() {
+    local name="always-present"
+    local out
+    # Run with a non-percentile feature flag to confirm section still appears.
+    out=$(run_ltl_v -hm duration)
+    assert_line "$name" "$out" '^=== PERCENTILE MODE ===$'
+    assert_line "$name" "$out" '^consumers_active: none$'
+    rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Run all scenarios
+# ---------------------------------------------------------------------------
+
+echo "Validating percentile-mode -V block (Issue #189, PR #189-2)"
+echo ""
+
+echo "[scenario_default]"
+scenario_default
+
+echo ""
+echo "[scenario_opt_out]"
+scenario_opt_out
+
+echo ""
+echo "[scenario_precision_tier]"
+scenario_precision_tier
+
+echo ""
+echo "[scenario_pbpd_non_tier]"
+scenario_pbpd_non_tier
+
+echo ""
+echo "[scenario_flag_conflict]"
+scenario_flag_conflict
+
+echo ""
+echo "[scenario_pbpd_out_of_range]"
+scenario_pbpd_out_of_range
+
+echo ""
+echo "[scenario_always_present]"
+scenario_always_present
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [[ "$fail" -gt 0 ]]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+echo "ALL PERCENTILE-MODE TESTS PASSED"


### PR DESCRIPTION
## Summary

PR #189-2 of three per the audit's recommended scope partition (\`features/189-bin-counter-primitives-implementation-readiness-audit.md § Recommended PR-sized scope partition\`):

1. PR #198 (merged) — primitives + CLI flag parsing.
2. **PR #189-2 (this PR)** — \`=== PERCENTILE MODE ===\` \`-V\` block + \`tests/validate-percentile-mode.sh\`.
3. PR #189-3 — \`print_help()\` + \`docs/usage.md\` updates.

## What's in this PR

**New sub \`emit_percentile_mode_verbose()\` in \`ltl\`** called from the verbose flush path right after \`emit_index_readback_verbose()\` per the audit's C8 recommended ordering. The section is **always emitted under \`-V\`** regardless of which features are active — the stability contract locked at \`features/187-...-percentiles.md § Decision 8\` requires it.

Run-level fields emitted (all locked, field names contractual):

| Field | When | Annotation form |
|---|---|---|
| \`opt_out_active\` | always | \`yes\` \| \`no\` |
| \`opt_out_notice\` | only when \`opt_out_active: yes\` | locked deprecation message |
| \`percentile_precision\` | always | \`<LEVEL>\` (1..9 or literal \`n/a\`); source annotation tracks \`--percentile-precision\` side |
| \`buckets_per_decade\` | always | resolved bpd; source annotation tracks full conflict story |
| \`consumers_active: none\` | always (this PR) | replaced by per-consumer blocks in the first consumer-migration PR |

Both \`percentile_precision\` and \`buckets_per_decade\` source annotations append \`; not in effect this run\` when \`--exact-percentiles\` is active. Literal \`n/a\` rendering for non-tier \`-pbpd\` values locked at \`features/189-...-audit.md § Bucket A § A5\`.

**New \`tests/validate-percentile-mode.sh\`** mirrors \`tests/validate-index-readback.sh\` exactly — same \`assert_line\` / \`assert_no_line\` helpers, same per-scenario block structure. Seven scenarios:

1. Default run — asserts every locked field with default source annotation.
2. \`--exact-percentiles\` — asserts opt-out branch + deprecation notice + \`; not in effect this run\` suffix on both source fields.
3. \`--percentile-precision 7\` — asserts tier-table resolution (level 7 → bpd 115).
4. \`-pbpd 100\` — asserts non-tier value renders the literal string \`n/a\` per audit A5.
5. \`-pbpd 100 --percentile-precision 4\` (conflict) — asserts the two fields carry the two locked annotation styles correctly.
6. \`-pbpd 9999\` (invalid) — asserts the warning fires and both fields fall back to defaults.
7. Always-present-under-V — runs with \`-hm duration\` to confirm the section appears even when no percentile feature is active.

## Verification

- [x] \`perl -c ltl\` — OK
- [x] \`tests/validate-regression.sh\` — 19/19 PASS (byte-identical; \`-V\` not used)
- [x] \`tests/validate-histogram-ticks.sh\` — 15/15 PASS
- [x] \`tests/validate-index-readback.sh\` — 51/51 PASS
- [x] \`tests/validate-percentile-mode.sh\` — 22/22 PASS (new)

## Test plan

- [x] Run all four validate scripts; all green
- [x] Each of the seven scenarios in the new test script passes
- [x] Section renders correctly across the five non-default flag combinations (manually verified end-to-end against the locked Decision 8 example output)

## Out of scope

- \`print_help()\` + \`docs/usage.md\` text — PR #189-3.
- Per-consumer blocks — added by each consumer's own migration ticket per the locked stability contract. The \`consumers_active: none\` line in this PR is replaced by the per-consumer block emission code in those tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)