### PR TITLE
Issue #34 Phase 2: rename -V section + add per-consumer scaffolding

### DIFF
--- a/features/187-histogram-bin-counter-percentiles.md
+++ b/features/187-histogram-bin-counter-percentiles.md
@@ -144,7 +144,7 @@ The unified contract is deterministic for a given input. The Decision 1 formula 
 
 ### R7 — `-V` observability
 
-A dedicated `=== PERCENTILE MODE ===` section reports the unified contract's state. The full format, field names, consumer-name strings, and structural conventions are locked in *Locked decisions from research* § Decision 8. R7 is the requirements-section anchor; Decision 8 is authoritative.
+A dedicated `=== BIN-COUNTER MODE ===` section reports the unified contract's state. The full format, field names, consumer-name strings, and structural conventions are locked in *Locked decisions from research* § Decision 8. R7 is the requirements-section anchor; Decision 8 is authoritative.
 
 The contract surface includes (full detail in Decision 8):
 
@@ -153,12 +153,12 @@ The contract surface includes (full detail in Decision 8):
 - **Shared-partition consumers**: `shares_partitions_with:` short-form blocks.
 - **Section presence**: always emitted under `-V`; reports `consumers_active: none` when no consumer is computing.
 
-The section name (`=== PERCENTILE MODE ===`), all field names, and all consumer-name strings are part of the locked feature contract per Decision 8. Field-name changes require a new locked-decision entry.
+The section name (`=== BIN-COUNTER MODE ===`), all field names, and all consumer-name strings are part of the locked feature contract per Decision 8. Field-name changes require a new locked-decision entry.
 - **Rebin telemetry (per-consumer using the unified path)**: `total_rebin_events`, `rebins_per_key { p50, p95, p99, max }`, `max_partition_bins` (Decision 5 lock; intended to support empirical seed-heuristic tuning).
 - **Tier-correctness for filtered runs**: if a run includes a filter, `-V` reports the filter context so an analyst can audit whether the result is appropriate (R2.2 reframed as audit concern, not gate).
 - **Pre-migration consumers (any still running the sort-based path during phased migration)**: `n` (the value count consumed) and `sorted: yes` line, matching R11's byte-identical contract.
 
-Section name (`=== PERCENTILE MODE ===`) and the core field labels are part of the feature contract. Practical decision 8 settles cosmetic and verbosity details.
+Section name (`=== BIN-COUNTER MODE ===`) and the core field labels are part of the feature contract. Practical decision 8 settles cosmetic and verbosity details.
 
 ### R8 — Coupling to the unified primitive contract
 
@@ -455,7 +455,7 @@ This section defines the **contract-surface validation scenarios** that any cons
 
 ### Contract-level scenario suite
 
-Run ltl with `-V`, assert against the `=== PERCENTILE MODE ===` section. These scenarios validate the unified contract surface (R7, R10) independently of any specific consumer's migration progress.
+Run ltl with `-V`, assert against the `=== BIN-COUNTER MODE ===` section. These scenarios validate the unified contract surface (R7, R10) independently of any specific consumer's migration progress.
 
 | Scenario | Setup | Action | Assertions |
 |---|---|---|---|
@@ -703,7 +703,7 @@ D3 is the central deliverable of Phase 1. It synthesizes D1's analysis into a me
 
 D3 does **not** lock the implementation. The decision conversation between user and Claude is what locks it; D3 is the input to that conversation, and the locked entries live in *Locked decisions from research*.
 
-> **Status as of 2026-05-19: GROUNDED + F1, Decisions 1, 1A, 2, 3, 4, 5, 7, 8, 10 locked; Decisions 6, 9 DISSOLVED. All decision-conversation work complete.** The D3 content has been rebuilt from `features/187-histogram-industry-grounding.md` (industry-practice research pass) with primary-source citations. Locked: **F1** (design-philosophy framing: ltl as query-time analyzer, `buckets_per_decade` as the analyst's lever, rank-in-bin information used); **Decision 1** (R4 uses the Prometheus native-exponential in-bucket interpolation formula, verified verbatim against `promql/quantile.go` lines 331–353); **Decision 1A** (use rank-in-bin); **Decision 2** (`buckets_per_decade` default 53 / OTEP-149 Scale-4 analog; two CLI flags — numeric `-pbpd` and tiered `--percentile-precision 1..9`; valid range 4 ≤ N ≤ 616; `-pbpd` always wins on conflict); **Decision 3** (no per-bin sample-count guard in R4; no partition-level rank-support signal in `-V`; follows strict industry convention); **Decision 4** (Prometheus `+Inf` overflow convention adopted verbatim for high end; symmetric `-Inf`-equivalent underflow convention for low end; separate counters; overflow/underflow contribute to N; R4 returns `boundary[B]` or `boundary[0]` if target rank lands in overflow/underflow; per-quantile `-V` audit field `out_of_range_bounded: high|low|none`); **Decision 5** (HdrHistogram-style auto-resize per partition across all consumers; partition seeded with full-default-span centered on first value; HdrHistogram-convention doubling on rebin; no precedent run or #179 index dependency for partition sizing; per-partition rebin telemetry exposed in `-V` for empirical seed-heuristic tuning); **Decision 7** (visible `--exact-percentiles` flag with deprecation notice; global scope; available one release cycle past each consumer's migration validation per implementation-ticket choice; `-V` reports top-level banner AND per-consumer `user_opt_out` line per R10); **Decision 8** (`-V` `=== PERCENTILE MODE ===` section with run-level header + per-consumer blocks; locked consumer-name strings; field names and section/consumer/field naming all locked; format mirrors existing `=== INDEX READ-BACK ===` convention; primary purpose is testability and AI-agent debugging); **Decision 10** (prototype validation scope — five mandatory aspects #189 must validate empirically before production code begins: in-bin formula on real data, auto-resize lifecycle on per-key fan-out at scale, initial seed heuristic + overflow/underflow on edge cases, end-to-end `-V` output sample, calculation accuracy vs. current array-of-values approach; hard prerequisite for #189 production code). **Decision 6** dissolved — no runtime gate in the unified contract. **Decision 9** dissolved — activation policy and release-engineering decisions are out of scope for #187; they belong to the per-consumer implementation tickets that consume this contract.
+> **Status as of 2026-05-19: GROUNDED + F1, Decisions 1, 1A, 2, 3, 4, 5, 7, 8, 10 locked; Decisions 6, 9 DISSOLVED. All decision-conversation work complete.** The D3 content has been rebuilt from `features/187-histogram-industry-grounding.md` (industry-practice research pass) with primary-source citations. Locked: **F1** (design-philosophy framing: ltl as query-time analyzer, `buckets_per_decade` as the analyst's lever, rank-in-bin information used); **Decision 1** (R4 uses the Prometheus native-exponential in-bucket interpolation formula, verified verbatim against `promql/quantile.go` lines 331–353); **Decision 1A** (use rank-in-bin); **Decision 2** (`buckets_per_decade` default 53 / OTEP-149 Scale-4 analog; two CLI flags — numeric `-pbpd` and tiered `--percentile-precision 1..9`; valid range 4 ≤ N ≤ 616; `-pbpd` always wins on conflict); **Decision 3** (no per-bin sample-count guard in R4; no partition-level rank-support signal in `-V`; follows strict industry convention); **Decision 4** (Prometheus `+Inf` overflow convention adopted verbatim for high end; symmetric `-Inf`-equivalent underflow convention for low end; separate counters; overflow/underflow contribute to N; R4 returns `boundary[B]` or `boundary[0]` if target rank lands in overflow/underflow; per-quantile `-V` audit field `out_of_range_bounded: high|low|none`); **Decision 5** (HdrHistogram-style auto-resize per partition across all consumers; partition seeded with full-default-span centered on first value; HdrHistogram-convention doubling on rebin; no precedent run or #179 index dependency for partition sizing; per-partition rebin telemetry exposed in `-V` for empirical seed-heuristic tuning); **Decision 7** (visible `--exact-percentiles` flag with deprecation notice; global scope; available one release cycle past each consumer's migration validation per implementation-ticket choice; `-V` reports top-level banner AND per-consumer `user_opt_out` line per R10); **Decision 8** (`-V` `=== BIN-COUNTER MODE ===` section with run-level header + per-consumer blocks; locked consumer-name strings; field names and section/consumer/field naming all locked; format mirrors existing `=== INDEX READ-BACK ===` convention; primary purpose is testability and AI-agent debugging); **Decision 10** (prototype validation scope — five mandatory aspects #189 must validate empirically before production code begins: in-bin formula on real data, auto-resize lifecycle on per-key fan-out at scale, initial seed heuristic + overflow/underflow on edge cases, end-to-end `-V` output sample, calculation accuracy vs. current array-of-values approach; hard prerequisite for #189 production code). **Decision 6** dissolved — no runtime gate in the unified contract. **Decision 9** dissolved — activation policy and release-engineering decisions are out of scope for #187; they belong to the per-consumer implementation tickets that consume this contract.
 
 #### D3 memo — the six decisions
 
@@ -1002,7 +1002,7 @@ Whichever framing ltl picks, the decision conversation must record that the valu
 Beyond the six analytical decisions above, the decision conversation must resolve four practical questions before Phase 2 implementation begins. The literature consulted in `features/187-histogram-industry-grounding.md` does not document conventions for any of these (the libraries leave configuration, observability format, activation policy, and prototyping triggers to the consumer); they are recorded here as ltl-specific decisions, distinct from the analytical decisions 1–6 above.
 
 7. **User-facing opt-out from the unified path** — **LOCKED (2026-05-19)**: visible `--exact-percentiles` flag with deprecation notice on every invocation, global scope, available one release cycle past each consumer's R9 migration. `-V` reports both a top-level banner and the per-consumer `user_opt_out` line per R10. Full lock recorded in *Locked decisions from research* § Decision 7 below.
-8. **`-V` reporting verbosity and format** — **LOCKED (2026-05-19)**: `=== PERCENTILE MODE ===` section with run-level header + per-consumer blocks, mirroring the existing `=== INDEX READ-BACK ===` block convention in ltl. Consumer names lowercase-with-underscores; `out_of_range_bounded:` reported inline per-quantile (Option A). Full lock recorded in *Locked decisions from research* § Decision 8 below.
+8. **`-V` reporting verbosity and format** — **LOCKED (2026-05-19)**: `=== BIN-COUNTER MODE ===` section with run-level header + per-consumer blocks, mirroring the existing `=== INDEX READ-BACK ===` block convention in ltl. Consumer names lowercase-with-underscores; `out_of_range_bounded:` reported inline per-quantile (Option A). Full lock recorded in *Locked decisions from research* § Decision 8 below.
 9. **Phase 2 default activation policy** — **DISSOLVED (2026-05-19)**: this question is out of scope for #187, which is a research-and-architecture-foundation deliverable. Activation policy, shipping cadence, default-on-vs-default-off, and per-release ramp decisions belong to the per-consumer implementation tickets that consume this contract, not to #187. Full dissolution rationale recorded in *Locked decisions from research* § Decision 9 below.
 10. **Prototype validation scope — what #189 must validate before production code** — **LOCKED (2026-05-19)**: #187 specifies the aspects of the locked architecture that must be validated empirically through prototyping before #189 begins production implementation. Five aspects are in scope: (a) the in-bin interpolation formula's behavior on real data; (b) the auto-resize partition lifecycle's behavior on per-key fan-out at scale; (c) the initial partition seeding heuristic and overflow/underflow handling on edge-case data; (d) an end-to-end verbose output sample for downstream comparison; (e) calculation accuracy compared to the array-of-values approach currently in use. The prototype is a hard prerequisite for #189's production code; #189 owns where the prototype lives and how it's structured. Full lock recorded in *Locked decisions from research* § Decision 10 below.
 
@@ -1418,7 +1418,7 @@ Non-binding.
 - **CLI parsing convention**: `--exact-percentiles` is a boolean flag handled in the same family as ltl's existing CLI flags (per CLAUDE.md's existing CLI conventions). Consistent with how ltl handles other boolean flags like `--ms`, `--hg`, `-hm`.
 - **Banner format suggestion** (practical decision 8 finalizes): something like:
   ```
-  === PERCENTILE MODE ===
+  === BIN-COUNTER MODE ===
   WARNING: --exact-percentiles is active. Output reflects the pre-#187 sort-based
   computation path. This flag is deprecated and will be removed in a future release.
   See docs/usage.md for the unified-path defaults.
@@ -1431,16 +1431,18 @@ Non-binding.
   - `docs/usage.md` — analyst-facing explanation of when to use the flag, what it does, and the migration path (use Decision 2's precision lever, or use an older ltl release if the analyst genuinely needs byte-identical pre-feature output).
 - **Retirement mechanism**: when the flag is removed in a future release, the removal is itself a release-process item — bump the major or minor version per ltl's release conventions, document the removal in release notes, ensure the deprecation notice appeared in the prior release.
 
-### Decision 8 — `-V` reporting verbosity and format — **LOCKED (2026-05-19)**
+### Decision 8 — `-V` reporting verbosity and format — **LOCKED (2026-05-19); section name amended 2026-05-20**
+
+> **Amendment 2026-05-20 (#34 Phase 2)**: section name changed from `=== PERCENTILE MODE ===` to `=== BIN-COUNTER MODE ===`. The substrate is HdrHistogram-style histogram bin counters; percentiles are one of three derivations from it, alongside bin counts (`histogram_bins`) and cell colors (`heatmap_cells`), which are not percentiles. The original name described the output of one consumer family; the amended name describes the substrate the entire contract is built on. Function name in code amended from `emit_percentile_mode_verbose` to `emit_bin_counter_mode_verbose` for the same reason. The user-facing `--exact-percentiles` / `-ep` flag is unchanged — it correctly names the user's choice rather than the substrate. All field names, consumer-name strings, and per-consumer field-name lockings within Decision 8 remain in effect verbatim.
 
 #### Contract
 
-`-V` output for percentile and histogram bin-counter state lives in a dedicated section named `=== PERCENTILE MODE ===`. The section is **always present** under `-V`, regardless of which consumers are active; if no consumer is computing percentiles or bin counts in the current run, the section reports `consumers_active: none` after the run-level header.
+`-V` output for percentile and histogram bin-counter state lives in a dedicated section named `=== BIN-COUNTER MODE ===`. The section is **always present** under `-V`, regardless of which consumers are active; if no consumer is computing percentiles or bin counts in the current run, the section reports `consumers_active: none` after the run-level header.
 
 The section's primary purpose is **testability and AI-agent debugging**. Field names are stable across releases; cosmetic changes to formatting that affect field-name greps require a new locked-decision entry. Reader-friendliness is secondary to grep-stability and coverage of the research-locked observability signals.
 
 **Conventions** (matching ltl's existing `=== INDEX READ-BACK ===` block, `ltl:836`):
-- Section header: `=== PERCENTILE MODE ===`.
+- Section header: `=== BIN-COUNTER MODE ===`.
 - Top-level lines: `key: value` with lowercase-with-underscores keys.
 - Nested blocks: `block_opener: <name>` followed by two-space-indented `key: value` lines.
 - Inline multi-value lines: space-separated `key=value` pairs (used for the per-quantile `out_of_range_bounded:` audit, see below).
@@ -1510,7 +1512,7 @@ No per-consumer blocks in that case.
 Default run with all consumers migrated:
 
 ```
-=== PERCENTILE MODE ===
+=== BIN-COUNTER MODE ===
 opt_out_active: no
 percentile_precision: 5 (default)
 buckets_per_decade: 53 (default)
@@ -1553,7 +1555,7 @@ consumer: histogram_bins
 Opt-out active:
 
 ```
-=== PERCENTILE MODE ===
+=== BIN-COUNTER MODE ===
 opt_out_active: yes
 opt_out_notice: --exact-percentiles is set; all migrated consumers reverted to pre-#187 sort-based computation. This flag is deprecated and will be removed in a future release.
 percentile_precision: 5 (default; not in effect this run)
@@ -1571,7 +1573,7 @@ consumer: csv_output
 Precision override with conflict:
 
 ```
-=== PERCENTILE MODE ===
+=== BIN-COUNTER MODE ===
 opt_out_active: no
 percentile_precision: 4 (--percentile-precision 4; overridden)
 buckets_per_decade: 100 (-pbpd 100; --percentile-precision 4 overridden)
@@ -1599,7 +1601,7 @@ consumer: summary_table
 No consumers active:
 
 ```
-=== PERCENTILE MODE ===
+=== BIN-COUNTER MODE ===
 opt_out_active: no
 percentile_precision: 5 (default)
 buckets_per_decade: 53 (default)
@@ -1620,7 +1622,7 @@ consumers_active: none
 
 Non-binding.
 
-- **Section emission point**: emit the `=== PERCENTILE MODE ===` block at the appropriate point in `@verbose_output` so it appears in the standard `-V` output order alongside `=== INDEX READ-BACK ===` and `=== Verbose ===`. Exact ordering relative to those other sections is implementation discretion; tests should not depend on inter-section ordering.
+- **Section emission point**: emit the `=== BIN-COUNTER MODE ===` block at the appropriate point in `@verbose_output` so it appears in the standard `-V` output order alongside `=== INDEX READ-BACK ===` and `=== Verbose ===`. Exact ordering relative to those other sections is implementation discretion; tests should not depend on inter-section ordering.
 - **Per-consumer iteration order**: emit per-consumer blocks in the order listed in the locked consumer-name table. This is part of the contract — tests grep for consumer blocks in this order.
 - **Field-value formatting**:
   - Integer counts: bare decimal (`1247`, not `1,247`).
@@ -1687,7 +1689,7 @@ Before #189 begins production implementation of the unified primitive helpers, t
    - The locked seed (partition opens at 5 decades centered on the first value seen) must be validated against real latency data to confirm p99 rebin counts fall in the expected 0–2 range. Surface any keys that rebin pathologically; document if the seed needs tuning before #189's production implementation locks in the heuristic.
    - The Decision 4 overflow/underflow handling (separate counters at the partition boundaries; R4 returns `boundary[B]` or `boundary[0]` when target rank lands in overflow/underflow) must be exercised against pathological inputs constructed from D2 datasets — extreme outliers, very narrow distributions, mixed scale regimes. Confirm the `out_of_range_bounded: high|low|none` audit field per Decision 8 fires correctly per quantile, and document the hit rate in normal vs. pathological scenarios.
 
-4. **End-to-end `-V` output sample for downstream comparison.** The prototype must produce a real `=== PERCENTILE MODE ===` verbose output block, per the locked Decision 8 format, against real log files. The output sample becomes a reference for downstream work: implementation tickets compare their migrated consumers' actual output against this prototype output to spot deviations; tests can grep against known-good output. The sample must exercise enough scenarios (default precision, `--percentile-precision` override, `-pbpd` override, flag conflict, overflow audit firing, opt-out active) to cover the format's locked surface.
+4. **End-to-end `-V` output sample for downstream comparison.** The prototype must produce a real `=== BIN-COUNTER MODE ===` verbose output block, per the locked Decision 8 format, against real log files. The output sample becomes a reference for downstream work: implementation tickets compare their migrated consumers' actual output against this prototype output to spot deviations; tests can grep against known-good output. The sample must exercise enough scenarios (default precision, `--percentile-precision` override, `-pbpd` override, flag conflict, overflow audit firing, opt-out active) to cover the format's locked surface.
 
 5. **Calculation accuracy compared to the array-of-values approach currently in use.** Direct comparison between the unified contract's output (Decision 1 formula over auto-resize partitions per Decision 5) and ltl's *existing* `calculate_statistics` retained-array sort-and-index approach (`ltl:5488`). For every required percentile per consumer (per R3) across D2 datasets, the prototype must show that the unified output sits within the bin-resolution bound (per R4, ~1.1% midpoint error at locked default 53 bpd) of today's exact output. This is the operational accuracy validation — confirming that the locked architecture produces output users will accept as a quality improvement over the current implementation, not a regression.
 

--- a/features/189-bin-counter-primitives-implementation-readiness-audit.md
+++ b/features/189-bin-counter-primitives-implementation-readiness-audit.md
@@ -70,7 +70,7 @@ The sweep confirms the spec's `Audit findings` section (`features/189-histogram-
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ #189 production — primitive helpers in ltl                  │
-│   scope: R1-R6 helpers, =PERCENTILE MODE= -V block,         │
+│   scope: R1-R6 helpers, =BIN-COUNTER MODE= -V block,         │
 │   --percentile-precision / -pbpd / --exact-percentiles      │
 │   CLI flags, primitive-level unit tests, baseline           │
 │   harness scenarios. NO CONSUMER IS MIGRATED.               │
@@ -144,9 +144,9 @@ Each item below records what was landed and where it lives in the spec, so a re-
 
 **Rationale:** the prototype's V4 scenarios surfaced this small format question (`prototype/189-bin-counter-primitives-validation-report.md` § V4 *Findings* finding 2). It's not a contract gap — it's a small cosmetic question Decision 8 didn't anticipate. Calling it out in the spec lets #189 production pick a convention and not have to bikeshed it during implementation.
 
-### A6 (deferred) — Tests for `=== PERCENTILE MODE ===` section
+### A6 (deferred) — Tests for `=== BIN-COUNTER MODE ===` section
 
-`tests/baseline/` does not currently have a scenario asserting the `=== PERCENTILE MODE ===` block, but Decision 8's stability contract says "section name, all top-level field names, all consumer-name strings, and all per-consumer field names are part of the locked feature contract." Test coverage for this is a contract surface but is **#189 production's responsibility, not this audit's**. Recorded here so the production ticket knows test scaffolding for the new `-V` section is in scope. See `tests/validate-index-readback.sh` for the existing pattern.
+`tests/baseline/` does not currently have a scenario asserting the `=== BIN-COUNTER MODE ===` block, but Decision 8's stability contract says "section name, all top-level field names, all consumer-name strings, and all per-consumer field names are part of the locked feature contract." Test coverage for this is a contract surface but is **#189 production's responsibility, not this audit's**. Recorded here so the production ticket knows test scaffolding for the new `-V` section is in scope. See `tests/validate-index-readback.sh` for the existing pattern.
 
 ---
 
@@ -220,7 +220,7 @@ The unified contract eliminates four raw value arrays. Each migration ticket del
 
 **Anchor correction:** the audit's earlier draft referred to this function as `print_memory_breakdown`; no such function exists in `ltl`. The actual sub is `measure_memory_structures`.
 
-**Recommended change:** when each consumer migrates and its raw-array global is deleted, the corresponding `Devel::Size` line in `measure_memory_structures` is updated to track the new counter-store global (or removed if memory tracking is consolidated into the `counter_memory_bytes` field of `=== PERCENTILE MODE ===`). The `MEMORY_FINAL` block in `print_verbose_output` (`ltl:6578-6587`) is a **second** emission site — see new B14.
+**Recommended change:** when each consumer migrates and its raw-array global is deleted, the corresponding `Devel::Size` line in `measure_memory_structures` is updated to track the new counter-store global (or removed if memory tracking is consolidated into the `counter_memory_bytes` field of `=== BIN-COUNTER MODE ===`). The `MEMORY_FINAL` block in `print_verbose_output` (`ltl:6578-6587`) is a **second** emission site — see new B14.
 
 **Owning ticket:** each consumer migration touches the corresponding `Devel::Size` line.
 
@@ -228,7 +228,7 @@ The unified contract eliminates four raw value arrays. Each migration ticket del
 
 **Today:** `@verbose_output` is built up sequentially; `=== INDEX READ-BACK ===` (`ltl:836`) is one of **four** existing `=== ... ===` blocks in the verbose-output pipeline — see B17 for the full inventory.
 
-**Recommended change:** #189 production adds a `=== PERCENTILE MODE ===` block to `@verbose_output` at the appropriate point. Decision 8 line 1623 leaves the exact ordering relative to other `-V` sections at implementer discretion; tests should not depend on inter-section ordering.
+**Recommended change:** #189 production adds a `=== BIN-COUNTER MODE ===` block to `@verbose_output` at the appropriate point. Decision 8 line 1623 leaves the exact ordering relative to other `-V` sections at implementer discretion; tests should not depend on inter-section ordering.
 
 **Owning ticket:** #189 production.
 
@@ -236,9 +236,9 @@ The unified contract eliminates four raw value arrays. Each migration ticket del
 
 **Today:** `tests/validate-index-readback.sh` is the existing pattern for `-V`-section regression tests. `tests/validate-regression.sh` is the broader output-regression harness.
 
-**Recommended change:** #189 production adds `tests/validate-percentile-mode.sh` (or equivalent) following the `validate-index-readback.sh` pattern, asserting the `=== PERCENTILE MODE ===` block's run-level header and per-consumer block fields per Decision 8's locked stability contract. Each consumer migration adds its own baseline-regression scenarios per #187 R11.
+**Recommended change:** #189 production adds `tests/validate-percentile-mode.sh` (or equivalent) following the `validate-index-readback.sh` pattern, asserting the `=== BIN-COUNTER MODE ===` block's run-level header and per-consumer block fields per Decision 8's locked stability contract. Each consumer migration adds its own baseline-regression scenarios per #187 R11.
 
-**Owning tickets:** #189 production owns the new `=== PERCENTILE MODE ===` test scaffold; each consumer migration extends the baseline-regression harness for that consumer's user-visible output.
+**Owning tickets:** #189 production owns the new `=== BIN-COUNTER MODE ===` test scaffold; each consumer migration extends the baseline-regression harness for that consumer's user-visible output.
 
 ### B8 — `print_help()` (`ltl:1051`)
 
@@ -270,7 +270,7 @@ The unified contract eliminates four raw value arrays. Each migration ticket del
 
 **Today:** analyst-facing documentation, synced to the public wiki on each release. Heatmap options reference at `docs/usage.md:180+`; histogram options reference at `docs/usage.md:202+`. **`-hgbpd` is not documented in `docs/usage.md` today** (sweep confirmed: no `-hgbpd` references in the file) — a pre-existing gap that the migration can incidentally close by documenting the percentile-precision tier table alongside it.
 
-**Recommended change:** #189 production adds analyst-facing explanation of when to use the new flags (per Decision 2 line 1194 and Decision 7 line 1431). Specifically: the `--percentile-precision 1..9` tier table; how to read `=== PERCENTILE MODE ===` output; when to consider `--exact-percentiles` opt-out. The natural insertion point sits between the heatmap section and the histogram section, since percentile mode now applies to all consumers.
+**Recommended change:** #189 production adds analyst-facing explanation of when to use the new flags (per Decision 2 line 1194 and Decision 7 line 1431). Specifically: the `--percentile-precision 1..9` tier table; how to read `=== BIN-COUNTER MODE ===` output; when to consider `--exact-percentiles` opt-out. The natural insertion point sits between the heatmap section and the histogram section, since percentile mode now applies to all consumers.
 
 **Owning ticket:** #189 production.
 
@@ -307,7 +307,7 @@ The unified contract eliminates four raw value arrays. Each migration ticket del
 
 **Sweep finding:** the audit doc's B5 cites `print_memory_breakdown` (no such function — actual sub is `measure_memory_structures` at `ltl:3206`). It misses the second emission site at `ltl:6578-6587`. Two emission sites mean any rename or repurposing of `%log_analysis`/`%log_messages` under the unified contract must update both locations.
 
-**Recommended change:** production updates both `measure_memory_structures` (B5) and `print_verbose_output` (this row) when consumers migrate. Specifically: when `log_messages{}{}{durations}` becomes a counter store under Phase 2, `ltl:6579` continues to track `%log_messages` (which now holds the counter stores instead of raw arrays) — the line stays valid but the value drops by ~100×. Per-consumer counter memory is also tracked separately in the new `counter_memory_bytes` field of `=== PERCENTILE MODE ===`.
+**Recommended change:** production updates both `measure_memory_structures` (B5) and `print_verbose_output` (this row) when consumers migrate. Specifically: when `log_messages{}{}{durations}` becomes a counter store under Phase 2, `ltl:6579` continues to track `%log_messages` (which now holds the counter stores instead of raw arrays) — the line stays valid but the value drops by ~100×. Per-consumer counter memory is also tracked separately in the new `counter_memory_bytes` field of `=== BIN-COUNTER MODE ===`.
 
 **Owning ticket:** each consumer migration touches both Devel::Size emission sites.
 
@@ -355,9 +355,9 @@ This row is recorded to **flag the consolidation-flow interaction** for the Phas
 | `=== BENCHMARK DATA ===` | `ltl:6541` (`print` direct from `print_verbose_output`) | Benchmark TSV emission (closed with `=== END BENCHMARK DATA ===` at `ltl:6604`) |
 | `=== Consolidation Summary (Issue #96) ===` | `ltl:8116` (push to `@verbose_output`) | Fuzzy-message-consolidation telemetry |
 
-**Sweep finding:** the audit doc cites only `=== INDEX READ-BACK ===` (B6). Production must pick `=== PERCENTILE MODE ===`'s ordering relative to all four blocks, and must also pick whether to follow the `@verbose_output` push convention (used by 3 of 4) or the direct-print convention (used by `=== BENCHMARK DATA ===`). The push convention is the natural choice — the BENCHMARK DATA block uses direct print only because its TSV format is consumed by `tests/baseline/run-benchmark.sh` separately from the human-readable `-V` output.
+**Sweep finding:** the audit doc cites only `=== INDEX READ-BACK ===` (B6). Production must pick `=== BIN-COUNTER MODE ===`'s ordering relative to all four blocks, and must also pick whether to follow the `@verbose_output` push convention (used by 3 of 4) or the direct-print convention (used by `=== BENCHMARK DATA ===`). The push convention is the natural choice — the BENCHMARK DATA block uses direct print only because its TSV format is consumed by `tests/baseline/run-benchmark.sh` separately from the human-readable `-V` output.
 
-**Recommended change:** #189 production adds `=== PERCENTILE MODE ===` via the `@verbose_output` push convention, following the pattern at `ltl:836` and `ltl:8116`. The block sits naturally after `=== INDEX READ-BACK ===` (which describes the data substrate the partitions were built from) and before `=== Consolidation Summary ===` (which is end-of-pipeline telemetry). Tests must not assert inter-block ordering per Decision 8.
+**Recommended change:** #189 production adds `=== BIN-COUNTER MODE ===` via the `@verbose_output` push convention, following the pattern at `ltl:836` and `ltl:8116`. The block sits naturally after `=== INDEX READ-BACK ===` (which describes the data substrate the partitions were built from) and before `=== Consolidation Summary ===` (which is end-of-pipeline telemetry). Tests must not assert inter-block ordering per Decision 8.
 
 **Owning ticket:** #189 production. See new C8 for the explicit ordering decision.
 
@@ -398,7 +398,7 @@ The prototype gave evidence but didn't lock these — they're production concern
 
 **Recommendation (non-binding):** parse both flags during option parsing; resolve to `($bpd, $precision_source)` once, store on a global or pass through to partition construction explicitly. The prototype uses a global `$precision_source` string for the `-V` source annotation (`prototype/189-bin-counter-primitives.pl:79-91`); production might prefer a struct.
 
-### C4 — `=== PERCENTILE MODE ===` block wiring
+### C4 — `=== BIN-COUNTER MODE ===` block wiring
 
 **Question:** where does the block emission live? A new `print_percentile_mode()` sub called from the existing `-V` emission path? Inline in the main flow?
 
@@ -428,9 +428,9 @@ The prototype gave evidence but didn't lock these — they're production concern
 
 **Why this is Bucket C, not Bucket A:** Decision 2 locks the new flag's contract but does not address legacy flag interactions. The decision is genuinely #189-production's call.
 
-### C8 — `=== PERCENTILE MODE ===` block ordering vs. four existing blocks
+### C8 — `=== BIN-COUNTER MODE ===` block ordering vs. four existing blocks
 
-**Question:** per B17, there are four existing `=== ... ===` blocks in the verbose-output pipeline. Where does the new `=== PERCENTILE MODE ===` block go in the sequence?
+**Question:** per B17, there are four existing `=== ... ===` blocks in the verbose-output pipeline. Where does the new `=== BIN-COUNTER MODE ===` block go in the sequence?
 
 **Recommendation (non-binding):** insert after `=== INDEX READ-BACK ===` (which describes the data substrate the partitions were built from) and before `=== Consolidation Summary ===` (which is end-of-pipeline telemetry). Specifically: push to `@verbose_output` immediately after the existing push at `ltl:836+` and before the consolidation summary push at `ltl:8116`. Decision 8 line 1623 explicitly leaves inter-block ordering at production's discretion, so this is purely an ergonomic choice — but the recommendation tracks the data flow (substrate → percentile mode → consolidation) the analyst sees.
 
@@ -444,7 +444,7 @@ When #189 production is opened, the work decomposes naturally into the following
 
 1. **PR #189-1: Primitive helpers + CLI flag parsing (no `-V` output yet).** R1–R6 helpers landed in `ltl`. `--percentile-precision`, `-pbpd`, `--exact-percentiles` parsed but unused. Unit tests for R1–R6 against synthetic inputs. No consumer changes. Baseline regression passes byte-identically because nothing observable changes.
 
-2. **PR #189-2: `=== PERCENTILE MODE ===` `-V` block + `consumers_active: none` state.** The block emits per Decision 8 with `consumers_active: none` because no consumer is migrated. `tests/validate-percentile-mode.sh` asserts the block's run-level header and the no-consumer-active path. Baseline regression continues to pass byte-identically.
+2. **PR #189-2: `=== BIN-COUNTER MODE ===` `-V` block + `consumers_active: none` state.** The block emits per Decision 8 with `consumers_active: none` because no consumer is migrated. `tests/validate-percentile-mode.sh` asserts the block's run-level header and the no-consumer-active path. Baseline regression continues to pass byte-identically.
 
 3. **PR #189-3: `README.md`, `docs/usage.md`, `print_help()` updates.** Analyst-facing documentation lands. No code changes beyond `print_help()`. Wiki sync happens at next release.
 
@@ -460,7 +460,7 @@ For each downstream ticket, the full set of `ltl` code surfaces it touches per t
 
 ### #189 production
 
-- B5 (memory tracking in `measure_memory_structures` at `ltl:3206-3240` — new `counter_memory_bytes` field in `=== PERCENTILE MODE ===`)
+- B5 (memory tracking in `measure_memory_structures` at `ltl:3206-3240` — new `counter_memory_bytes` field in `=== BIN-COUNTER MODE ===`)
 - B6 (`=== INDEX READ-BACK ===` block coexistence — adds new block at appropriate point)
 - B7 (`tests/baseline/` — adds `tests/validate-percentile-mode.sh`)
 - B8 (`print_help()` — adds three new flags)

--- a/features/189-histogram-bin-counter-primitives.md
+++ b/features/189-histogram-bin-counter-primitives.md
@@ -71,7 +71,7 @@ Before #189 begins production implementation of the primitives, **the locked arc
 
 3. **Initial partition seeding heuristic and overflow/underflow handling on edge-case data.** Validate the locked seed (partition opens at 5 decades centered on the first value seen) produces p99 rebin counts in the expected 0–2 range on real latency data. Construct pathological D2 inputs (extreme outliers, very narrow distributions, mixed scale regimes) and confirm the locked `out_of_range_bounded: high|low|none` audit field fires correctly per quantile and that R4 returns the correct boundary value.
 
-4. **End-to-end `-V` output sample for downstream comparison.** Produce a real `=== PERCENTILE MODE ===` verbose output block (per #187 Decision 8's locked format) from the prototype running against real log files. Exercise enough scenarios (default precision, `--percentile-precision` override, `-pbpd` override, flag conflict, overflow audit firing, opt-out active) to cover the locked format surface.
+4. **End-to-end `-V` output sample for downstream comparison.** Produce a real `=== BIN-COUNTER MODE ===` verbose output block (per #187 Decision 8's locked format) from the prototype running against real log files. Exercise enough scenarios (default precision, `--percentile-precision` override, `-pbpd` override, flag conflict, overflow audit firing, opt-out active) to cover the locked format surface.
 
 5. **Calculation accuracy compared to the array-of-values approach currently in use.** Direct comparison between the prototype's unified-contract output and ltl's existing `calculate_statistics` retained-array sort-and-index approach (`ltl:5488`). For every required percentile per consumer (per #187 R3) across D2 datasets, confirm the unified output sits within the bin-resolution bound (per #187 R4) of today's exact output.
 
@@ -217,7 +217,7 @@ Auto-resize (R1) reallocates the counter storage when the partition extends. The
 
 ### R9 — Telemetry surface for `-V` output (per #187 Decision 8)
 
-The primitives expose telemetry signals that consumers populate into the locked `=== PERCENTILE MODE ===` `-V` section per #187 Decision 8. The primitives themselves do not produce `-V` output; they make the data available.
+The primitives expose telemetry signals that consumers populate into the locked `=== BIN-COUNTER MODE ===` `-V` section per #187 Decision 8. The primitives themselves do not produce `-V` output; they make the data available.
 
 The primitives must expose:
 
@@ -483,7 +483,7 @@ These constraints apply across all consumers and are the hard inputs to #189's p
 
 - [ ] R1–R11 hold.
 - [ ] All primitive behavior matches the locked #187 contract: Decision 1's formula in R4; Decision 5's auto-resize lifecycle in R1; Decision 4's overflow/underflow handling in R6; Decision 2's resolved `buckets_per_decade` value drives R1's bin count.
-- [ ] The R9 telemetry surface provides every data point that #187 Decision 8 requires consumers to surface in `=== PERCENTILE MODE ===` output.
+- [ ] The R9 telemetry surface provides every data point that #187 Decision 8 requires consumers to surface in `=== BIN-COUNTER MODE ===` output.
 - [ ] Primitive-level unit tests cover R1–R6 (see Validation below).
 - [ ] Cross-consumer composition tests demonstrate that R7 (partition independence) and R8 (lifecycle independence) hold when multiple consumers exercise the primitives simultaneously.
 - [ ] Per-consumer migration tickets can consume the primitives without forking, duplicating, or extending them beyond their locked contract.

--- a/features/34-histogram-bin-counter-mode.md
+++ b/features/34-histogram-bin-counter-mode.md
@@ -115,7 +115,7 @@ The migrated consumers do not require any feature-specific overflow handling bey
 
 ### R7 — Telemetry surface for `-V` output per #187 Decision 8
 
-Each migrated consumer produces a per-consumer block in the locked `=== PERCENTILE MODE ===` `-V` section per #187 Decision 8, with the locked consumer-name strings: `heatmap_cells`, `heatmap_markers`, `histogram_view`, `histogram_bins`.
+Each migrated consumer produces a per-consumer block in the locked `=== BIN-COUNTER MODE ===` `-V` section per #187 Decision 8, with the locked consumer-name strings: `heatmap_cells`, `heatmap_markers`, `histogram_view`, `histogram_bins`.
 
 Each per-consumer block reports the contract-surface fields locked in #187 Decision 8: `path`, `partition_keying`, `partition_count`, `total_rebin_events`, `max_partition_bins`, `partitions_with_overflow_count`, `partitions_with_underflow_count`, `counter_memory_bytes`, `rebins_per_partition`, `percentiles_emitted`, `out_of_range_bounded`, `shares_partitions_with` (where applicable).
 
@@ -139,7 +139,7 @@ The partitions are independent in `[min, max]` as each per-time-bucket partition
 
 ### R10 — Per-consumer `-V` path reporting
 
-Each consumer's `path:` line in its `=== PERCENTILE MODE ===` block per #187 Decision 8 reports the active path for that consumer:
+Each consumer's `path:` line in its `=== BIN-COUNTER MODE ===` block per #187 Decision 8 reports the active path for that consumer:
 
 - `unified` — consumer is on the migrated path.
 - `pre_migration` — consumer has not yet migrated, or this is a pre-migration validation run.
@@ -221,7 +221,7 @@ The pre-migration code paths that this feature's implementation replaces. Line r
 - [ ] R4 holds: per-line accumulation during parse via #189 R2 / R3; no raw-value arrays under the unified path.
 - [ ] R5 holds: display geometry preserved via render-time re-projection.
 - [ ] R6 holds: overflow/underflow per #187 Decision 4 implemented by #189; this feature consumes that mechanism.
-- [ ] R7 holds: `=== PERCENTILE MODE ===` section reports each consumer's block per #187 Decision 8.
+- [ ] R7 holds: `=== BIN-COUNTER MODE ===` section reports each consumer's block per #187 Decision 8.
 - [ ] R8 holds: display geometry unchanged; precision improvements documented in release notes.
 - [ ] R9 holds: heatmap and histogram have independent partitions per #189 R7.
 - [ ] R10 holds: per-consumer `path:` line reports correctly under all four states.
@@ -233,7 +233,7 @@ The pre-migration code paths that this feature's implementation replaces. Line r
 - [ ] Under `--exact-percentiles`, all four consumers' output is byte-identical to the pre-feature implementation per #187 R11a.
 - [ ] Under the unified path, all four consumers' percentile values fall within the bin-resolution bound per #187 R4 around the pre-migration values, across the D2 dataset set.
 - [ ] `tests/baseline/` regression harness passes for the heatmap and histogram outputs.
-- [ ] `-V` `=== PERCENTILE MODE ===` output matches the locked format per #187 Decision 8 (consumer-name strings, field names, format).
+- [ ] `-V` `=== BIN-COUNTER MODE ===` output matches the locked format per #187 Decision 8 (consumer-name strings, field names, format).
 
 ## Validation
 
@@ -241,7 +241,7 @@ This section defines the **validation scenarios** for the heatmap and histogram 
 
 ### Contract-level scenarios from #187
 
-The contract-level validation scenarios specified in #187 § Validation apply to this feature's consumers. They cover the locked `=== PERCENTILE MODE ===` format, per-consumer `path:` reporting, opt-out behavior, out-of-range bounded reporting, and accuracy comparison against the pre-migration output. The implementation ticket runs these scenarios against the four consumers in this feature's scope.
+The contract-level validation scenarios specified in #187 § Validation apply to this feature's consumers. They cover the locked `=== BIN-COUNTER MODE ===` format, per-consumer `path:` reporting, opt-out behavior, out-of-range bounded reporting, and accuracy comparison against the pre-migration output. The implementation ticket runs these scenarios against the four consumers in this feature's scope.
 
 ### Heatmap-specific validation
 

--- a/ltl
+++ b/ltl
@@ -1155,21 +1155,15 @@ sub emit_index_readback_verbose {
     }
 }
 
-# Issue #189 (PR #189-2): emit the `=== PERCENTILE MODE ===` section into
-# @verbose_output. Always emitted under -V per the locked stability contract.
-# Field names, consumer-name strings, and the three-value audit enum
-# (none|low|high) are locked at:
+# Section name, field names, consumer-name strings, and the three-value audit
+# enum (none|low|high) are locked at:
 #   features/187-histogram-bin-counter-percentiles.md § Decision 8
-# Tests assert grep-level stability of every field this sub emits; field-name
-# changes require a new locked-decision entry. Field values may evolve freely.
-#
-# In this PR (no consumer migrated yet) the section always reports
-# `consumers_active: none` after the run-level header. The first consumer
-# migration replaces that line with per-consumer blocks in the locked order.
-sub emit_percentile_mode_verbose {
+# Field-name changes require a new locked-decision entry. Field values may
+# evolve freely.
+sub emit_bin_counter_mode_verbose {
     return unless $verbose;
 
-    push @verbose_output, "=== PERCENTILE MODE ===";
+    push @verbose_output, "=== BIN-COUNTER MODE ===";
 
     # Run-level header — opt_out_active first per the locked example output.
     my $opt_out = $exact_percentiles_optout ? 'yes' : 'no';
@@ -1220,10 +1214,33 @@ sub emit_percentile_mode_verbose {
     push @verbose_output,
         "buckets_per_decade: $percentile_buckets_per_decade ($percentile_precision_source$not_in_effect)";
 
-    # PR #189-2 ships no migrated consumer; the section always terminates
-    # here. PR #189-3 onwards will replace this with per-consumer blocks
-    # emitted in the locked order from the consumer-name table.
-    push @verbose_output, "consumers_active: none";
+    my %feature_active = (
+        summary_table     => 1,
+        csv_output        => $write_messages_to_csv ? 1 : 0,
+        time_bucket_stats => ($print_durations && !$omit_durations
+                              && !$omit_stats && !$heatmap_enabled) ? 1 : 0,
+        heatmap_markers   => $heatmap_enabled ? 1 : 0,
+        heatmap_cells     => $heatmap_enabled ? 1 : 0,
+        histogram_view    => $histogram_enabled ? 1 : 0,
+        histogram_bins    => $histogram_enabled ? 1 : 0,
+    );
+
+    my @consumer_order = qw(
+        summary_table
+        csv_output
+        time_bucket_stats
+        heatmap_markers
+        heatmap_cells
+        histogram_view
+        histogram_bins
+    );
+
+    for my $consumer (@consumer_order) {
+        push @verbose_output, "";
+        push @verbose_output, "consumer: $consumer";
+        my $path = $feature_active{$consumer} ? 'pre_migration' : 'feature_not_active';
+        push @verbose_output, "  path: $path";
+    }
 }
 
 sub write_index_file {
@@ -8682,11 +8699,7 @@ $elapsed_total = $elapsed_read_files + $elapsed_initialize_empty_time_windows + 
 detect_index_drift();
 emit_index_readback_verbose();
 
-# Issue #189 (PR #189-2): always emit the percentile-mode section under -V.
-# Ordering recommendation locked at:
-#   features/189-bin-counter-primitives-implementation-readiness-audit.md § Bucket C § C8
-# Tests assert per-block contents only, not inter-block ordering.
-emit_percentile_mode_verbose();
+emit_bin_counter_mode_verbose();
 
 print_verbose_output();
 


### PR DESCRIPTION
## Summary

Phase 2 of #34 — independent of the blocked Phase 3 consumer migration. Two changes:

- Rename `=== PERCENTILE MODE ===` → `=== BIN-COUNTER MODE ===` and `emit_percentile_mode_verbose` → `emit_bin_counter_mode_verbose`. The substrate is HdrHistogram-style histogram bin counters; percentiles are one of three derivations from it alongside bin counts and cell colors. The user-facing `--exact-percentiles` / `-ep` flag is unchanged.
- Replace single-line `consumers_active: none` placeholder with seven per-consumer blocks emitted in the locked #187 Decision-8 order. Each reports `path: pre_migration` when its feature is engaged or `path: feature_not_active` otherwise. Phase 3 (blocked by #201) will populate the four heatmap/histogram blocks with real partition state.
- Amend #187 Decision 8 to record the section-name change. Sweep matching references through features/187, features/189, features/195, and features/34.

Non-`-V` output is byte-identical to pre-change. Regression suite passes (19/19).

## Status

- Phase 3 (consumer migration) was attempted and reverted. Blocked by **#201** (Investigation: Fixed-bin-count primitive variant for display-geometry-bound consumers). See https://github.com/gregeva/logtimeline/issues/34#issuecomment-4493103562 for details.
- Branch `34-histogram-bin-counter` stays alive after this merge for Phase 3 resumption post-#201.

## Test plan

- [x] `./tests/validate-regression.sh` — 19/19 passing
- [x] `./ltl -V --disable-progress logs/AccessLogs/...` shows `=== BIN-COUNTER MODE ===` banner and all seven consumer blocks in locked order
- [x] `./ltl -V --disable-progress -hm duration -hg ...` shows `path: pre_migration` for the four heatmap/histogram consumers when those features are engaged
- [x] Non-`-V` output byte-identical to pre-change baseline