### PR TITLE
Issue #189: docs + help-layout test (PR #189-3 of three)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,6 +175,51 @@ ltl -so max access.log
 ltl -so occurrences -sa access.log
 ```
 
+### Percentile mode
+
+ltl computes latency percentiles for the summary table, CSV output, per-time-bucket statistics, heatmap markers, and histogram indicators. Under the unified percentile contract (issue [#187](https://github.com/gregeva/logtimeline/issues/187)), these consumers share a single bin-counter substrate with log-spaced bin geometry and HdrHistogram-style auto-resize. Bin precision is tunable; the locked default (53 buckets per decade, ~1.3% precision) matches OpenTelemetry's Scale-4 analog and is appropriate for the vast majority of analyses.
+
+When this matters: at the default precision, percentile values like P50 / P99 are within ~1.3% of their true sort-based values. Increasing precision reduces binning error proportionally at the cost of memory per partition (~2.1 KB per partition at default precision; scales linearly with bpd).
+
+| Option | Description |
+|--------|-------------|
+| `-pp, --percentile-precision <N>` | Precision tier 1..9 (default: 5). See tier table below. |
+| `-pbpd, --percentile-buckets-per-decade <N>` | Buckets per decade directly (default: 53; valid 4..616). Overrides `--percentile-precision` when both supplied. |
+| `-ep, --exact-percentiles` | Revert all migrated consumers to exact sort-based percentile computation. Deprecated; intended as a safety net during the migration. |
+
+**Precision tier table** (`--percentile-precision N` → buckets-per-decade):
+
+| N | bpd | Worst-case binning error |
+|---|-----|--------------------------|
+| 1 | 4   | ~14%                     |
+| 2 | 8   | ~7%                      |
+| 3 | 16  | ~3.5%                    |
+| 4 | 32  | ~1.8%                    |
+| 5 | 53  | ~1.1% (default)          |
+| 6 | 80  | ~0.7%                    |
+| 7 | 115 | ~0.5%                    |
+| 8 | 256 | ~0.2%                    |
+| 9 | 616 | ~0.09%                   |
+
+Use `-V` to inspect the active settings. The `=== PERCENTILE MODE ===` section reports the resolved precision, the source annotation (default, flag, or override), per-consumer state, and per-quantile audit codes (`out_of_range_bounded: pN=none|low|high`).
+
+```bash
+# Default precision (5 / 53 bpd)
+ltl access.log
+
+# Higher precision tier for tight outlier analysis
+ltl -pp 7 access.log
+
+# Direct buckets-per-decade override
+ltl -pbpd 100 access.log
+
+# Inspect the resolved settings
+ltl -V access.log | grep -A 5 'PERCENTILE MODE'
+
+# Opt out to exact (sort-based) percentiles for byte-exact comparison
+ltl -ep access.log
+```
+
 ### Heatmap
 
 Heatmap mode replaces the per-bucket latency statistics with a color-intensity visualization showing how values are distributed within each time bucket. Where percentile statistics reduce a distribution to a handful of numbers, the heatmap reveals its full shape — bimodal distributions (cache hits vs. misses), shifting modes over time, outlier clustering, and long tails all become visually apparent. Each cell represents a value range, with color intensity proportional to the number of entries falling within that range. Logarithmic bucket boundaries provide resolution across the full range of values, from sub-millisecond to multi-second durations.
@@ -202,6 +247,7 @@ Histograms show the overall distribution shape of a metric across the entire tim
 | `-hg, --histogram [metric]` | Show an overall distribution histogram after the bar graph (`duration`, `bytes`, or `count`) |
 | `-hgw, --histogram-width <N>` | Histogram width as percentage of terminal (default: 95) |
 | `-hgh, --histogram-height <N>` | Histogram height in rows (default: 8) |
+| `-hgbpd, --histogram-buckets-per-decade <N>` | Histogram buckets per decade (default: 8) |
 
 ```bash
 # Show duration and bytes histograms side by side

--- a/features/187-histogram-bin-counter-percentiles.md
+++ b/features/187-histogram-bin-counter-percentiles.md
@@ -1132,7 +1132,7 @@ Non-binding guidance for #189's implementation — the contract above is what mu
 
 2. **Tiered lever** (user-friendly day-to-day analyst use):
    - Long form: `--percentile-precision LEVEL`
-   - No short form.
+   - Short form: `-pp LEVEL` (added 2026-05-19 per project requirement that every CLI option exposes both short and long forms; supersedes the prior "no short form" lock).
    - Valid range: **1 ≤ LEVEL ≤ 9**.
    - Default: LEVEL 5 (maps to bpd = 53).
    - Internally maps to `buckets_per_decade` per the locked table below.
@@ -1377,7 +1377,7 @@ ltl exposes a global user-facing opt-out flag that reverts all migrated consumer
 
 **Flag**:
 - Long form: `--exact-percentiles`
-- No short form.
+- Short form: `-ep` (added 2026-05-19 per project requirement that every CLI option exposes both short and long forms; supersedes the prior "no short form" lock).
 - Boolean flag (no argument).
 - Default: not set (unified path runs for all migrated consumers).
 

--- a/ltl
+++ b/ltl
@@ -1398,7 +1398,7 @@ sub print_help {
 
     # Description column starts at this position; adapt to terminal width
     my $opt_col   = 4;    # indent for option text
-    my $desc_col  = 47;   # column where descriptions begin
+    my $desc_col  = 52;   # column where descriptions begin (bumped from 47 to 52 in PR #189-3 to accommodate longer long-form option names like --histogram-buckets-per-decade and --percentile-buckets-per-decade per the project requirement that every option exposes both short and long forms; tied to $short_col below — when $short_col grows by N, $desc_col must grow by N)
     my $wrap_width = ($terminal_width && $terminal_width > 80) ? $terminal_width : 80;
 
     # Word-wrap a description string to fit between $desc_col and $wrap_width
@@ -1425,7 +1425,7 @@ sub print_help {
     };
 
     # Format an option line: option text left-aligned, description word-wrapped
-    my $short_col = 7;  # width allocated for short option (e.g. "-bs,  " or "-osum,")
+    my $short_col = 8;  # width allocated for short option text (including trailing comma). Bumped from 7 to 8 in PR #189-3 to accommodate "-hgbpd," (7 chars including comma) without forcing the long-form column one position right of every other row's long-form column. Also requires bumping $desc_col by the same amount.
     my $opt = sub {
         my ($flags, $desc) = @_;
         my $formatted;
@@ -1575,6 +1575,14 @@ sub print_help {
     $out .= $opt->("-hg,  --histogram [metric]",    "Show an overall distribution histogram after the bar graph (duration, bytes, or count)");
     $out .= $opt->("-hgw, --histogram-width <N>",   "Histogram width as percentage of terminal (default: 95)");
     $out .= $opt->("-hgh, --histogram-height <N>",  "Histogram height in rows (default: 8)");
+    $out .= $opt->("-hgbpd, --histogram-buckets-per-decade <N>", "Histogram buckets per decade (default: 8; 4=~10%, 8=~5%, 16=~2.5%, 32=~1% precision)");
+    $out .= $opt->("-hgb,  --histogram-buckets <N>",             "Override total histogram bucket count (default: 0 = auto-calculate from buckets-per-decade)");
+
+    # Percentile mode (Issue #189)
+    $out .= $subheading->("Percentile mode");
+    $out .= $opt->("-pp,   --percentile-precision <N>",            "Set percentile binning precision tier 1..9 (default: 5 = ~1.3%; 1=~10%, 9=~0.1%). Affects migrated consumers; see docs/usage.md");
+    $out .= $opt->("-pbpd, --percentile-buckets-per-decade <N>",   "Set percentile buckets-per-decade directly (default: 53; valid 4..616). Overrides --percentile-precision when both supplied");
+    $out .= $opt->("-ep,   --exact-percentiles",                   "Disable unified percentile mode; revert to exact sort-based computation (deprecated; -V shows opt_out_active: yes)");
 
     # User-Defined Metrics
     $out .= $subheading->("User-Defined Metrics");
@@ -3943,11 +3951,11 @@ sub adapt_to_command_line_options {
         'histogram|hg:s' => \&handle_histogram_option,
         'histogram-width|hgw=i' => sub { $histogram_width_percent = $_[1]; $histogram_width_explicit = 1; },
         'histogram-height|hgh=i' => sub { $histogram_height = $_[1]; $histogram_height_explicit = 1; },
-        'hgbpd=i' => \$histogram_buckets_per_decade,
-        'hgb=i' => \$histogram_bucket_override,
-        'pbpd=i' => \$percentile_buckets_per_decade,
-        'percentile-precision=i' => \$percentile_precision_level,
-        'exact-percentiles' => \$exact_percentiles_optout,
+        'hgbpd|histogram-buckets-per-decade=i' => \$histogram_buckets_per_decade,
+        'hgb|histogram-buckets=i' => \$histogram_bucket_override,
+        'pbpd|percentile-buckets-per-decade=i' => \$percentile_buckets_per_decade,
+        'pp|percentile-precision=i' => \$percentile_precision_level,
+        'ep|exact-percentiles' => \$exact_percentiles_optout,
         'terminal-width|tw=i' => \$terminal_width,
         'no-auto-hide|nah' => \$no_auto_hide,
         'debug-layout' => \$debug_layout,

--- a/tests/validate-help-layout.sh
+++ b/tests/validate-help-layout.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# validate-help-layout.sh — Validate `ltl --help` column-alignment layout.
+# Usage: ./tests/validate-help-layout.sh
+#
+# Ensures every option row's description starts at the same column and every
+# wrapped-description continuation line aligns at the same column. Catches
+# layout regressions when a new long-form option name exceeds the available
+# option-text column width without bumping $desc_col — exactly the failure
+# mode that shipped silently before PR #189-3 (which added
+# --histogram-buckets-per-decade and --percentile-buckets-per-decade).
+#
+# Project requirement: every CLI option in ltl exposes both a short and a
+# long form. This test guards the help-output column layout so that the
+# `--help` table stays grep-friendly and visually aligned as new options
+# are added.
+#
+# The test runs `ltl --help` at a fixed --terminal-width so wrap behavior
+# is deterministic across machines. It strips the terminal-formatting
+# bytes (underline / bold sequences and backspaces from `man`-style
+# overprint) before column-checking, then asserts:
+#
+#   - Every option row's description begins at the locked column.
+#   - Every continuation line of a wrapped description begins at the locked
+#     column with leading whitespace only (no overflow into the option-text
+#     region).
+#
+# The locked column is read from `ltl` itself ($desc_col in print_help) so
+# the test moves automatically if a future PR re-bumps it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LTL="$REPO_DIR/ltl"
+
+if [[ ! -x "$LTL" ]]; then
+    echo "ERROR: ltl not found or not executable at $LTL"
+    exit 1
+fi
+
+# Extract layout constants from ltl so the test follows future changes
+# automatically. The print_help() sub declares three:
+#     my $opt_col   = 4;    # indent for option text
+#     my $desc_col  = 52;   # column where descriptions begin
+#     my $short_col = 8;    # width allocated for short option (incl. comma)
+OPT_COL=$(perl -ne   'if (/^\s*my\s+\$opt_col\s*=\s*(\d+)\s*;/)   { print $1; exit }' "$LTL")
+DESC_COL=$(perl -ne  'if (/^\s*my\s+\$desc_col\s*=\s*(\d+)\s*;/)  { print $1; exit }' "$LTL")
+SHORT_COL=$(perl -ne 'if (/^\s*my\s+\$short_col\s*=\s*(\d+)\s*;/) { print $1; exit }' "$LTL")
+if [[ -z "$OPT_COL" || -z "$DESC_COL" || -z "$SHORT_COL" ]]; then
+    echo "ERROR: could not locate \$opt_col / \$desc_col / \$short_col in ltl print_help()"
+    exit 1
+fi
+# 1-indexed columns derived from the print_help layout invariants.
+EXPECTED_DESC_COL=$((DESC_COL + 1))                # description starts here
+EXPECTED_LONG_COL=$((OPT_COL + SHORT_COL + 1))     # long form starts here
+
+# Pin the width so wrap behavior is deterministic.
+# 120 cols gives every existing option's description enough room to wrap
+# meaningfully (at least 60 chars per description line) so wrap-continuation
+# alignment can be exercised.
+HELP_OUT=$(mktemp)
+"$LTL" --terminal-width 120 --help 2>&1 > "$HELP_OUT" || true
+
+# Strip terminal-rendering bytes: ANSI escape sequences and backspace
+# overstrike used for emphasis on terminals without color (see print_help in
+# ltl). Three patterns to collapse, applied repeatedly until idempotent:
+#   1. ANSI CSI sequences (just in case any leak in).
+#   2. Bold: "X\bX"  → "X"  (bs_bold)
+#   3. Underline: "_\bX" → "X"  (bs_underline)
+STRIPPED=$(mktemp)
+perl -CSDA -pe '
+    s/\e\[[0-9;]*[A-Za-z]//g;
+    1 while s/(.)\x08\1/$1/g;
+    1 while s/_\x08(.)/$1/g;
+' "$HELP_OUT" > "$STRIPPED"
+
+pass=0
+fail=0
+failures=()
+
+note_pass() { pass=$((pass + 1)); echo "  PASS  $1"; }
+note_fail() { fail=$((fail + 1)); failures+=("$1"); echo "  FAIL  $1"; }
+
+# ---------------------------------------------------------------------------
+# Sanity: $desc_col found and looks reasonable
+# ---------------------------------------------------------------------------
+echo "[sanity]"
+if [[ "$DESC_COL" -lt 30 || "$DESC_COL" -gt 80 ]]; then
+    note_fail "sanity :: \$desc_col=$DESC_COL is out of plausible range (30..80)"
+elif [[ "$SHORT_COL" -lt 5 || "$SHORT_COL" -gt 12 ]]; then
+    note_fail "sanity :: \$short_col=$SHORT_COL is out of plausible range (5..12)"
+elif [[ "$OPT_COL" -lt 2 || "$OPT_COL" -gt 8 ]]; then
+    note_fail "sanity :: \$opt_col=$OPT_COL is out of plausible range (2..8)"
+elif [[ "$DESC_COL" -le "$EXPECTED_LONG_COL" ]]; then
+    note_fail "sanity :: \$desc_col=$DESC_COL must exceed long-form column ($EXPECTED_LONG_COL = \$opt_col + \$short_col)"
+else
+    note_pass "sanity :: \$opt_col=$OPT_COL  \$short_col=$SHORT_COL  \$desc_col=$DESC_COL  long-form col=$EXPECTED_LONG_COL  desc col=$EXPECTED_DESC_COL"
+fi
+
+# ---------------------------------------------------------------------------
+# Check every option row's description starts at the expected column.
+# An "option row" is one of:
+#   1. Indented 4 spaces, starts with `-` (short+long, or short-only)
+#   2. Indented 4 spaces, starts with `--` (long-only)
+#   3. Indented 6 spaces, plain identifier — UDM sub-rows (name, unit, etc.)
+#      and INFO `--help` row
+# Skipped lines:
+#   - Subheadings (indented 2 spaces, single word or word-with-formatting)
+#   - Section headers in OPTIONS / ENVIRONMENT / INFO (no leading indent or
+#     all-caps doubled-letter pattern)
+#   - The EXAMPLES table (different layout)
+#   - Continuation lines (handled separately below)
+#   - Blank lines, prose paragraphs (Notes section)
+#
+# We detect the EXAMPLES section heading and stop scanning after it.
+# ---------------------------------------------------------------------------
+echo ""
+echo "[option-row alignment]"
+perl -e '
+    use strict; use warnings;
+    my ($file, $expected_desc_col, $expected_long_col) = @ARGV;
+    open my $fh, "<", $file or die "open $file: $!";
+    my $in_examples = 0;
+    my $option_rows_checked = 0;
+    my $continuation_rows_checked = 0;
+    my @bad_option_rows;
+    my @bad_continuation_rows;
+    my $line_no = 0;
+    my $prev_was_option_or_cont = 0;
+    # Long-only rows place "--" at $expected_long_col; the start of the
+    # leading whitespace is at column 1, so the indent before "--" is
+    # ($expected_long_col - 1) spaces. We use this to identify long-only
+    # option rows (e.g., --help in the INFO section).
+    my $long_only_indent = " " x ($expected_long_col - 1);
+    while (my $line = <$fh>) {
+        $line_no++;
+        chomp $line;
+
+        # EXAMPLES section uses a different layout — stop scanning.
+        if ($line =~ /^EXAMPLES\s*$/) { $in_examples = 1; next; }
+        next if $in_examples;
+
+        # Section headers (no leading spaces, all-caps-ish): ignore.
+        next if $line =~ /^[A-Z]/;
+
+        # Subheadings: indented exactly 2 spaces, then a non-dash token.
+        next if $line =~ /^  [^- ]/;
+
+        # Blank line resets the wrapped-description state.
+        if ($line =~ /^\s*$/) { $prev_was_option_or_cont = 0; next; }
+
+        # Option row variants:
+        #   1. Short form: indented 4 spaces, starts with `-` (e.g., -bs).
+        #   2. UDM sub-row: indented 10 spaces, starts with letter or `/`
+        #      (e.g., `      name`).  (Indent 10 = 4 + short_col(8) - 2)
+        #      Actually these use $opt_col + (short_col - 1) spacing.
+        #   3. Long-only row: indented ($expected_long_col - 1) spaces,
+        #      starts with `--` (e.g., `--help`).
+        my $is_option_row = 0;
+        if ($line =~ /^    -/) {
+            $is_option_row = 1;
+        } elsif ($line =~ /^\Q$long_only_indent\E--/) {
+            $is_option_row = 1;
+        } elsif ($line =~ /^          [^- ]/) {
+            # UDM-style sub-row: 10 leading spaces then a letter or slash.
+            # These are not full option rows but follow the same description
+            # column. The leading-indent count is hardcoded to 10 because
+            # the UDM block in print_help emits them with that literal
+            # spacing; the test treats them as option-text-empty rows for
+            # the purpose of description-column alignment.
+            $is_option_row = 1;
+        }
+
+        if ($is_option_row) {
+            if ($line =~ /^(.*\S)( {2,})(\S.*)$/) {
+                my $desc_starts_at = length($1) + length($2) + 1;  # 1-indexed
+                if ($desc_starts_at != $expected_desc_col) {
+                    push @bad_option_rows, {
+                        line => $line_no, expected => $expected_desc_col,
+                        got => $desc_starts_at, text => $line,
+                    };
+                }
+                $option_rows_checked++;
+                $prev_was_option_or_cont = 1;
+            }
+            next;
+        }
+
+        # Continuation row: ($expected_desc_col - 1) leading spaces then
+        # non-space. Only treat as such if we just saw an option row or
+        # another continuation row.
+        if ($prev_was_option_or_cont && $line =~ /^( +)(\S.*)$/) {
+            my $lead = length($1);
+            my $cont_starts_at = $lead + 1;
+            if ($cont_starts_at != $expected_desc_col) {
+                push @bad_continuation_rows, {
+                    line => $line_no, expected => $expected_desc_col,
+                    got => $cont_starts_at, text => $line,
+                };
+            }
+            $continuation_rows_checked++;
+            next;
+        }
+
+        $prev_was_option_or_cont = 0;
+    }
+    close $fh;
+
+    print "checked $option_rows_checked option rows, $continuation_rows_checked continuation rows\n";
+    if (@bad_option_rows) {
+        print "BAD_OPTION_ROWS: ", scalar(@bad_option_rows), "\n";
+        for my $b (@bad_option_rows) {
+            print sprintf("  line %d: expected col %d, got col %d  ::  %s\n",
+                $b->{line}, $b->{expected}, $b->{got}, $b->{text});
+        }
+        exit 2;
+    }
+    if (@bad_continuation_rows) {
+        print "BAD_CONTINUATION_ROWS: ", scalar(@bad_continuation_rows), "\n";
+        for my $b (@bad_continuation_rows) {
+            print sprintf("  line %d: expected col %d, got col %d  ::  %s\n",
+                $b->{line}, $b->{expected}, $b->{got}, $b->{text});
+        }
+        exit 3;
+    }
+    exit 0;
+' "$STRIPPED" "$EXPECTED_DESC_COL" "$EXPECTED_LONG_COL"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+    note_pass "every option row description starts at col $EXPECTED_DESC_COL"
+    note_pass "every wrapped-description continuation row starts at col $EXPECTED_DESC_COL"
+elif [[ $rc -eq 2 ]]; then
+    note_fail "one or more option rows have misaligned description column (see output above)"
+elif [[ $rc -eq 3 ]]; then
+    note_fail "one or more continuation rows have misaligned column (see output above)"
+else
+    note_fail "Perl inspector exited with unexpected code $rc"
+fi
+
+# ---------------------------------------------------------------------------
+# Check every short+long option row's long-form column alignment.
+# Long-form-column drift is a real failure mode independent of the description
+# column: when a short form's length pushes the long form one or more columns
+# right of where shorter short forms put it, the result is a visually ragged
+# left margin even though the description column itself stays aligned.
+# Locked invariant: every short-form row places its long form starting at
+# the SAME column (the one determined by $opt_col + $short_col).
+# ---------------------------------------------------------------------------
+echo ""
+echo "[long-form column alignment]"
+perl -e '
+    use strict; use warnings;
+    my ($file, $expected_col) = @ARGV;
+    open my $fh, "<", $file or die "open $file: $!";
+    my $in_examples = 0;
+    my $checked = 0;
+    my @bad;
+    while (my $line = <$fh>) {
+        if ($line =~ /^EXAMPLES\s*$/) { $in_examples = 1; next; }
+        next if $in_examples;
+        next unless $line =~ /^    -/;        # short-form rows only
+        next unless $line =~ /, +--/;          # must have both forms
+        if ($line =~ /(--\S+)/) {
+            my $long = $1;
+            my $idx = index($line, $long);
+            my $col = $idx + 1;  # 1-indexed
+            $checked++;
+            if ($col != $expected_col) {
+                push @bad, { col => $col, line => $line };
+            }
+        }
+    }
+    close $fh;
+    print "checked $checked short+long rows; expected long-form col $expected_col\n";
+    if (@bad) {
+        print "BAD_LONG_FORM_COLUMNS: ", scalar(@bad), " row(s) misaligned\n";
+        for my $b (@bad) {
+            chomp $b->{line};
+            print sprintf("  got col %d :: %s\n", $b->{col}, $b->{line});
+        }
+        exit 2;
+    }
+    exit 0;
+' "$STRIPPED" "$EXPECTED_LONG_COL"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+    note_pass "every short+long row places its long form at col $EXPECTED_LONG_COL"
+elif [[ $rc -eq 2 ]]; then
+    note_fail "one or more short+long rows misalign the long-form column (see output above)"
+else
+    note_fail "long-form-column Perl inspector exited with unexpected code $rc"
+fi
+
+# ---------------------------------------------------------------------------
+# Spot check: ensure the percentile-mode options (the ones that triggered
+# the original bug) are present in the help output with both forms.
+# ---------------------------------------------------------------------------
+echo ""
+echo "[short+long form presence]"
+assert_pair() {
+    local short="$1" long="$2"
+    # Pattern: "$short," followed by spaces then "$long" then either space,
+    # <ARG>, [ARG], or end of line. Uses POSIX character class for portability.
+    if grep -qE "^[[:space:]]+${short}, +${long}([[:space:]]|<|\[|$)" "$STRIPPED"; then
+        note_pass "$short, $long"
+    else
+        note_fail "$short, $long  (expected both short and long form on same line)"
+    fi
+}
+assert_pair "-pp"    "--percentile-precision"
+assert_pair "-pbpd"  "--percentile-buckets-per-decade"
+assert_pair "-ep"    "--exact-percentiles"
+assert_pair "-hgbpd" "--histogram-buckets-per-decade"
+assert_pair "-hgb"   "--histogram-buckets"
+
+# ---------------------------------------------------------------------------
+# Wrap-up
+# ---------------------------------------------------------------------------
+rm -f "$HELP_OUT" "$STRIPPED"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [[ "$fail" -gt 0 ]]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+echo "ALL HELP-LAYOUT TESTS PASSED"


### PR DESCRIPTION
## Summary

Final PR of the three-PR partition for issue #189:

- PR #198 (merged) — primitives + CLI flag parsing.
- PR #199 (merged) — \`=== PERCENTILE MODE ===\` \`-V\` block + test suite.
- **PR #189-3 (this PR)** — docs + help-layout regression test + short/long form parity for all percentile-mode and histogram-bpd flags.

After this PR, the percentile-mode contract surface is fully shipped and primed for the first consumer migration.

## What's in this PR

### Docs

- **\`print_help()\`** — new \"Percentile mode\" subheading block with \`-pp, --percentile-precision\`, \`-pbpd, --percentile-buckets-per-decade\`, \`-ep, --exact-percentiles\`. Also documents the previously-undocumented \`-hgbpd\` and \`-hgb\` in the Histogram block.
- **\`docs/usage.md\`** — new \`### Percentile mode\` section before the Heatmap section: prose, options table, precision tier table mapping \`--percentile-precision N\` to bpd and worst-case error, example commands. Also adds the missing \`-hgbpd\` row to the existing Histogram options table.

### Code

- **Short/long form parity**: every CLI option carries both forms. Added \`-pp\`, \`-ep\` short forms; added \`--percentile-buckets-per-decade\`, \`--histogram-buckets-per-decade\`, \`--histogram-buckets\` long forms. Project-wide requirement that supersedes the per-feature \"no short form\" entries in the spec.
- **Layout column bumps**: \`\$short_col\` 7→8 and \`\$desc_col\` 47→52 in \`print_help()\` to accommodate the new longer long-form names while keeping every row's long-form and description columns aligned.

### Spec amendments (\`features/187-histogram-bin-counter-percentiles.md\`)

- § Decision 2 (Tiered lever): added short form \`-pp\`, supersedes prior \"no short form\" lock.
- § Decision 7 (Flag): added short form \`-ep\`, supersedes prior \"no short form\" lock.

### New test (\`tests/validate-help-layout.sh\`)

The user pointed out during PR review that the existing test suite didn't catch the description-column misalignment that shipped silently when the new long-form names were added — and then caught (during this PR's review) that the long-form column itself was also drifting for \`-hgbpd\` specifically. Both failure modes are now guarded.

The test extracts \`\$opt_col\` / \`\$short_col\` / \`\$desc_col\` directly from \`ltl\` so it follows future changes automatically, and asserts three invariants:

1. **Description column** — every option row's description starts at \`\$desc_col + 1\` (currently col 53).
2. **Continuation column** — every wrapped-description line aligns to the same column.
3. **Long-form column** — every short+long row places the long form at \`\$opt_col + \$short_col + 1\` (currently col 13).

Plus 5 spot-checks that the percentile-mode and histogram-bpd options carry both forms in the help output.

**Verified during development to catch both regressions**: reverting \`\$desc_col\` fires the description-column check; reverting \`\$short_col\` fires the long-form-column check.

## Verification

- [x] \`perl -c ltl\` — OK
- [x] \`tests/validate-regression.sh\` — 19/19 PASS
- [x] \`tests/validate-histogram-ticks.sh\` — 15/15 PASS
- [x] \`tests/validate-index-readback.sh\` — 51/51 PASS
- [x] \`tests/validate-percentile-mode.sh\` — 22/22 PASS
- [x] \`tests/validate-help-layout.sh\` — 9/9 PASS (new)

## Test plan

- [x] All five validate scripts green
- [x] Visual inspection of \`ltl --help\` confirms every long form starts at col 13 and every description at col 53
- [x] Negative test: reverting \`\$short_col\` to 7 produces a single fail with the \`-hgbpd\` row identified
- [x] Negative test: reverting \`\$desc_col\` to 47 produces two fails (one each for \`-hgbpd\` and \`-pbpd\`)

## Out of scope

- **Wiki sync**: \`docs/usage.md\` is the source of truth; the wiki is overwritten on each release per the release checklist. This PR does not touch the wiki.
- **Consumer migrations**: still each their own ticket per #187 R9. After this PR lands, the substrate is complete and the first consumer migration ticket can begin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)