### PR TITLE
Issue #34 follow-up: pin heatmap regression tests to --exact-percentiles

### DIFF
--- a/tests/capture-regression.sh
+++ b/tests/capture-regression.sh
@@ -73,9 +73,14 @@ for w in 160 200; do
 done
 
 # --- Heatmap modes at width 160 ---
+# --exact-percentiles pins these captures to the sort-and-index path. The
+# unified bin-counter path (#34/#201) is approximate within bin-resolution
+# bound and would make the reference fragile to precision tweaks. Layout
+# coverage is what we want; bin-counter accuracy is covered by
+# tests/validate-percentile-mode.sh.
 echo "Heatmap modes at width 160:"
 for mode in duration bytes count; do
-    run_test "heatmap-${mode}-w160" "$LTL" $COMMON --terminal-width 160 -hm "$mode" "$SCRIPT_LOG"
+    run_test "heatmap-${mode}-w160" "$LTL" $COMMON --exact-percentiles --terminal-width 160 -hm "$mode" "$SCRIPT_LOG"
 done
 
 # --- Omit flags at width 160 ---
@@ -90,7 +95,7 @@ echo "Auto-hide at narrow widths:"
 run_test "autohide-w80" "$LTL" $COMMON --terminal-width 80 "$ACCESS_LOG"
 run_test "autohide-w100" "$LTL" $COMMON --terminal-width 100 "$ACCESS_LOG"
 run_test "noautohide-w80" "$LTL" $COMMON --terminal-width 80 --no-auto-hide "$ACCESS_LOG"
-run_test "autohide-hm-w120" "$LTL" $COMMON --terminal-width 120 -hm duration "$SCRIPT_LOG"
+run_test "autohide-hm-w120" "$LTL" $COMMON --exact-percentiles --terminal-width 120 -hm duration "$SCRIPT_LOG"
 
 # --- Millisecond precision with constrained time range ---
 echo "Millisecond precision at width 160:"

--- a/tests/reference-output/autohide-hm-w120.txt
+++ b/tests/reference-output/autohide-hm-w120.txt
@@ -12,5 +12,5 @@
  2025-04-10 06:00 ERROR: 405 WARN: 63691 INFO: 115  3.4:535.1/m │ █████████████████████████████████████████████████████ 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1ms──────16.4ms───────340.4ms───────7.1s────────3.1m
 
-command-line options: --disable-progress -osum -n 1 --terminal-width 120 -hm duration 
+command-line options: --disable-progress -osum -n 1 --exact-percentiles --terminal-width 120 -hm duration 
 

--- a/tests/reference-output/heatmap-bytes-w160.txt
+++ b/tests/reference-output/heatmap-bytes-w160.txt
@@ -12,5 +12,5 @@
  2025-04-10 06:00 ERROR: 405 WARN: 63691 INFO: 115  3.4:535.1/m │ █████████████████████   8.7h     430.6  │ █             ███ ██|███                        ██||
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─504 B────1.1 KiB──────2.5 KiB───────6 KiB─────15 KiB
 
-command-line options: --disable-progress -osum -n 1 --terminal-width 160 -hm bytes 
+command-line options: --disable-progress -osum -n 1 --exact-percentiles --terminal-width 160 -hm bytes 
 

--- a/tests/reference-output/heatmap-count-w160.txt
+++ b/tests/reference-output/heatmap-count-w160.txt
@@ -12,5 +12,5 @@
  2025-04-10 06:00 ERROR: 405 WARN: 63691 INFO: 115  3.4:535.1/m │ █████████████████████   8.7h     430.6  │ █   █  █ | ███████|███|█     █ ██████ █ ███     █|██
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1──────────5.8─────────38.7─────────259.3───────2.0k
 
-command-line options: --disable-progress -osum -n 1 --terminal-width 160 -hm count 
+command-line options: --disable-progress -osum -n 1 --exact-percentiles --terminal-width 160 -hm count 
 

--- a/tests/reference-output/heatmap-duration-w160.txt
+++ b/tests/reference-output/heatmap-duration-w160.txt
@@ -12,5 +12,5 @@
  2025-04-10 06:00 ERROR: 405 WARN: 63691 INFO: 115  3.4:535.1/m │ █████████████████████   8.7h     430.6  │ █ █ ███|██████████████████████████|██|███████|██████
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1ms──────16.4ms───────340.4ms───────7.1s────────3.1m
 
-command-line options: --disable-progress -osum -n 1 --terminal-width 160 -hm duration 
+command-line options: --disable-progress -osum -n 1 --exact-percentiles --terminal-width 160 -hm duration 
 

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -81,8 +81,14 @@ for w in 160 200; do
 done
 
 # --- Heatmap modes at width 160 ---
+# --exact-percentiles pins these to the sort-and-index path so the reference
+# stays byte-stable. The unified bin-counter path (#34/#201) is approximate
+# within bin-resolution bound (well below visibility threshold per #201 V8)
+# but not byte-identical, which would make this layout/rendering regression
+# suite fragile to precision tweaks. Layout coverage is what we want here;
+# bin-counter accuracy is covered by tests/validate-percentile-mode.sh.
 for mode in duration bytes count; do
-    run_test "heatmap-${mode}-w160" "$LTL" $COMMON --terminal-width 160 -hm "$mode" "$SCRIPT_LOG"
+    run_test "heatmap-${mode}-w160" "$LTL" $COMMON --exact-percentiles --terminal-width 160 -hm "$mode" "$SCRIPT_LOG"
 done
 
 # --- Omit flags at width 160 ---
@@ -95,7 +101,7 @@ run_test "omit-ov-or-w160" "$LTL" $COMMON --terminal-width 160 -ov -or "$ACCESS_
 run_test "autohide-w80" "$LTL" $COMMON --terminal-width 80 "$ACCESS_LOG"
 run_test "autohide-w100" "$LTL" $COMMON --terminal-width 100 "$ACCESS_LOG"
 run_test "noautohide-w80" "$LTL" $COMMON --terminal-width 80 --no-auto-hide "$ACCESS_LOG"
-run_test "autohide-hm-w120" "$LTL" $COMMON --terminal-width 120 -hm duration "$SCRIPT_LOG"
+run_test "autohide-hm-w120" "$LTL" $COMMON --exact-percentiles --terminal-width 120 -hm duration "$SCRIPT_LOG"
 
 # --- Millisecond precision ---
 run_test "ms-w160" "$LTL" $COMMON --terminal-width 160 -ms -bs 1000 -st 00:00 -et 00:05 "$ACCESS_LOG"


### PR DESCRIPTION
## Summary

After #34 Phase 3 landed, two heatmap regression tests (heatmap-bytes-w160, heatmap-count-w160) failed with 1-2 cell marker drifts on the ScriptLog dataset — within the bin-resolution bound the unified bin-counter path is allowed to deviate by, but not byte-identical to the captured exact-path references.

This PR pins all four heatmap regression tests (the three -hm modes plus autohide-hm-w120) to the exact path via --exact-percentiles, keeping these layout/rendering checks byte-stable across future precision tweaks. Bin-counter accuracy is independently covered by tests/validate-percentile-mode.sh.

## Changes

- tests/validate-regression.sh + tests/capture-regression.sh: add --exact-percentiles to all 4 heatmap test invocations, with a comment block explaining why.
- tests/reference-output/heatmap-{duration,bytes,count}-w160.txt + autohide-hm-w120.txt: re-captured. Only the cmdline-options echo line changed (now includes --exact-percentiles); bar content is byte-identical to the pre-#34 references because the exact path is preserved verbatim.

## Test plan

- [x] ./tests/validate-regression.sh — 19/19 PASS