### PR TITLE
Backfill v0.14.4 benchmark baseline against shipped binary

### DIFF
--- a/tests/baseline/results/v0.14.4.tsv
+++ b/tests/baseline/results/v0.14.4.tsv
@@ -1,856 +1,75 @@
 test_name	options	metric_type	metric_name	value
-humungous-log-uniqueness-standard		version	0.14.3
-humungous-log-uniqueness-standard		FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-standard		lines_read	288025
-humungous-log-uniqueness-standard		lines_included	288025
-humungous-log-uniqueness-standard		TIMING	read_files	2.356
-humungous-log-uniqueness-standard		TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-standard		TIMING	group_similar	0.000
-humungous-log-uniqueness-standard		TIMING	calculate_statistics	0.303
-humungous-log-uniqueness-standard		TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-standard		TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-standard		TIMING	normalize_data	0.001
-humungous-log-uniqueness-standard		TIMING	total	2.660
-humungous-log-uniqueness-standard		MEMORY	rss_peak	210419712
-humungous-log-uniqueness-standard		MEMORY	consolidation_clusters	120
-humungous-log-uniqueness-standard		MEMORY	consolidation_key_message	120
-humungous-log-uniqueness-standard		MEMORY	consolidation_patterns	120
-humungous-log-uniqueness-standard		MEMORY	consolidation_unmatched	120
-humungous-log-uniqueness-standard		MEMORY	heatmap_data	120
-humungous-log-uniqueness-standard		MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-standard		MEMORY	heatmap_raw	120
-humungous-log-uniqueness-standard		MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-standard		MEMORY	histogram_values	576
-humungous-log-uniqueness-standard		MEMORY	log_analysis	232
-humungous-log-uniqueness-standard		MEMORY	log_messages	133188237
-humungous-log-uniqueness-standard		MEMORY	log_occurrences	4619
-humungous-log-uniqueness-standard		MEMORY	log_sessions	120
-humungous-log-uniqueness-standard		MEMORY	log_stats	120
-humungous-log-uniqueness-standard		MEMORY	log_threadpools	232
-humungous-log-uniqueness-standard		MEMORY	threadpool_activity	762
-humungous-log-uniqueness-standard		MEMORY	udm_last_value	120
-humungous-log-uniqueness-standard		MEMORY_FINAL	log_messages	133188237
-humungous-log-uniqueness-standard		MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_clusters	120
-humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_patterns	120
-humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_key_message	120
-humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_unmatched	120
-humungous-log-uniqueness-standard		COUNTS	log_messages_entries	286659
-humungous-log-uniqueness-standard		COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-standard		COUNTS	log_stats_entries	5
-humungous-log-uniqueness-standard		CONFIG	terminal_width	200
-humungous-log-uniqueness-standard		CONFIG	terminal_height	52
-humungous-log-uniqueness-standard		CONFIG	max_log_message_length	200
-humungous-log-uniqueness-standard		CONFIG	time_bucket_size	60
-humungous-log-uniqueness-standard		CONFIG	bucket_size_seconds	3600.00
-humungous-log-uniqueness-top25	-n 25	version	0.14.3
-humungous-log-uniqueness-top25	-n 25	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-top25	-n 25	lines_read	288025
-humungous-log-uniqueness-top25	-n 25	lines_included	288025
-humungous-log-uniqueness-top25	-n 25	TIMING	read_files	2.396
-humungous-log-uniqueness-top25	-n 25	TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-top25	-n 25	TIMING	group_similar	0.000
-humungous-log-uniqueness-top25	-n 25	TIMING	calculate_statistics	0.266
-humungous-log-uniqueness-top25	-n 25	TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-top25	-n 25	TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-top25	-n 25	TIMING	normalize_data	0.001
-humungous-log-uniqueness-top25	-n 25	TIMING	total	2.663
-humungous-log-uniqueness-top25	-n 25	MEMORY	rss_peak	209993728
-humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_clusters	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_key_message	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_patterns	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_unmatched	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_data	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_raw	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	histogram_values	576
-humungous-log-uniqueness-top25	-n 25	MEMORY	log_analysis	232
-humungous-log-uniqueness-top25	-n 25	MEMORY	log_messages	133188237
-humungous-log-uniqueness-top25	-n 25	MEMORY	log_occurrences	4619
-humungous-log-uniqueness-top25	-n 25	MEMORY	log_sessions	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	log_stats	120
-humungous-log-uniqueness-top25	-n 25	MEMORY	log_threadpools	232
-humungous-log-uniqueness-top25	-n 25	MEMORY	threadpool_activity	762
-humungous-log-uniqueness-top25	-n 25	MEMORY	udm_last_value	120
-humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	log_messages	133188237
-humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
-humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
-humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
-humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
-humungous-log-uniqueness-top25	-n 25	COUNTS	log_messages_entries	286659
-humungous-log-uniqueness-top25	-n 25	COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-top25	-n 25	COUNTS	log_stats_entries	5
-humungous-log-uniqueness-top25	-n 25	CONFIG	terminal_width	200
-humungous-log-uniqueness-top25	-n 25	CONFIG	terminal_height	52
-humungous-log-uniqueness-top25	-n 25	CONFIG	max_log_message_length	200
-humungous-log-uniqueness-top25	-n 25	CONFIG	time_bucket_size	60
-humungous-log-uniqueness-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	version	0.14.3
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	lines_read	288025
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	lines_included	288025
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	read_files	6.360
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	group_similar	4.000
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.000
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.001
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	total	10.361
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	rss_peak	257851392
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	200881
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	132762
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	25503
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	108036
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_analysis	232
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_messages	123591
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	4619
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_stats	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	100953
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	200881
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	25503
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	65592
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	72
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	5
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	terminal_height	52
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
-humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
-humungous-log-uniqueness-heatmap	-hm	version	0.14.3
-humungous-log-uniqueness-heatmap	-hm	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-heatmap	-hm	lines_read	288025
-humungous-log-uniqueness-heatmap	-hm	lines_included	288025
-humungous-log-uniqueness-heatmap	-hm	TIMING	read_files	2.377
-humungous-log-uniqueness-heatmap	-hm	TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-heatmap	-hm	TIMING	group_similar	0.000
-humungous-log-uniqueness-heatmap	-hm	TIMING	calculate_statistics	0.332
-humungous-log-uniqueness-heatmap	-hm	TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-heatmap	-hm	TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-heatmap	-hm	TIMING	normalize_data	0.001
-humungous-log-uniqueness-heatmap	-hm	TIMING	total	2.709
-humungous-log-uniqueness-heatmap	-hm	MEMORY	rss_peak	209960960
-humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_clusters	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_key_message	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_patterns	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_unmatched	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_data	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_raw	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	histogram_values	576
-humungous-log-uniqueness-heatmap	-hm	MEMORY	log_analysis	232
-humungous-log-uniqueness-heatmap	-hm	MEMORY	log_messages	133188237
-humungous-log-uniqueness-heatmap	-hm	MEMORY	log_occurrences	4619
-humungous-log-uniqueness-heatmap	-hm	MEMORY	log_sessions	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	log_stats	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY	log_threadpools	232
-humungous-log-uniqueness-heatmap	-hm	MEMORY	threadpool_activity	762
-humungous-log-uniqueness-heatmap	-hm	MEMORY	udm_last_value	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	log_messages	133188237
-humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
-humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
-humungous-log-uniqueness-heatmap	-hm	COUNTS	log_messages_entries	286659
-humungous-log-uniqueness-heatmap	-hm	COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-heatmap	-hm	COUNTS	log_stats_entries	5
-humungous-log-uniqueness-heatmap	-hm	CONFIG	terminal_width	200
-humungous-log-uniqueness-heatmap	-hm	CONFIG	terminal_height	52
-humungous-log-uniqueness-heatmap	-hm	CONFIG	max_log_message_length	200
-humungous-log-uniqueness-heatmap	-hm	CONFIG	time_bucket_size	60
-humungous-log-uniqueness-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
-humungous-log-uniqueness-histogram	-hg	version	0.14.3
-humungous-log-uniqueness-histogram	-hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-histogram	-hg	lines_read	288025
-humungous-log-uniqueness-histogram	-hg	lines_included	288025
-humungous-log-uniqueness-histogram	-hg	TIMING	read_files	2.354
-humungous-log-uniqueness-histogram	-hg	TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-histogram	-hg	TIMING	group_similar	0.000
-humungous-log-uniqueness-histogram	-hg	TIMING	calculate_statistics	0.286
-humungous-log-uniqueness-histogram	-hg	TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-histogram	-hg	TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-histogram	-hg	TIMING	normalize_data	0.001
-humungous-log-uniqueness-histogram	-hg	TIMING	total	2.642
-humungous-log-uniqueness-histogram	-hg	MEMORY	rss_peak	209403904
-humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_clusters	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_key_message	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_patterns	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_unmatched	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_data	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_raw	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	histogram_values	576
-humungous-log-uniqueness-histogram	-hg	MEMORY	log_analysis	232
-humungous-log-uniqueness-histogram	-hg	MEMORY	log_messages	133188237
-humungous-log-uniqueness-histogram	-hg	MEMORY	log_occurrences	4619
-humungous-log-uniqueness-histogram	-hg	MEMORY	log_sessions	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	log_stats	120
-humungous-log-uniqueness-histogram	-hg	MEMORY	log_threadpools	232
-humungous-log-uniqueness-histogram	-hg	MEMORY	threadpool_activity	762
-humungous-log-uniqueness-histogram	-hg	MEMORY	udm_last_value	120
-humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	log_messages	133188237
-humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_clusters	120
-humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_patterns	120
-humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_key_message	120
-humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_unmatched	120
-humungous-log-uniqueness-histogram	-hg	COUNTS	log_messages_entries	286659
-humungous-log-uniqueness-histogram	-hg	COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-histogram	-hg	COUNTS	log_stats_entries	5
-humungous-log-uniqueness-histogram	-hg	CONFIG	terminal_width	200
-humungous-log-uniqueness-histogram	-hg	CONFIG	terminal_height	52
-humungous-log-uniqueness-histogram	-hg	CONFIG	max_log_message_length	200
-humungous-log-uniqueness-histogram	-hg	CONFIG	time_bucket_size	60
-humungous-log-uniqueness-histogram	-hg	CONFIG	bucket_size_seconds	3600.00
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	version	0.14.3
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	lines_read	288025
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	lines_included	288025
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	read_files	2.412
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.284
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	total	2.697
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	rss_peak	211206144
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	histogram_values	576
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_analysis	232
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_messages	133188237
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	4619
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_stats	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	133188237
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	286659
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	5
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	terminal_height	52
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
-humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.3
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	lines_read	288025
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	lines_included	288025
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	6.227
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	4.149
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.000
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.000
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	0.000
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.001
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	10.377
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	258015232
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	200881
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	132762
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	25503
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	108036
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	576
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	232
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	123591
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	4619
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	100953
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	232
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	200881
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	25503
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	65592
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	72
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	5
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	5
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	52
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
-humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-standard		version	0.14.3
-single-day-application-log-standard		FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-standard		lines_read	479904
-single-day-application-log-standard		lines_included	479904
-single-day-application-log-standard		TIMING	read_files	3.615
-single-day-application-log-standard		TIMING	initialize_buckets	0.000
-single-day-application-log-standard		TIMING	group_similar	0.000
-single-day-application-log-standard		TIMING	calculate_statistics	0.006
-single-day-application-log-standard		TIMING	heatmap_statistics	0.000
-single-day-application-log-standard		TIMING	histogram_statistics	0.000
-single-day-application-log-standard		TIMING	normalize_data	0.001
-single-day-application-log-standard		TIMING	total	3.622
-single-day-application-log-standard		MEMORY	rss_peak	34816000
-single-day-application-log-standard		MEMORY	consolidation_clusters	120
-single-day-application-log-standard		MEMORY	consolidation_key_message	120
-single-day-application-log-standard		MEMORY	consolidation_patterns	120
-single-day-application-log-standard		MEMORY	consolidation_unmatched	120
-single-day-application-log-standard		MEMORY	heatmap_data	120
-single-day-application-log-standard		MEMORY	heatmap_data_hl	120
-single-day-application-log-standard		MEMORY	heatmap_raw	120
-single-day-application-log-standard		MEMORY	heatmap_raw_hl	120
-single-day-application-log-standard		MEMORY	histogram_values	576
-single-day-application-log-standard		MEMORY	log_analysis	232
-single-day-application-log-standard		MEMORY	log_messages	2872100
-single-day-application-log-standard		MEMORY	log_occurrences	22310
-single-day-application-log-standard		MEMORY	log_sessions	120
-single-day-application-log-standard		MEMORY	log_stats	120
-single-day-application-log-standard		MEMORY	log_threadpools	232
-single-day-application-log-standard		MEMORY	threadpool_activity	762
-single-day-application-log-standard		MEMORY	udm_last_value	120
-single-day-application-log-standard		MEMORY_FINAL	log_messages	2872100
-single-day-application-log-standard		MEMORY_FINAL	log_analysis	232
-single-day-application-log-standard		MEMORY_FINAL	consolidation_clusters	120
-single-day-application-log-standard		MEMORY_FINAL	consolidation_patterns	120
-single-day-application-log-standard		MEMORY_FINAL	consolidation_key_message	120
-single-day-application-log-standard		MEMORY_FINAL	consolidation_unmatched	120
-single-day-application-log-standard		COUNTS	log_messages_entries	6512
-single-day-application-log-standard		COUNTS	log_occurrences_entries	24
-single-day-application-log-standard		COUNTS	log_stats_entries	24
-single-day-application-log-standard		CONFIG	terminal_width	200
-single-day-application-log-standard		CONFIG	terminal_height	52
-single-day-application-log-standard		CONFIG	max_log_message_length	200
-single-day-application-log-standard		CONFIG	time_bucket_size	60
-single-day-application-log-standard		CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-top25	-n 25	version	0.14.3
-single-day-application-log-top25	-n 25	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-top25	-n 25	lines_read	479904
-single-day-application-log-top25	-n 25	lines_included	479904
-single-day-application-log-top25	-n 25	TIMING	read_files	3.578
-single-day-application-log-top25	-n 25	TIMING	initialize_buckets	0.000
-single-day-application-log-top25	-n 25	TIMING	group_similar	0.000
-single-day-application-log-top25	-n 25	TIMING	calculate_statistics	0.007
-single-day-application-log-top25	-n 25	TIMING	heatmap_statistics	0.000
-single-day-application-log-top25	-n 25	TIMING	histogram_statistics	0.000
-single-day-application-log-top25	-n 25	TIMING	normalize_data	0.001
-single-day-application-log-top25	-n 25	TIMING	total	3.586
-single-day-application-log-top25	-n 25	MEMORY	rss_peak	34373632
-single-day-application-log-top25	-n 25	MEMORY	consolidation_clusters	120
-single-day-application-log-top25	-n 25	MEMORY	consolidation_key_message	120
-single-day-application-log-top25	-n 25	MEMORY	consolidation_patterns	120
-single-day-application-log-top25	-n 25	MEMORY	consolidation_unmatched	120
-single-day-application-log-top25	-n 25	MEMORY	heatmap_data	120
-single-day-application-log-top25	-n 25	MEMORY	heatmap_data_hl	120
-single-day-application-log-top25	-n 25	MEMORY	heatmap_raw	120
-single-day-application-log-top25	-n 25	MEMORY	heatmap_raw_hl	120
-single-day-application-log-top25	-n 25	MEMORY	histogram_values	576
-single-day-application-log-top25	-n 25	MEMORY	log_analysis	232
-single-day-application-log-top25	-n 25	MEMORY	log_messages	2872100
-single-day-application-log-top25	-n 25	MEMORY	log_occurrences	22310
-single-day-application-log-top25	-n 25	MEMORY	log_sessions	120
-single-day-application-log-top25	-n 25	MEMORY	log_stats	120
-single-day-application-log-top25	-n 25	MEMORY	log_threadpools	232
-single-day-application-log-top25	-n 25	MEMORY	threadpool_activity	762
-single-day-application-log-top25	-n 25	MEMORY	udm_last_value	120
-single-day-application-log-top25	-n 25	MEMORY_FINAL	log_messages	2872100
-single-day-application-log-top25	-n 25	MEMORY_FINAL	log_analysis	232
-single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
-single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
-single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
-single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
-single-day-application-log-top25	-n 25	COUNTS	log_messages_entries	6512
-single-day-application-log-top25	-n 25	COUNTS	log_occurrences_entries	24
-single-day-application-log-top25	-n 25	COUNTS	log_stats_entries	24
-single-day-application-log-top25	-n 25	CONFIG	terminal_width	200
-single-day-application-log-top25	-n 25	CONFIG	terminal_height	52
-single-day-application-log-top25	-n 25	CONFIG	max_log_message_length	200
-single-day-application-log-top25	-n 25	CONFIG	time_bucket_size	60
-single-day-application-log-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-top25-consolidate	-n 25 -g	version	0.14.3
-single-day-application-log-top25-consolidate	-n 25 -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-top25-consolidate	-n 25 -g	lines_read	479904
-single-day-application-log-top25-consolidate	-n 25 -g	lines_included	479904
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	read_files	6.086
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	group_similar	0.182
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.000
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.001
-single-day-application-log-top25-consolidate	-n 25 -g	TIMING	total	6.271
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	rss_peak	128270336
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	448005
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	99829
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	55576
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	122904
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_analysis	232
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_messages	162229
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	22310
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_stats	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	137524
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	232
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	448005
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	55576
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	65592
-single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
-single-day-application-log-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	136
-single-day-application-log-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	24
-single-day-application-log-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	24
-single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
-single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	terminal_height	52
-single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
-single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
-single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-heatmap	-hm	version	0.14.3
-single-day-application-log-heatmap	-hm	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-heatmap	-hm	lines_read	479904
-single-day-application-log-heatmap	-hm	lines_included	479904
-single-day-application-log-heatmap	-hm	TIMING	read_files	3.603
-single-day-application-log-heatmap	-hm	TIMING	initialize_buckets	0.000
-single-day-application-log-heatmap	-hm	TIMING	group_similar	0.000
-single-day-application-log-heatmap	-hm	TIMING	calculate_statistics	0.006
-single-day-application-log-heatmap	-hm	TIMING	heatmap_statistics	0.000
-single-day-application-log-heatmap	-hm	TIMING	histogram_statistics	0.000
-single-day-application-log-heatmap	-hm	TIMING	normalize_data	0.001
-single-day-application-log-heatmap	-hm	TIMING	total	3.610
-single-day-application-log-heatmap	-hm	MEMORY	rss_peak	34668544
-single-day-application-log-heatmap	-hm	MEMORY	consolidation_clusters	120
-single-day-application-log-heatmap	-hm	MEMORY	consolidation_key_message	120
-single-day-application-log-heatmap	-hm	MEMORY	consolidation_patterns	120
-single-day-application-log-heatmap	-hm	MEMORY	consolidation_unmatched	120
-single-day-application-log-heatmap	-hm	MEMORY	heatmap_data	120
-single-day-application-log-heatmap	-hm	MEMORY	heatmap_data_hl	120
-single-day-application-log-heatmap	-hm	MEMORY	heatmap_raw	120
-single-day-application-log-heatmap	-hm	MEMORY	heatmap_raw_hl	120
-single-day-application-log-heatmap	-hm	MEMORY	histogram_values	576
-single-day-application-log-heatmap	-hm	MEMORY	log_analysis	232
-single-day-application-log-heatmap	-hm	MEMORY	log_messages	2872100
-single-day-application-log-heatmap	-hm	MEMORY	log_occurrences	22310
-single-day-application-log-heatmap	-hm	MEMORY	log_sessions	120
-single-day-application-log-heatmap	-hm	MEMORY	log_stats	120
-single-day-application-log-heatmap	-hm	MEMORY	log_threadpools	232
-single-day-application-log-heatmap	-hm	MEMORY	threadpool_activity	762
-single-day-application-log-heatmap	-hm	MEMORY	udm_last_value	120
-single-day-application-log-heatmap	-hm	MEMORY_FINAL	log_messages	2872100
-single-day-application-log-heatmap	-hm	MEMORY_FINAL	log_analysis	232
-single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
-single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
-single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
-single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
-single-day-application-log-heatmap	-hm	COUNTS	log_messages_entries	6512
-single-day-application-log-heatmap	-hm	COUNTS	log_occurrences_entries	24
-single-day-application-log-heatmap	-hm	COUNTS	log_stats_entries	24
-single-day-application-log-heatmap	-hm	CONFIG	terminal_width	200
-single-day-application-log-heatmap	-hm	CONFIG	terminal_height	52
-single-day-application-log-heatmap	-hm	CONFIG	max_log_message_length	200
-single-day-application-log-heatmap	-hm	CONFIG	time_bucket_size	60
-single-day-application-log-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-histogram	-hg	version	0.14.3
-single-day-application-log-histogram	-hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-histogram	-hg	lines_read	479904
-single-day-application-log-histogram	-hg	lines_included	479904
-single-day-application-log-histogram	-hg	TIMING	read_files	3.587
-single-day-application-log-histogram	-hg	TIMING	initialize_buckets	0.000
-single-day-application-log-histogram	-hg	TIMING	group_similar	0.000
-single-day-application-log-histogram	-hg	TIMING	calculate_statistics	0.006
-single-day-application-log-histogram	-hg	TIMING	heatmap_statistics	0.000
-single-day-application-log-histogram	-hg	TIMING	histogram_statistics	0.000
-single-day-application-log-histogram	-hg	TIMING	normalize_data	0.001
-single-day-application-log-histogram	-hg	TIMING	total	3.594
-single-day-application-log-histogram	-hg	MEMORY	rss_peak	34684928
-single-day-application-log-histogram	-hg	MEMORY	consolidation_clusters	120
-single-day-application-log-histogram	-hg	MEMORY	consolidation_key_message	120
-single-day-application-log-histogram	-hg	MEMORY	consolidation_patterns	120
-single-day-application-log-histogram	-hg	MEMORY	consolidation_unmatched	120
-single-day-application-log-histogram	-hg	MEMORY	heatmap_data	120
-single-day-application-log-histogram	-hg	MEMORY	heatmap_data_hl	120
-single-day-application-log-histogram	-hg	MEMORY	heatmap_raw	120
-single-day-application-log-histogram	-hg	MEMORY	heatmap_raw_hl	120
-single-day-application-log-histogram	-hg	MEMORY	histogram_values	576
-single-day-application-log-histogram	-hg	MEMORY	log_analysis	232
-single-day-application-log-histogram	-hg	MEMORY	log_messages	2872100
-single-day-application-log-histogram	-hg	MEMORY	log_occurrences	22310
-single-day-application-log-histogram	-hg	MEMORY	log_sessions	120
-single-day-application-log-histogram	-hg	MEMORY	log_stats	120
-single-day-application-log-histogram	-hg	MEMORY	log_threadpools	232
-single-day-application-log-histogram	-hg	MEMORY	threadpool_activity	762
-single-day-application-log-histogram	-hg	MEMORY	udm_last_value	120
-single-day-application-log-histogram	-hg	MEMORY_FINAL	log_messages	2872100
-single-day-application-log-histogram	-hg	MEMORY_FINAL	log_analysis	232
-single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_clusters	120
-single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_patterns	120
-single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_key_message	120
-single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_unmatched	120
-single-day-application-log-histogram	-hg	COUNTS	log_messages_entries	6512
-single-day-application-log-histogram	-hg	COUNTS	log_occurrences_entries	24
-single-day-application-log-histogram	-hg	COUNTS	log_stats_entries	24
-single-day-application-log-histogram	-hg	CONFIG	terminal_width	200
-single-day-application-log-histogram	-hg	CONFIG	terminal_height	52
-single-day-application-log-histogram	-hg	CONFIG	max_log_message_length	200
-single-day-application-log-histogram	-hg	CONFIG	time_bucket_size	60
-single-day-application-log-histogram	-hg	CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-heatmap-histogram	-hm -hg	version	0.14.3
-single-day-application-log-heatmap-histogram	-hm -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-heatmap-histogram	-hm -hg	lines_read	479904
-single-day-application-log-heatmap-histogram	-hm -hg	lines_included	479904
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	read_files	3.532
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.006
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.000
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	0.000
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
-single-day-application-log-heatmap-histogram	-hm -hg	TIMING	total	3.539
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	rss_peak	34684928
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	histogram_values	576
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_analysis	232
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_messages	2872100
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	22310
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_stats	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	2872100
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	232
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
-single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
-single-day-application-log-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	6512
-single-day-application-log-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	24
-single-day-application-log-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	24
-single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
-single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	terminal_height	52
-single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
-single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
-single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.3
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	lines_read	479904
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	lines_included	479904
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	6.093
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	0.167
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.000
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.000
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	0.000
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.002
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	6.263
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	127254528
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	447791
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	99829
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	55660
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	122904
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	576
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	232
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	162229
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	22054
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	137524
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	232
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	447791
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	55660
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	65592
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	136
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	24
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	24
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	52
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
-single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
-multi-day-application-logs-standard	-bs 480	version	0.14.3
-multi-day-application-logs-standard	-bs 480	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
-multi-day-application-logs-standard	-bs 480	lines_read	930031
-multi-day-application-logs-standard	-bs 480	lines_included	930028
-multi-day-application-logs-standard	-bs 480	TIMING	read_files	7.758
-multi-day-application-logs-standard	-bs 480	TIMING	initialize_buckets	0.000
-multi-day-application-logs-standard	-bs 480	TIMING	group_similar	0.000
-multi-day-application-logs-standard	-bs 480	TIMING	calculate_statistics	0.199
-multi-day-application-logs-standard	-bs 480	TIMING	heatmap_statistics	0.000
-multi-day-application-logs-standard	-bs 480	TIMING	histogram_statistics	0.000
-multi-day-application-logs-standard	-bs 480	TIMING	normalize_data	0.001
-multi-day-application-logs-standard	-bs 480	TIMING	total	7.958
-multi-day-application-logs-standard	-bs 480	MEMORY	rss_peak	118571008
-multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_clusters	120
-multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_key_message	120
-multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_patterns	120
-multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_unmatched	120
-multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_data	120
-multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_data_hl	120
-multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_raw	120
-multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_raw_hl	120
-multi-day-application-logs-standard	-bs 480	MEMORY	histogram_values	576
-multi-day-application-logs-standard	-bs 480	MEMORY	log_analysis	232
-multi-day-application-logs-standard	-bs 480	MEMORY	log_messages	48030790
-multi-day-application-logs-standard	-bs 480	MEMORY	log_occurrences	58017
-multi-day-application-logs-standard	-bs 480	MEMORY	log_sessions	120
-multi-day-application-logs-standard	-bs 480	MEMORY	log_stats	120
-multi-day-application-logs-standard	-bs 480	MEMORY	log_threadpools	232
-multi-day-application-logs-standard	-bs 480	MEMORY	threadpool_activity	762
-multi-day-application-logs-standard	-bs 480	MEMORY	udm_last_value	120
-multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	log_messages	48030790
-multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	log_analysis	232
-multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_clusters	120
-multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_patterns	120
-multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_key_message	120
-multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-application-logs-standard	-bs 480	COUNTS	log_messages_entries	105902
-multi-day-application-logs-standard	-bs 480	COUNTS	log_occurrences_entries	53
-multi-day-application-logs-standard	-bs 480	COUNTS	log_stats_entries	53
-multi-day-application-logs-standard	-bs 480	CONFIG	terminal_width	200
-multi-day-application-logs-standard	-bs 480	CONFIG	terminal_height	52
-multi-day-application-logs-standard	-bs 480	CONFIG	max_log_message_length	200
-multi-day-application-logs-standard	-bs 480	CONFIG	time_bucket_size	480
-multi-day-application-logs-standard	-bs 480	CONFIG	bucket_size_seconds	28800.00
-multi-day-application-logs-top25	-bs 480 -n 25	version	0.14.3
-multi-day-application-logs-top25	-bs 480 -n 25	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
-multi-day-application-logs-top25	-bs 480 -n 25	lines_read	930031
-multi-day-application-logs-top25	-bs 480 -n 25	lines_included	930028
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	read_files	7.654
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	initialize_buckets	0.000
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	group_similar	0.000
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	calculate_statistics	0.181
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	heatmap_statistics	0.000
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	histogram_statistics	0.000
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	normalize_data	0.001
-multi-day-application-logs-top25	-bs 480 -n 25	TIMING	total	7.837
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	rss_peak	117800960
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_clusters	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_key_message	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_patterns	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_unmatched	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_data	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_data_hl	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_raw	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_raw_hl	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	histogram_values	576
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_analysis	232
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_messages	48030790
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_occurrences	58017
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_sessions	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_stats	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_threadpools	232
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	threadpool_activity	762
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	udm_last_value	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	log_messages	48030790
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	log_analysis	232
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_clusters	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_patterns	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_key_message	120
-multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-application-logs-top25	-bs 480 -n 25	COUNTS	log_messages_entries	105902
-multi-day-application-logs-top25	-bs 480 -n 25	COUNTS	log_occurrences_entries	53
-multi-day-application-logs-top25	-bs 480 -n 25	COUNTS	log_stats_entries	53
-multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	terminal_width	200
-multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	terminal_height	52
-multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	max_log_message_length	200
-multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	time_bucket_size	480
-multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	bucket_size_seconds	28800.00
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	version	0.14.3
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	lines_read	930031
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	lines_included	930028
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	read_files	37.200
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	initialize_buckets	0.001
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	group_similar	2.273
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	calculate_statistics	0.003
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	heatmap_statistics	0.000
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	histogram_statistics	0.000
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	normalize_data	0.003
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	total	39.478
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	rss_peak	236158976
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_clusters	3738276
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_key_message	316853
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_patterns	497821
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_unmatched	376806
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_data	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_data_hl	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_raw	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_raw_hl	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	histogram_values	576
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_analysis	232
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_messages	726422
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_occurrences	57953
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_sessions	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_stats	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_threadpools	232
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	threadpool_activity	762
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	udm_last_value	120
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	log_messages	726422
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	log_analysis	232
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_clusters	3738276
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_patterns	497821
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_key_message	131128
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	COUNTS	log_messages_entries	1304
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	COUNTS	log_occurrences_entries	53
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	COUNTS	log_stats_entries	53
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	terminal_width	200
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	terminal_height	52
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	max_log_message_length	200
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	time_bucket_size	480
-multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	bucket_size_seconds	28800.00
-multi-day-application-logs-heatmap	-bs 480 -hm	version	0.14.4
-multi-day-application-logs-heatmap	-bs 480 -hm	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
-multi-day-application-logs-heatmap	-bs 480 -hm	lines_read	930031
-multi-day-application-logs-heatmap	-bs 480 -hm	lines_included	930028
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	read_files	7.594
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	initialize_buckets	0.000
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	group_similar	0.000
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	calculate_statistics	0.179
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	heatmap_statistics	0.000
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	histogram_statistics	0.000
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	normalize_data	0.001
-multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	total	7.775
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	rss_peak	116080640
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_clusters	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_key_message	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_patterns	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_unmatched	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_data	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_data_hl	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_raw	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_raw_hl	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	histogram_values	576
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_analysis	232
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_messages	48030790
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_occurrences	58017
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_sessions	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_stats	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_threadpools	232
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	threadpool_activity	762
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	udm_last_value	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	log_messages	48030790
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	log_analysis	232
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_clusters	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_patterns	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_key_message	120
-multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-application-logs-heatmap	-bs 480 -hm	COUNTS	log_messages_entries	105902
-multi-day-application-logs-heatmap	-bs 480 -hm	COUNTS	log_occurrences_entries	53
-multi-day-application-logs-heatmap	-bs 480 -hm	COUNTS	log_stats_entries	53
-multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	terminal_width	200
-multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	terminal_height	52
-multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	max_log_message_length	200
-multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	time_bucket_size	480
-multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	bucket_size_seconds	28800.00
-multi-day-application-logs-histogram	-bs 480 -hg	version	0.14.4
-multi-day-application-logs-histogram	-bs 480 -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
-multi-day-application-logs-histogram	-bs 480 -hg	lines_read	930031
-multi-day-application-logs-histogram	-bs 480 -hg	lines_included	930028
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	read_files	7.476
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	initialize_buckets	0.000
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	group_similar	0.000
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	calculate_statistics	0.178
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	heatmap_statistics	0.000
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	histogram_statistics	0.000
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	normalize_data	0.001
-multi-day-application-logs-histogram	-bs 480 -hg	TIMING	total	7.656
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	rss_peak	115998720
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_clusters	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_key_message	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_patterns	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_unmatched	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_data	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_data_hl	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_raw	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_raw_hl	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	histogram_values	576
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_analysis	232
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_messages	48030790
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_occurrences	57953
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_sessions	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_stats	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_threadpools	232
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	threadpool_activity	762
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	udm_last_value	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	log_messages	48030790
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	log_analysis	232
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_clusters	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_patterns	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_key_message	120
-multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-application-logs-histogram	-bs 480 -hg	COUNTS	log_messages_entries	105902
-multi-day-application-logs-histogram	-bs 480 -hg	COUNTS	log_occurrences_entries	53
-multi-day-application-logs-histogram	-bs 480 -hg	COUNTS	log_stats_entries	53
-multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	terminal_width	200
-multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	terminal_height	52
-multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	max_log_message_length	200
-multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	time_bucket_size	480
-multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	bucket_size_seconds	28800.00
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	version	0.14.4
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	lines_read	930031
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	lines_included	930028
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	read_files	38.423
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	initialize_buckets	0.000
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	group_similar	4.932
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	calculate_statistics	0.003
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	heatmap_statistics	0.000
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	histogram_statistics	0.000
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	normalize_data	0.003
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	total	43.362
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	rss_peak	233226240
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_clusters	3738228
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_key_message	3717942
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_key_trigrams	65252458
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_key_trigrams_norm	10920069
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_ngram_index	63718988
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_patterns	497442
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_posting_size	1688882
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_unmatched	2241530
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_data	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_data_hl	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_raw	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_raw_hl	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	histogram_values	576
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_analysis	232
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_messages	3335663
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_occurrences	58017
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_sessions	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_stats	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_threadpools	232
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	threadpool_activity	762
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	udm_last_value	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	log_messages	726422
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	log_analysis	232
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_clusters	3738228
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_patterns	497442
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_key_message	131128
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams_norm	8248
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	COUNTS	log_messages_entries	1304
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	COUNTS	log_occurrences_entries	53
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	COUNTS	log_stats_entries	53
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	terminal_width	200
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	terminal_height	24
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	max_log_message_length	200
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	time_bucket_size	480
+multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	bucket_size_seconds	28800.00
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	version	0.14.4
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	lines_read	930031
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	lines_included	930028
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	read_files	7.617
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	read_files	7.780
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	initialize_buckets	0.000
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	group_similar	0.000
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	calculate_statistics	0.177
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	calculate_statistics	0.188
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	heatmap_statistics	0.000
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	histogram_statistics	0.000
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	normalize_data	0.001
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	total	7.796
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	rss_peak	116146176
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	TIMING	total	7.969
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	rss_peak	116113408
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_clusters	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_key_message	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_key_trigrams	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_ngram_index	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_patterns	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_posting_size	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	consolidation_unmatched	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	heatmap_data	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	heatmap_data_hl	120
@@ -859,7 +78,7 @@ multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	heatmap_raw_
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	histogram_values	576
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_analysis	232
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_messages	48030790
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_occurrences	58017
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_occurrences	57953
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_sessions	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_stats	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY	log_threadpools	232
@@ -871,250 +90,241 @@ multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consol
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consolidation_patterns	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consolidation_key_message	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	COUNTS	log_messages_entries	105902
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	COUNTS	log_occurrences_entries	53
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	COUNTS	log_stats_entries	53
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	CONFIG	terminal_width	200
-multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	CONFIG	terminal_height	52
+multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	CONFIG	terminal_height	24
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	CONFIG	max_log_message_length	200
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	CONFIG	time_bucket_size	480
 multi-day-application-logs-heatmap-histogram	-bs 480 -hm -hg	CONFIG	bucket_size_seconds	28800.00
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	version	0.14.4
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	lines_read	930031
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	lines_included	930028
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	read_files	35.483
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	initialize_buckets	0.000
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	group_similar	2.030
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	calculate_statistics	0.002
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	heatmap_statistics	0.000
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	histogram_statistics	0.000
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	normalize_data	0.003
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	TIMING	total	37.518
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	rss_peak	234078208
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_clusters	3738276
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_key_message	316853
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_patterns	497821
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	consolidation_unmatched	376806
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_data	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_data_hl	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_raw	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	heatmap_raw_hl	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	histogram_values	576
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_analysis	232
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_messages	726422
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_occurrences	58017
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_sessions	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_stats	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	log_threadpools	232
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	threadpool_activity	762
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY	udm_last_value	120
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	log_messages	726422
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	log_analysis	232
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_clusters	3738276
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_patterns	497821
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_key_message	131128
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	COUNTS	log_messages_entries	1304
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	COUNTS	log_occurrences_entries	53
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	COUNTS	log_stats_entries	53
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	terminal_width	200
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	terminal_height	52
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	max_log_message_length	200
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	time_bucket_size	480
-multi-day-application-logs-heatmap-histogram-consolidate	-bs 480 -hm -hg -g	CONFIG	bucket_size_seconds	28800.00
-multi-day-custom-logs-standard		version	0.14.4
-multi-day-custom-logs-standard		FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
-multi-day-custom-logs-standard		lines_read	1530399
-multi-day-custom-logs-standard		lines_included	1530399
-multi-day-custom-logs-standard		TIMING	read_files	15.668
-multi-day-custom-logs-standard		TIMING	initialize_buckets	0.000
-multi-day-custom-logs-standard		TIMING	group_similar	0.000
-multi-day-custom-logs-standard		TIMING	calculate_statistics	0.383
-multi-day-custom-logs-standard		TIMING	heatmap_statistics	0.000
-multi-day-custom-logs-standard		TIMING	histogram_statistics	0.000
-multi-day-custom-logs-standard		TIMING	normalize_data	0.001
-multi-day-custom-logs-standard		TIMING	total	16.051
-multi-day-custom-logs-standard		MEMORY	rss_peak	208453632
-multi-day-custom-logs-standard		MEMORY	consolidation_clusters	120
-multi-day-custom-logs-standard		MEMORY	consolidation_key_message	120
-multi-day-custom-logs-standard		MEMORY	consolidation_patterns	120
-multi-day-custom-logs-standard		MEMORY	consolidation_unmatched	120
-multi-day-custom-logs-standard		MEMORY	heatmap_data	120
-multi-day-custom-logs-standard		MEMORY	heatmap_data_hl	120
-multi-day-custom-logs-standard		MEMORY	heatmap_raw	120
-multi-day-custom-logs-standard		MEMORY	heatmap_raw_hl	120
-multi-day-custom-logs-standard		MEMORY	histogram_values	576
-multi-day-custom-logs-standard		MEMORY	log_analysis	29828257
-multi-day-custom-logs-standard		MEMORY	log_messages	107569190
-multi-day-custom-logs-standard		MEMORY	log_occurrences	20755
-multi-day-custom-logs-standard		MEMORY	log_sessions	120
-multi-day-custom-logs-standard		MEMORY	log_stats	55983
-multi-day-custom-logs-standard		MEMORY	log_threadpools	232
-multi-day-custom-logs-standard		MEMORY	threadpool_activity	762
-multi-day-custom-logs-standard		MEMORY	udm_last_value	120
-multi-day-custom-logs-standard		MEMORY_FINAL	log_messages	107569190
-multi-day-custom-logs-standard		MEMORY_FINAL	log_analysis	20342
-multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_clusters	120
-multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_patterns	120
-multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_key_message	120
-multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_unmatched	120
-multi-day-custom-logs-standard		COUNTS	log_messages_entries	182419
-multi-day-custom-logs-standard		COUNTS	log_occurrences_entries	25
-multi-day-custom-logs-standard		COUNTS	log_stats_entries	25
-multi-day-custom-logs-standard		CONFIG	terminal_width	200
-multi-day-custom-logs-standard		CONFIG	terminal_height	52
-multi-day-custom-logs-standard		CONFIG	max_log_message_length	200
-multi-day-custom-logs-standard		CONFIG	time_bucket_size	60
-multi-day-custom-logs-standard		CONFIG	bucket_size_seconds	3600.00
-multi-day-custom-logs-top25	-n 25	version	0.14.4
-multi-day-custom-logs-top25	-n 25	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
-multi-day-custom-logs-top25	-n 25	lines_read	1530399
-multi-day-custom-logs-top25	-n 25	lines_included	1530399
-multi-day-custom-logs-top25	-n 25	TIMING	read_files	15.496
-multi-day-custom-logs-top25	-n 25	TIMING	initialize_buckets	0.000
-multi-day-custom-logs-top25	-n 25	TIMING	group_similar	0.000
-multi-day-custom-logs-top25	-n 25	TIMING	calculate_statistics	0.391
-multi-day-custom-logs-top25	-n 25	TIMING	heatmap_statistics	0.000
-multi-day-custom-logs-top25	-n 25	TIMING	histogram_statistics	0.000
-multi-day-custom-logs-top25	-n 25	TIMING	normalize_data	0.001
-multi-day-custom-logs-top25	-n 25	TIMING	total	15.888
-multi-day-custom-logs-top25	-n 25	MEMORY	rss_peak	208519168
-multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_clusters	120
-multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_key_message	120
-multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_patterns	120
-multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_unmatched	120
-multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_data	120
-multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_data_hl	120
-multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_raw	120
-multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_raw_hl	120
-multi-day-custom-logs-top25	-n 25	MEMORY	histogram_values	576
-multi-day-custom-logs-top25	-n 25	MEMORY	log_analysis	29828257
-multi-day-custom-logs-top25	-n 25	MEMORY	log_messages	107588918
-multi-day-custom-logs-top25	-n 25	MEMORY	log_occurrences	20755
-multi-day-custom-logs-top25	-n 25	MEMORY	log_sessions	120
-multi-day-custom-logs-top25	-n 25	MEMORY	log_stats	55983
-multi-day-custom-logs-top25	-n 25	MEMORY	log_threadpools	232
-multi-day-custom-logs-top25	-n 25	MEMORY	threadpool_activity	762
-multi-day-custom-logs-top25	-n 25	MEMORY	udm_last_value	120
-multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	log_messages	107588918
-multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	log_analysis	20342
-multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
-multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
-multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
-multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-custom-logs-top25	-n 25	COUNTS	log_messages_entries	182419
-multi-day-custom-logs-top25	-n 25	COUNTS	log_occurrences_entries	25
-multi-day-custom-logs-top25	-n 25	COUNTS	log_stats_entries	25
-multi-day-custom-logs-top25	-n 25	CONFIG	terminal_width	200
-multi-day-custom-logs-top25	-n 25	CONFIG	terminal_height	52
-multi-day-custom-logs-top25	-n 25	CONFIG	max_log_message_length	200
-multi-day-custom-logs-top25	-n 25	CONFIG	time_bucket_size	60
-multi-day-custom-logs-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
-multi-day-custom-logs-top25-consolidate	-n 25 -g	version	0.14.4
-multi-day-custom-logs-top25-consolidate	-n 25 -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
-multi-day-custom-logs-top25-consolidate	-n 25 -g	lines_read	1530399
-multi-day-custom-logs-top25-consolidate	-n 25 -g	lines_included	1530399
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	read_files	46.921
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	group_similar	3.303
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.294
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.002
-multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	total	50.520
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	rss_peak	261914624
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	30969856
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	202120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	206763
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	254813
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_analysis	29828001
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_messages	30013620
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	20755
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_stats	55727
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	30013620
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	20086
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	30969856
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	206763
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	131128
-multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
-multi-day-custom-logs-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	606
-multi-day-custom-logs-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	25
-multi-day-custom-logs-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	25
-multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
-multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	terminal_height	52
-multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
-multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
-multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
-multi-day-custom-logs-heatmap	-hm	version	0.14.4
-multi-day-custom-logs-heatmap	-hm	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
-multi-day-custom-logs-heatmap	-hm	lines_read	1530399
-multi-day-custom-logs-heatmap	-hm	lines_included	1530399
-multi-day-custom-logs-heatmap	-hm	TIMING	read_files	15.735
-multi-day-custom-logs-heatmap	-hm	TIMING	initialize_buckets	0.000
-multi-day-custom-logs-heatmap	-hm	TIMING	group_similar	0.000
-multi-day-custom-logs-heatmap	-hm	TIMING	calculate_statistics	0.310
-multi-day-custom-logs-heatmap	-hm	TIMING	heatmap_statistics	0.402
-multi-day-custom-logs-heatmap	-hm	TIMING	histogram_statistics	0.000
-multi-day-custom-logs-heatmap	-hm	TIMING	normalize_data	0.001
-multi-day-custom-logs-heatmap	-hm	TIMING	total	16.448
-multi-day-custom-logs-heatmap	-hm	MEMORY	rss_peak	216956928
-multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_clusters	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_key_message	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_patterns	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_unmatched	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_data	44280
-multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_data_hl	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_raw	29774424
-multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_raw_hl	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	histogram_values	576
-multi-day-custom-logs-heatmap	-hm	MEMORY	log_analysis	21169
-multi-day-custom-logs-heatmap	-hm	MEMORY	log_messages	108064422
-multi-day-custom-logs-heatmap	-hm	MEMORY	log_occurrences	20755
-multi-day-custom-logs-heatmap	-hm	MEMORY	log_sessions	120
-multi-day-custom-logs-heatmap	-hm	MEMORY	log_stats	50759
-multi-day-custom-logs-heatmap	-hm	MEMORY	log_threadpools	232
-multi-day-custom-logs-heatmap	-hm	MEMORY	threadpool_activity	762
-multi-day-custom-logs-heatmap	-hm	MEMORY	udm_last_value	120
-multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	log_messages	108064422
-multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	log_analysis	20086
-multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
-multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
-multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
-multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-custom-logs-heatmap	-hm	COUNTS	log_messages_entries	182419
-multi-day-custom-logs-heatmap	-hm	COUNTS	log_occurrences_entries	25
-multi-day-custom-logs-heatmap	-hm	COUNTS	log_stats_entries	25
-multi-day-custom-logs-heatmap	-hm	CONFIG	terminal_width	200
-multi-day-custom-logs-heatmap	-hm	CONFIG	terminal_height	52
-multi-day-custom-logs-heatmap	-hm	CONFIG	max_log_message_length	200
-multi-day-custom-logs-heatmap	-hm	CONFIG	time_bucket_size	60
-multi-day-custom-logs-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
+multi-day-application-logs-histogram	-bs 480 -hg	version	0.14.4
+multi-day-application-logs-histogram	-bs 480 -hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-histogram	-bs 480 -hg	lines_read	930031
+multi-day-application-logs-histogram	-bs 480 -hg	lines_included	930028
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	read_files	7.575
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	initialize_buckets	0.000
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	group_similar	0.000
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	calculate_statistics	0.191
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	heatmap_statistics	0.000
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	histogram_statistics	0.000
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	normalize_data	0.001
+multi-day-application-logs-histogram	-bs 480 -hg	TIMING	total	7.767
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	rss_peak	116326400
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_clusters	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_key_message	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_key_trigrams	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_ngram_index	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_patterns	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_posting_size	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	consolidation_unmatched	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_data	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_data_hl	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_raw	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	heatmap_raw_hl	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	histogram_values	576
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_analysis	232
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_messages	48030790
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_occurrences	58017
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_sessions	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_stats	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	log_threadpools	232
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	threadpool_activity	762
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY	udm_last_value	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	log_messages	48030790
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	log_analysis	232
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_clusters	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_patterns	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_key_message	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-application-logs-histogram	-bs 480 -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-application-logs-histogram	-bs 480 -hg	COUNTS	log_messages_entries	105902
+multi-day-application-logs-histogram	-bs 480 -hg	COUNTS	log_occurrences_entries	53
+multi-day-application-logs-histogram	-bs 480 -hg	COUNTS	log_stats_entries	53
+multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	terminal_width	200
+multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	terminal_height	24
+multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	max_log_message_length	200
+multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	time_bucket_size	480
+multi-day-application-logs-histogram	-bs 480 -hg	CONFIG	bucket_size_seconds	28800.00
+multi-day-application-logs-heatmap	-bs 480 -hm	version	0.14.4
+multi-day-application-logs-heatmap	-bs 480 -hm	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-heatmap	-bs 480 -hm	lines_read	930031
+multi-day-application-logs-heatmap	-bs 480 -hm	lines_included	930028
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	read_files	7.704
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	initialize_buckets	0.000
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	group_similar	0.000
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	calculate_statistics	0.183
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	heatmap_statistics	0.000
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	histogram_statistics	0.000
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	normalize_data	0.002
+multi-day-application-logs-heatmap	-bs 480 -hm	TIMING	total	7.889
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	rss_peak	116457472
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_clusters	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_key_message	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_key_trigrams	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_ngram_index	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_patterns	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_posting_size	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	consolidation_unmatched	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_data	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_data_hl	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_raw	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	heatmap_raw_hl	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	histogram_values	576
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_analysis	232
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_messages	48030790
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_occurrences	57953
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_sessions	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_stats	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	log_threadpools	232
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	threadpool_activity	762
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY	udm_last_value	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	log_messages	48030790
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	log_analysis	232
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_clusters	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_patterns	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_key_message	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-application-logs-heatmap	-bs 480 -hm	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-application-logs-heatmap	-bs 480 -hm	COUNTS	log_messages_entries	105902
+multi-day-application-logs-heatmap	-bs 480 -hm	COUNTS	log_occurrences_entries	53
+multi-day-application-logs-heatmap	-bs 480 -hm	COUNTS	log_stats_entries	53
+multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	terminal_width	200
+multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	terminal_height	24
+multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	max_log_message_length	200
+multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	time_bucket_size	480
+multi-day-application-logs-heatmap	-bs 480 -hm	CONFIG	bucket_size_seconds	28800.00
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.4
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	lines_read	1530399
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	lines_included	1530399
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	50.019
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	5.609
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.181
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.537
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	0.680
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.002
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	57.028
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	308412416
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	30969882
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	6071226
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams	65646167
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams_norm	4753336
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_ngram_index	64238971
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	206885
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_posting_size	489529
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	3425671
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	42488
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	29774424
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	31238848
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	21169
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	30006420
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	20499
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	50759
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	30006420
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	20086
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	30969882
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	206885
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	131128
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams_norm	4152
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	606
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	25
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	25
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	24
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
+multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
+multi-day-custom-logs-heatmap-histogram	-hm -hg	version	0.14.4
+multi-day-custom-logs-heatmap-histogram	-hm -hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-heatmap-histogram	-hm -hg	lines_read	1530399
+multi-day-custom-logs-heatmap-histogram	-hm -hg	lines_included	1530399
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	read_files	16.256
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.334
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.419
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	0.543
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
+multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	total	17.553
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	rss_peak	260341760
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_ngram_index	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_posting_size	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	44216
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	29774424
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	histogram_values	31238848
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_analysis	21169
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_messages	108064422
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	20499
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_stats	50759
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	108064422
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	20086
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	182419
+multi-day-custom-logs-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	25
+multi-day-custom-logs-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	25
+multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
+multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	terminal_height	24
+multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
+multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
+multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
 multi-day-custom-logs-histogram	-hg	version	0.14.4
-multi-day-custom-logs-histogram	-hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-histogram	-hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
 multi-day-custom-logs-histogram	-hg	lines_read	1530399
 multi-day-custom-logs-histogram	-hg	lines_included	1530399
-multi-day-custom-logs-histogram	-hg	TIMING	read_files	16.053
+multi-day-custom-logs-histogram	-hg	TIMING	read_files	15.851
 multi-day-custom-logs-histogram	-hg	TIMING	initialize_buckets	0.000
 multi-day-custom-logs-histogram	-hg	TIMING	group_similar	0.000
-multi-day-custom-logs-histogram	-hg	TIMING	calculate_statistics	0.394
+multi-day-custom-logs-histogram	-hg	TIMING	calculate_statistics	0.404
 multi-day-custom-logs-histogram	-hg	TIMING	heatmap_statistics	0.000
-multi-day-custom-logs-histogram	-hg	TIMING	histogram_statistics	0.530
+multi-day-custom-logs-histogram	-hg	TIMING	histogram_statistics	0.538
 multi-day-custom-logs-histogram	-hg	TIMING	normalize_data	0.001
-multi-day-custom-logs-histogram	-hg	TIMING	total	16.978
-multi-day-custom-logs-histogram	-hg	MEMORY	rss_peak	254754816
+multi-day-custom-logs-histogram	-hg	TIMING	total	16.795
+multi-day-custom-logs-histogram	-hg	MEMORY	rss_peak	253706240
 multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_clusters	120
 multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_key_message	120
+multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_key_trigrams	120
+multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_ngram_index	120
 multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_patterns	120
+multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_posting_size	120
 multi-day-custom-logs-histogram	-hg	MEMORY	consolidation_unmatched	120
 multi-day-custom-logs-histogram	-hg	MEMORY	heatmap_data	120
 multi-day-custom-logs-histogram	-hg	MEMORY	heatmap_data_hl	120
@@ -1135,294 +345,343 @@ multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_clusters	120
 multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_patterns	120
 multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_key_message	120
 multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-custom-logs-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
 multi-day-custom-logs-histogram	-hg	COUNTS	log_messages_entries	182419
 multi-day-custom-logs-histogram	-hg	COUNTS	log_occurrences_entries	25
 multi-day-custom-logs-histogram	-hg	COUNTS	log_stats_entries	25
 multi-day-custom-logs-histogram	-hg	CONFIG	terminal_width	200
-multi-day-custom-logs-histogram	-hg	CONFIG	terminal_height	52
+multi-day-custom-logs-histogram	-hg	CONFIG	terminal_height	24
 multi-day-custom-logs-histogram	-hg	CONFIG	max_log_message_length	200
 multi-day-custom-logs-histogram	-hg	CONFIG	time_bucket_size	60
 multi-day-custom-logs-histogram	-hg	CONFIG	bucket_size_seconds	3600.00
-multi-day-custom-logs-heatmap-histogram	-hm -hg	version	0.14.4
-multi-day-custom-logs-heatmap-histogram	-hm -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
-multi-day-custom-logs-heatmap-histogram	-hm -hg	lines_read	1530399
-multi-day-custom-logs-heatmap-histogram	-hm -hg	lines_included	1530399
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	read_files	16.063
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.314
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.407
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	0.528
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
-multi-day-custom-logs-heatmap-histogram	-hm -hg	TIMING	total	17.313
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	rss_peak	261783552
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	44024
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	29774680
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	histogram_values	31238848
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_analysis	21425
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_messages	108064422
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	20755
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_stats	51015
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	108064422
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	20342
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
-multi-day-custom-logs-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	182419
-multi-day-custom-logs-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	25
-multi-day-custom-logs-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	25
-multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
-multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	terminal_height	52
-multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
-multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
-multi-day-custom-logs-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.4
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/gregeva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	lines_read	1530399
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	lines_included	1530399
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	46.430
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	3.177
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.161
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.483
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	0.676
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.002
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	50.930
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	303497216
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	30969856
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	202120
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	206763
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	254813
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	44664
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	29774680
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	31238848
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	21425
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	30004692
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	20755
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	51015
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	30004692
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	20342
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	30969856
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	206763
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	131128
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	606
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	25
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	25
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	52
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
-multi-day-custom-logs-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
-single-day-access-log-standard		version	0.14.4
-single-day-access-log-standard		FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
-single-day-access-log-standard		lines_read	761698
-single-day-access-log-standard		lines_included	761698
-single-day-access-log-standard		TIMING	read_files	9.109
-single-day-access-log-standard		TIMING	initialize_buckets	0.000
-single-day-access-log-standard		TIMING	group_similar	0.000
-single-day-access-log-standard		TIMING	calculate_statistics	0.201
-single-day-access-log-standard		TIMING	heatmap_statistics	0.000
-single-day-access-log-standard		TIMING	histogram_statistics	0.000
-single-day-access-log-standard		TIMING	normalize_data	0.001
-single-day-access-log-standard		TIMING	total	9.311
-single-day-access-log-standard		MEMORY	rss_peak	161185792
-single-day-access-log-standard		MEMORY	consolidation_clusters	120
-single-day-access-log-standard		MEMORY	consolidation_key_message	120
-single-day-access-log-standard		MEMORY	consolidation_patterns	120
-single-day-access-log-standard		MEMORY	consolidation_unmatched	120
-single-day-access-log-standard		MEMORY	heatmap_data	120
-single-day-access-log-standard		MEMORY	heatmap_data_hl	120
-single-day-access-log-standard		MEMORY	heatmap_raw	120
-single-day-access-log-standard		MEMORY	heatmap_raw_hl	120
-single-day-access-log-standard		MEMORY	histogram_values	576
-single-day-access-log-standard		MEMORY	log_analysis	55254897
-single-day-access-log-standard		MEMORY	log_messages	58184154
-single-day-access-log-standard		MEMORY	log_occurrences	18844
-single-day-access-log-standard		MEMORY	log_sessions	120
-single-day-access-log-standard		MEMORY	log_stats	32315
-single-day-access-log-standard		MEMORY	log_threadpools	232
-single-day-access-log-standard		MEMORY	threadpool_activity	762
-single-day-access-log-standard		MEMORY	udm_last_value	120
-single-day-access-log-standard		MEMORY_FINAL	log_messages	58184154
-single-day-access-log-standard		MEMORY_FINAL	log_analysis	6670
-single-day-access-log-standard		MEMORY_FINAL	consolidation_clusters	120
-single-day-access-log-standard		MEMORY_FINAL	consolidation_patterns	120
-single-day-access-log-standard		MEMORY_FINAL	consolidation_key_message	120
-single-day-access-log-standard		MEMORY_FINAL	consolidation_unmatched	120
-single-day-access-log-standard		COUNTS	log_messages_entries	3184
-single-day-access-log-standard		COUNTS	log_occurrences_entries	15
-single-day-access-log-standard		COUNTS	log_stats_entries	15
-single-day-access-log-standard		CONFIG	terminal_width	200
-single-day-access-log-standard		CONFIG	terminal_height	52
-single-day-access-log-standard		CONFIG	max_log_message_length	200
-single-day-access-log-standard		CONFIG	time_bucket_size	60
-single-day-access-log-standard		CONFIG	bucket_size_seconds	3600.00
-single-day-access-log-top25	-n 25	version	0.14.4
-single-day-access-log-top25	-n 25	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
-single-day-access-log-top25	-n 25	lines_read	761698
-single-day-access-log-top25	-n 25	lines_included	761698
-single-day-access-log-top25	-n 25	TIMING	read_files	9.069
-single-day-access-log-top25	-n 25	TIMING	initialize_buckets	0.000
-single-day-access-log-top25	-n 25	TIMING	group_similar	0.000
-single-day-access-log-top25	-n 25	TIMING	calculate_statistics	0.224
-single-day-access-log-top25	-n 25	TIMING	heatmap_statistics	0.000
-single-day-access-log-top25	-n 25	TIMING	histogram_statistics	0.000
-single-day-access-log-top25	-n 25	TIMING	normalize_data	0.001
-single-day-access-log-top25	-n 25	TIMING	total	9.293
-single-day-access-log-top25	-n 25	MEMORY	rss_peak	162594816
-single-day-access-log-top25	-n 25	MEMORY	consolidation_clusters	120
-single-day-access-log-top25	-n 25	MEMORY	consolidation_key_message	120
-single-day-access-log-top25	-n 25	MEMORY	consolidation_patterns	120
-single-day-access-log-top25	-n 25	MEMORY	consolidation_unmatched	120
-single-day-access-log-top25	-n 25	MEMORY	heatmap_data	120
-single-day-access-log-top25	-n 25	MEMORY	heatmap_data_hl	120
-single-day-access-log-top25	-n 25	MEMORY	heatmap_raw	120
-single-day-access-log-top25	-n 25	MEMORY	heatmap_raw_hl	120
-single-day-access-log-top25	-n 25	MEMORY	histogram_values	576
-single-day-access-log-top25	-n 25	MEMORY	log_analysis	55254769
-single-day-access-log-top25	-n 25	MEMORY	log_messages	58205010
-single-day-access-log-top25	-n 25	MEMORY	log_occurrences	18716
-single-day-access-log-top25	-n 25	MEMORY	log_sessions	120
-single-day-access-log-top25	-n 25	MEMORY	log_stats	32187
-single-day-access-log-top25	-n 25	MEMORY	log_threadpools	232
-single-day-access-log-top25	-n 25	MEMORY	threadpool_activity	762
-single-day-access-log-top25	-n 25	MEMORY	udm_last_value	120
-single-day-access-log-top25	-n 25	MEMORY_FINAL	log_messages	58205010
-single-day-access-log-top25	-n 25	MEMORY_FINAL	log_analysis	6542
-single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
-single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
-single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
-single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
-single-day-access-log-top25	-n 25	COUNTS	log_messages_entries	3184
-single-day-access-log-top25	-n 25	COUNTS	log_occurrences_entries	15
-single-day-access-log-top25	-n 25	COUNTS	log_stats_entries	15
-single-day-access-log-top25	-n 25	CONFIG	terminal_width	200
-single-day-access-log-top25	-n 25	CONFIG	terminal_height	52
-single-day-access-log-top25	-n 25	CONFIG	max_log_message_length	200
-single-day-access-log-top25	-n 25	CONFIG	time_bucket_size	60
-single-day-access-log-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
-single-day-access-log-top25-consolidate	-n 25 -g	version	0.14.4
-single-day-access-log-top25-consolidate	-n 25 -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
-single-day-access-log-top25-consolidate	-n 25 -g	lines_read	761698
-single-day-access-log-top25-consolidate	-n 25 -g	lines_included	761698
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	read_files	10.393
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	group_similar	0.729
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.341
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.001
-single-day-access-log-top25-consolidate	-n 25 -g	TIMING	total	11.465
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	rss_peak	200572928
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	50888153
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	476277
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	123909
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	325196
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_analysis	55254897
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_messages	56062775
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	18844
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_stats	32315
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	56062775
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	6670
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	50888153
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	123909
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	65592
-single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	296
-single-day-access-log-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	598
-single-day-access-log-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	15
-single-day-access-log-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	15
-single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
-single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	terminal_height	52
-single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
-single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
-single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
-single-day-access-log-heatmap	-hm	version	0.14.4
-single-day-access-log-heatmap	-hm	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
-single-day-access-log-heatmap	-hm	lines_read	761698
-single-day-access-log-heatmap	-hm	lines_included	761698
-single-day-access-log-heatmap	-hm	TIMING	read_files	9.260
-single-day-access-log-heatmap	-hm	TIMING	initialize_buckets	0.000
-single-day-access-log-heatmap	-hm	TIMING	group_similar	0.000
-single-day-access-log-heatmap	-hm	TIMING	calculate_statistics	0.058
-single-day-access-log-heatmap	-hm	TIMING	heatmap_statistics	0.561
-single-day-access-log-heatmap	-hm	TIMING	histogram_statistics	0.000
-single-day-access-log-heatmap	-hm	TIMING	normalize_data	0.001
-single-day-access-log-heatmap	-hm	TIMING	total	9.881
-single-day-access-log-heatmap	-hm	MEMORY	rss_peak	167591936
-single-day-access-log-heatmap	-hm	MEMORY	consolidation_clusters	120
-single-day-access-log-heatmap	-hm	MEMORY	consolidation_key_message	120
-single-day-access-log-heatmap	-hm	MEMORY	consolidation_patterns	120
-single-day-access-log-heatmap	-hm	MEMORY	consolidation_unmatched	120
-single-day-access-log-heatmap	-hm	MEMORY	heatmap_data	34866
-single-day-access-log-heatmap	-hm	MEMORY	heatmap_data_hl	120
-single-day-access-log-heatmap	-hm	MEMORY	heatmap_raw	41847756
-single-day-access-log-heatmap	-hm	MEMORY	heatmap_raw_hl	120
-single-day-access-log-heatmap	-hm	MEMORY	histogram_values	576
-single-day-access-log-heatmap	-hm	MEMORY	log_analysis	8281
-single-day-access-log-heatmap	-hm	MEMORY	log_messages	58184154
-single-day-access-log-heatmap	-hm	MEMORY	log_occurrences	18844
-single-day-access-log-heatmap	-hm	MEMORY	log_sessions	120
-single-day-access-log-heatmap	-hm	MEMORY	log_stats	29219
-single-day-access-log-heatmap	-hm	MEMORY	log_threadpools	232
-single-day-access-log-heatmap	-hm	MEMORY	threadpool_activity	762
-single-day-access-log-heatmap	-hm	MEMORY	udm_last_value	120
-single-day-access-log-heatmap	-hm	MEMORY_FINAL	log_messages	58184154
-single-day-access-log-heatmap	-hm	MEMORY_FINAL	log_analysis	6670
-single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
-single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
-single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
-single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
-single-day-access-log-heatmap	-hm	COUNTS	log_messages_entries	3184
-single-day-access-log-heatmap	-hm	COUNTS	log_occurrences_entries	15
-single-day-access-log-heatmap	-hm	COUNTS	log_stats_entries	15
-single-day-access-log-heatmap	-hm	CONFIG	terminal_width	200
-single-day-access-log-heatmap	-hm	CONFIG	terminal_height	52
-single-day-access-log-heatmap	-hm	CONFIG	max_log_message_length	200
-single-day-access-log-heatmap	-hm	CONFIG	time_bucket_size	60
-single-day-access-log-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
+multi-day-custom-logs-heatmap	-hm	version	0.14.4
+multi-day-custom-logs-heatmap	-hm	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-heatmap	-hm	lines_read	1530399
+multi-day-custom-logs-heatmap	-hm	lines_included	1530399
+multi-day-custom-logs-heatmap	-hm	TIMING	read_files	15.898
+multi-day-custom-logs-heatmap	-hm	TIMING	initialize_buckets	0.000
+multi-day-custom-logs-heatmap	-hm	TIMING	group_similar	0.000
+multi-day-custom-logs-heatmap	-hm	TIMING	calculate_statistics	0.330
+multi-day-custom-logs-heatmap	-hm	TIMING	heatmap_statistics	0.411
+multi-day-custom-logs-heatmap	-hm	TIMING	histogram_statistics	0.000
+multi-day-custom-logs-heatmap	-hm	TIMING	normalize_data	0.001
+multi-day-custom-logs-heatmap	-hm	TIMING	total	16.641
+multi-day-custom-logs-heatmap	-hm	MEMORY	rss_peak	216498176
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_clusters	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_key_message	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_key_trigrams	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_ngram_index	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_patterns	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_posting_size	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	consolidation_unmatched	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_data	43704
+multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_data_hl	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_raw	29774680
+multi-day-custom-logs-heatmap	-hm	MEMORY	heatmap_raw_hl	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	histogram_values	576
+multi-day-custom-logs-heatmap	-hm	MEMORY	log_analysis	21425
+multi-day-custom-logs-heatmap	-hm	MEMORY	log_messages	107569190
+multi-day-custom-logs-heatmap	-hm	MEMORY	log_occurrences	20755
+multi-day-custom-logs-heatmap	-hm	MEMORY	log_sessions	120
+multi-day-custom-logs-heatmap	-hm	MEMORY	log_stats	51015
+multi-day-custom-logs-heatmap	-hm	MEMORY	log_threadpools	232
+multi-day-custom-logs-heatmap	-hm	MEMORY	threadpool_activity	762
+multi-day-custom-logs-heatmap	-hm	MEMORY	udm_last_value	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	log_messages	107569190
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	log_analysis	20342
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-custom-logs-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-heatmap	-hm	COUNTS	log_messages_entries	182419
+multi-day-custom-logs-heatmap	-hm	COUNTS	log_occurrences_entries	25
+multi-day-custom-logs-heatmap	-hm	COUNTS	log_stats_entries	25
+multi-day-custom-logs-heatmap	-hm	CONFIG	terminal_width	200
+multi-day-custom-logs-heatmap	-hm	CONFIG	terminal_height	24
+multi-day-custom-logs-heatmap	-hm	CONFIG	max_log_message_length	200
+multi-day-custom-logs-heatmap	-hm	CONFIG	time_bucket_size	60
+multi-day-custom-logs-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
+multi-day-custom-logs-top25-consolidate	-n 25 -g	version	0.14.4
+multi-day-custom-logs-top25-consolidate	-n 25 -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-top25-consolidate	-n 25 -g	lines_read	1530399
+multi-day-custom-logs-top25-consolidate	-n 25 -g	lines_included	1530399
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	read_files	49.767
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	group_similar	5.241
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.329
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.002
+multi-day-custom-logs-top25-consolidate	-n 25 -g	TIMING	total	55.339
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	rss_peak	267337728
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	30969856
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	6071226
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams	65635927
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams_norm	4753336
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_ngram_index	64249275
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	206763
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_posting_size	489529
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	3425671
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_analysis	29828257
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_messages	30013620
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	20755
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_stats	55983
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	30013620
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	20342
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	30969856
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	206763
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	131128
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+multi-day-custom-logs-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams_norm	4152
+multi-day-custom-logs-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	606
+multi-day-custom-logs-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	25
+multi-day-custom-logs-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	25
+multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
+multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	terminal_height	24
+multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
+multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
+multi-day-custom-logs-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
+multi-day-custom-logs-top25	-n 25	version	0.14.4
+multi-day-custom-logs-top25	-n 25	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-top25	-n 25	lines_read	1530399
+multi-day-custom-logs-top25	-n 25	lines_included	1530399
+multi-day-custom-logs-top25	-n 25	TIMING	read_files	16.322
+multi-day-custom-logs-top25	-n 25	TIMING	initialize_buckets	0.000
+multi-day-custom-logs-top25	-n 25	TIMING	group_similar	0.000
+multi-day-custom-logs-top25	-n 25	TIMING	calculate_statistics	0.423
+multi-day-custom-logs-top25	-n 25	TIMING	heatmap_statistics	0.000
+multi-day-custom-logs-top25	-n 25	TIMING	histogram_statistics	0.000
+multi-day-custom-logs-top25	-n 25	TIMING	normalize_data	0.001
+multi-day-custom-logs-top25	-n 25	TIMING	total	16.746
+multi-day-custom-logs-top25	-n 25	MEMORY	rss_peak	210272256
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_clusters	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_key_message	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_key_trigrams	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_ngram_index	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_patterns	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_posting_size	120
+multi-day-custom-logs-top25	-n 25	MEMORY	consolidation_unmatched	120
+multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_data	120
+multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_data_hl	120
+multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_raw	120
+multi-day-custom-logs-top25	-n 25	MEMORY	heatmap_raw_hl	120
+multi-day-custom-logs-top25	-n 25	MEMORY	histogram_values	576
+multi-day-custom-logs-top25	-n 25	MEMORY	log_analysis	29828001
+multi-day-custom-logs-top25	-n 25	MEMORY	log_messages	108082422
+multi-day-custom-logs-top25	-n 25	MEMORY	log_occurrences	20499
+multi-day-custom-logs-top25	-n 25	MEMORY	log_sessions	120
+multi-day-custom-logs-top25	-n 25	MEMORY	log_stats	55727
+multi-day-custom-logs-top25	-n 25	MEMORY	log_threadpools	232
+multi-day-custom-logs-top25	-n 25	MEMORY	threadpool_activity	762
+multi-day-custom-logs-top25	-n 25	MEMORY	udm_last_value	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	log_messages	108082422
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	log_analysis	20086
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-custom-logs-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-top25	-n 25	COUNTS	log_messages_entries	182419
+multi-day-custom-logs-top25	-n 25	COUNTS	log_occurrences_entries	25
+multi-day-custom-logs-top25	-n 25	COUNTS	log_stats_entries	25
+multi-day-custom-logs-top25	-n 25	CONFIG	terminal_width	200
+multi-day-custom-logs-top25	-n 25	CONFIG	terminal_height	24
+multi-day-custom-logs-top25	-n 25	CONFIG	max_log_message_length	200
+multi-day-custom-logs-top25	-n 25	CONFIG	time_bucket_size	60
+multi-day-custom-logs-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
+multi-day-custom-logs-standard		version	0.14.4
+multi-day-custom-logs-standard		FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-10.0.log	485559953
+multi-day-custom-logs-standard		lines_read	1530399
+multi-day-custom-logs-standard		lines_included	1530399
+multi-day-custom-logs-standard		TIMING	read_files	16.214
+multi-day-custom-logs-standard		TIMING	initialize_buckets	0.000
+multi-day-custom-logs-standard		TIMING	group_similar	0.000
+multi-day-custom-logs-standard		TIMING	calculate_statistics	0.436
+multi-day-custom-logs-standard		TIMING	heatmap_statistics	0.000
+multi-day-custom-logs-standard		TIMING	histogram_statistics	0.000
+multi-day-custom-logs-standard		TIMING	normalize_data	0.001
+multi-day-custom-logs-standard		TIMING	total	16.651
+multi-day-custom-logs-standard		MEMORY	rss_peak	213614592
+multi-day-custom-logs-standard		MEMORY	consolidation_clusters	120
+multi-day-custom-logs-standard		MEMORY	consolidation_key_message	120
+multi-day-custom-logs-standard		MEMORY	consolidation_key_trigrams	120
+multi-day-custom-logs-standard		MEMORY	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-standard		MEMORY	consolidation_ngram_index	120
+multi-day-custom-logs-standard		MEMORY	consolidation_patterns	120
+multi-day-custom-logs-standard		MEMORY	consolidation_posting_size	120
+multi-day-custom-logs-standard		MEMORY	consolidation_unmatched	120
+multi-day-custom-logs-standard		MEMORY	heatmap_data	120
+multi-day-custom-logs-standard		MEMORY	heatmap_data_hl	120
+multi-day-custom-logs-standard		MEMORY	heatmap_raw	120
+multi-day-custom-logs-standard		MEMORY	heatmap_raw_hl	120
+multi-day-custom-logs-standard		MEMORY	histogram_values	576
+multi-day-custom-logs-standard		MEMORY	log_analysis	29828257
+multi-day-custom-logs-standard		MEMORY	log_messages	107568998
+multi-day-custom-logs-standard		MEMORY	log_occurrences	20755
+multi-day-custom-logs-standard		MEMORY	log_sessions	120
+multi-day-custom-logs-standard		MEMORY	log_stats	55983
+multi-day-custom-logs-standard		MEMORY	log_threadpools	232
+multi-day-custom-logs-standard		MEMORY	threadpool_activity	762
+multi-day-custom-logs-standard		MEMORY	udm_last_value	120
+multi-day-custom-logs-standard		MEMORY_FINAL	log_messages	107568998
+multi-day-custom-logs-standard		MEMORY_FINAL	log_analysis	20342
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_clusters	120
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_patterns	120
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_key_message	120
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_unmatched	120
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-custom-logs-standard		MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-custom-logs-standard		COUNTS	log_messages_entries	182419
+multi-day-custom-logs-standard		COUNTS	log_occurrences_entries	25
+multi-day-custom-logs-standard		COUNTS	log_stats_entries	25
+multi-day-custom-logs-standard		CONFIG	terminal_width	200
+multi-day-custom-logs-standard		CONFIG	terminal_height	24
+multi-day-custom-logs-standard		CONFIG	max_log_message_length	200
+multi-day-custom-logs-standard		CONFIG	time_bucket_size	60
+multi-day-custom-logs-standard		CONFIG	bucket_size_seconds	3600.00
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.4
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	lines_read	761698
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	lines_included	761698
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	12.075
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	6.178
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.319
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.691
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	1.597
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.002
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	20.863
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	344932352
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	52209401
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	904233
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams	4331228
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_ngram_index	5045687
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	126381
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_posting_size	360923
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	578706
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	34866
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	41847756
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	94480568
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	8281
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	58174234
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	18844
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	29219
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	57377795
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	6670
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	52209401
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	125445
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	65592
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	296
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams	16440
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	597
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	15
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	15
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	24
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
+single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
+single-day-access-log-heatmap-histogram	-hm -hg	version	0.14.4
+single-day-access-log-heatmap-histogram	-hm -hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-heatmap-histogram	-hm -hg	lines_read	761698
+single-day-access-log-heatmap-histogram	-hm -hg	lines_included	761698
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	read_files	9.959
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.071
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.605
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	1.584
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
+single-day-access-log-heatmap-histogram	-hm -hg	TIMING	total	12.219
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	rss_peak	306331648
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_ngram_index	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_posting_size	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	34866
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	41847756
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	histogram_values	94480568
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_analysis	8281
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_messages	58191194
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	18844
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_stats	29219
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	58191194
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	6670
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-access-log-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	3184
+single-day-access-log-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	15
+single-day-access-log-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	15
+single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
+single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	terminal_height	24
+single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
+single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
+single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
 single-day-access-log-histogram	-hg	version	0.14.4
-single-day-access-log-histogram	-hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-histogram	-hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
 single-day-access-log-histogram	-hg	lines_read	761698
 single-day-access-log-histogram	-hg	lines_included	761698
-single-day-access-log-histogram	-hg	TIMING	read_files	9.603
+single-day-access-log-histogram	-hg	TIMING	read_files	9.792
 single-day-access-log-histogram	-hg	TIMING	initialize_buckets	0.000
 single-day-access-log-histogram	-hg	TIMING	group_similar	0.000
-single-day-access-log-histogram	-hg	TIMING	calculate_statistics	0.228
+single-day-access-log-histogram	-hg	TIMING	calculate_statistics	0.238
 single-day-access-log-histogram	-hg	TIMING	heatmap_statistics	0.000
-single-day-access-log-histogram	-hg	TIMING	histogram_statistics	1.535
+single-day-access-log-histogram	-hg	TIMING	histogram_statistics	1.579
 single-day-access-log-histogram	-hg	TIMING	normalize_data	0.001
-single-day-access-log-histogram	-hg	TIMING	total	11.366
-single-day-access-log-histogram	-hg	MEMORY	rss_peak	300171264
+single-day-access-log-histogram	-hg	TIMING	total	11.610
+single-day-access-log-histogram	-hg	MEMORY	rss_peak	302301184
 single-day-access-log-histogram	-hg	MEMORY	consolidation_clusters	120
 single-day-access-log-histogram	-hg	MEMORY	consolidation_key_message	120
+single-day-access-log-histogram	-hg	MEMORY	consolidation_key_trigrams	120
+single-day-access-log-histogram	-hg	MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-histogram	-hg	MEMORY	consolidation_ngram_index	120
 single-day-access-log-histogram	-hg	MEMORY	consolidation_patterns	120
+single-day-access-log-histogram	-hg	MEMORY	consolidation_posting_size	120
 single-day-access-log-histogram	-hg	MEMORY	consolidation_unmatched	120
 single-day-access-log-histogram	-hg	MEMORY	heatmap_data	120
 single-day-access-log-histogram	-hg	MEMORY	heatmap_data_hl	120
@@ -1443,102 +702,1088 @@ single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_clusters	120
 single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_patterns	120
 single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_key_message	120
 single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_unmatched	120
+single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-access-log-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
 single-day-access-log-histogram	-hg	COUNTS	log_messages_entries	3184
 single-day-access-log-histogram	-hg	COUNTS	log_occurrences_entries	15
 single-day-access-log-histogram	-hg	COUNTS	log_stats_entries	15
 single-day-access-log-histogram	-hg	CONFIG	terminal_width	200
-single-day-access-log-histogram	-hg	CONFIG	terminal_height	52
+single-day-access-log-histogram	-hg	CONFIG	terminal_height	24
 single-day-access-log-histogram	-hg	CONFIG	max_log_message_length	200
 single-day-access-log-histogram	-hg	CONFIG	time_bucket_size	60
 single-day-access-log-histogram	-hg	CONFIG	bucket_size_seconds	3600.00
-single-day-access-log-heatmap-histogram	-hm -hg	version	0.14.4
-single-day-access-log-heatmap-histogram	-hm -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
-single-day-access-log-heatmap-histogram	-hm -hg	lines_read	761698
-single-day-access-log-heatmap-histogram	-hm -hg	lines_included	761698
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	read_files	9.849
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.064
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.583
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	1.527
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
-single-day-access-log-heatmap-histogram	-hm -hg	TIMING	total	12.025
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	rss_peak	306757632
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	34866
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	41847756
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	histogram_values	94480568
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_analysis	8281
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_messages	58184154
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	18844
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_stats	29219
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	58184154
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	6670
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
-single-day-access-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
-single-day-access-log-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	3184
-single-day-access-log-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	15
-single-day-access-log-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	15
-single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
-single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	terminal_height	52
-single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
-single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
-single-day-access-log-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.4
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	lines_read	761698
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	lines_included	761698
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	11.193
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	0.771
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.279
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.652
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	1.545
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.002
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	14.441
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	347422720
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	52193514
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	476277
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	124101
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	325196
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	34866
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	41847756
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	94480568
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	8281
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	57381194
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	18844
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	29219
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	57381194
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	6670
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	52193514
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	124101
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	65592
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	296
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	599
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	15
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	15
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	52
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
-single-day-access-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
+single-day-access-log-heatmap	-hm	version	0.14.4
+single-day-access-log-heatmap	-hm	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-heatmap	-hm	lines_read	761698
+single-day-access-log-heatmap	-hm	lines_included	761698
+single-day-access-log-heatmap	-hm	TIMING	read_files	9.376
+single-day-access-log-heatmap	-hm	TIMING	initialize_buckets	0.000
+single-day-access-log-heatmap	-hm	TIMING	group_similar	0.000
+single-day-access-log-heatmap	-hm	TIMING	calculate_statistics	0.060
+single-day-access-log-heatmap	-hm	TIMING	heatmap_statistics	0.571
+single-day-access-log-heatmap	-hm	TIMING	histogram_statistics	0.000
+single-day-access-log-heatmap	-hm	TIMING	normalize_data	0.001
+single-day-access-log-heatmap	-hm	TIMING	total	10.008
+single-day-access-log-heatmap	-hm	MEMORY	rss_peak	168230912
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_clusters	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_key_message	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_key_trigrams	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_ngram_index	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_patterns	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_posting_size	120
+single-day-access-log-heatmap	-hm	MEMORY	consolidation_unmatched	120
+single-day-access-log-heatmap	-hm	MEMORY	heatmap_data	34866
+single-day-access-log-heatmap	-hm	MEMORY	heatmap_data_hl	120
+single-day-access-log-heatmap	-hm	MEMORY	heatmap_raw	41847756
+single-day-access-log-heatmap	-hm	MEMORY	heatmap_raw_hl	120
+single-day-access-log-heatmap	-hm	MEMORY	histogram_values	576
+single-day-access-log-heatmap	-hm	MEMORY	log_analysis	8281
+single-day-access-log-heatmap	-hm	MEMORY	log_messages	57988058
+single-day-access-log-heatmap	-hm	MEMORY	log_occurrences	18844
+single-day-access-log-heatmap	-hm	MEMORY	log_sessions	120
+single-day-access-log-heatmap	-hm	MEMORY	log_stats	29219
+single-day-access-log-heatmap	-hm	MEMORY	log_threadpools	232
+single-day-access-log-heatmap	-hm	MEMORY	threadpool_activity	762
+single-day-access-log-heatmap	-hm	MEMORY	udm_last_value	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	log_messages	57988058
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	log_analysis	6670
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-access-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-access-log-heatmap	-hm	COUNTS	log_messages_entries	3184
+single-day-access-log-heatmap	-hm	COUNTS	log_occurrences_entries	15
+single-day-access-log-heatmap	-hm	COUNTS	log_stats_entries	15
+single-day-access-log-heatmap	-hm	CONFIG	terminal_width	200
+single-day-access-log-heatmap	-hm	CONFIG	terminal_height	24
+single-day-access-log-heatmap	-hm	CONFIG	max_log_message_length	200
+single-day-access-log-heatmap	-hm	CONFIG	time_bucket_size	60
+single-day-access-log-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
+single-day-access-log-top25-consolidate	-n 25 -g	version	0.14.4
+single-day-access-log-top25-consolidate	-n 25 -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-top25-consolidate	-n 25 -g	lines_read	761698
+single-day-access-log-top25-consolidate	-n 25 -g	lines_included	761698
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	read_files	10.991
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	group_similar	4.397
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.373
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.001
+single-day-access-log-top25-consolidate	-n 25 -g	TIMING	total	15.763
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	rss_peak	203374592
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	50832213
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	904233
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams	4329692
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_ngram_index	5050039
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	124917
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_posting_size	360923
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	578706
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_analysis	55254897
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_messages	58174234
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	18844
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_stats	32315
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	56099052
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	6670
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	50832213
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	123965
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	65592
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	296
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams	16440
+single-day-access-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-access-log-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	614
+single-day-access-log-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	15
+single-day-access-log-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	15
+single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
+single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	terminal_height	24
+single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
+single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
+single-day-access-log-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
+single-day-access-log-top25	-n 25	version	0.14.4
+single-day-access-log-top25	-n 25	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-top25	-n 25	lines_read	761698
+single-day-access-log-top25	-n 25	lines_included	761698
+single-day-access-log-top25	-n 25	TIMING	read_files	9.378
+single-day-access-log-top25	-n 25	TIMING	initialize_buckets	0.000
+single-day-access-log-top25	-n 25	TIMING	group_similar	0.000
+single-day-access-log-top25	-n 25	TIMING	calculate_statistics	0.245
+single-day-access-log-top25	-n 25	TIMING	heatmap_statistics	0.000
+single-day-access-log-top25	-n 25	TIMING	histogram_statistics	0.000
+single-day-access-log-top25	-n 25	TIMING	normalize_data	0.001
+single-day-access-log-top25	-n 25	TIMING	total	9.625
+single-day-access-log-top25	-n 25	MEMORY	rss_peak	164052992
+single-day-access-log-top25	-n 25	MEMORY	consolidation_clusters	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_key_message	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_key_trigrams	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_ngram_index	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_patterns	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_posting_size	120
+single-day-access-log-top25	-n 25	MEMORY	consolidation_unmatched	120
+single-day-access-log-top25	-n 25	MEMORY	heatmap_data	120
+single-day-access-log-top25	-n 25	MEMORY	heatmap_data_hl	120
+single-day-access-log-top25	-n 25	MEMORY	heatmap_raw	120
+single-day-access-log-top25	-n 25	MEMORY	heatmap_raw_hl	120
+single-day-access-log-top25	-n 25	MEMORY	histogram_values	576
+single-day-access-log-top25	-n 25	MEMORY	log_analysis	55254897
+single-day-access-log-top25	-n 25	MEMORY	log_messages	58197970
+single-day-access-log-top25	-n 25	MEMORY	log_occurrences	18844
+single-day-access-log-top25	-n 25	MEMORY	log_sessions	120
+single-day-access-log-top25	-n 25	MEMORY	log_stats	32315
+single-day-access-log-top25	-n 25	MEMORY	log_threadpools	232
+single-day-access-log-top25	-n 25	MEMORY	threadpool_activity	762
+single-day-access-log-top25	-n 25	MEMORY	udm_last_value	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	log_messages	58197970
+single-day-access-log-top25	-n 25	MEMORY_FINAL	log_analysis	6670
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-access-log-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-access-log-top25	-n 25	COUNTS	log_messages_entries	3184
+single-day-access-log-top25	-n 25	COUNTS	log_occurrences_entries	15
+single-day-access-log-top25	-n 25	COUNTS	log_stats_entries	15
+single-day-access-log-top25	-n 25	CONFIG	terminal_width	200
+single-day-access-log-top25	-n 25	CONFIG	terminal_height	24
+single-day-access-log-top25	-n 25	CONFIG	max_log_message_length	200
+single-day-access-log-top25	-n 25	CONFIG	time_bucket_size	60
+single-day-access-log-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
+single-day-access-log-standard		version	0.14.4
+single-day-access-log-standard		FILES	/Users/geva/Documents/GitHub/logtimeline/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt	155210047
+single-day-access-log-standard		lines_read	761698
+single-day-access-log-standard		lines_included	761698
+single-day-access-log-standard		TIMING	read_files	9.225
+single-day-access-log-standard		TIMING	initialize_buckets	0.000
+single-day-access-log-standard		TIMING	group_similar	0.000
+single-day-access-log-standard		TIMING	calculate_statistics	0.209
+single-day-access-log-standard		TIMING	heatmap_statistics	0.000
+single-day-access-log-standard		TIMING	histogram_statistics	0.000
+single-day-access-log-standard		TIMING	normalize_data	0.001
+single-day-access-log-standard		TIMING	total	9.436
+single-day-access-log-standard		MEMORY	rss_peak	165494784
+single-day-access-log-standard		MEMORY	consolidation_clusters	120
+single-day-access-log-standard		MEMORY	consolidation_key_message	120
+single-day-access-log-standard		MEMORY	consolidation_key_trigrams	120
+single-day-access-log-standard		MEMORY	consolidation_key_trigrams_norm	120
+single-day-access-log-standard		MEMORY	consolidation_ngram_index	120
+single-day-access-log-standard		MEMORY	consolidation_patterns	120
+single-day-access-log-standard		MEMORY	consolidation_posting_size	120
+single-day-access-log-standard		MEMORY	consolidation_unmatched	120
+single-day-access-log-standard		MEMORY	heatmap_data	120
+single-day-access-log-standard		MEMORY	heatmap_data_hl	120
+single-day-access-log-standard		MEMORY	heatmap_raw	120
+single-day-access-log-standard		MEMORY	heatmap_raw_hl	120
+single-day-access-log-standard		MEMORY	histogram_values	576
+single-day-access-log-standard		MEMORY	log_analysis	55254897
+single-day-access-log-standard		MEMORY	log_messages	58184154
+single-day-access-log-standard		MEMORY	log_occurrences	18844
+single-day-access-log-standard		MEMORY	log_sessions	120
+single-day-access-log-standard		MEMORY	log_stats	32315
+single-day-access-log-standard		MEMORY	log_threadpools	232
+single-day-access-log-standard		MEMORY	threadpool_activity	762
+single-day-access-log-standard		MEMORY	udm_last_value	120
+single-day-access-log-standard		MEMORY_FINAL	log_messages	58184154
+single-day-access-log-standard		MEMORY_FINAL	log_analysis	6670
+single-day-access-log-standard		MEMORY_FINAL	consolidation_clusters	120
+single-day-access-log-standard		MEMORY_FINAL	consolidation_patterns	120
+single-day-access-log-standard		MEMORY_FINAL	consolidation_key_message	120
+single-day-access-log-standard		MEMORY_FINAL	consolidation_unmatched	120
+single-day-access-log-standard		MEMORY_FINAL	consolidation_ngram_index	120
+single-day-access-log-standard		MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-access-log-standard		MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-access-log-standard		COUNTS	log_messages_entries	3184
+single-day-access-log-standard		COUNTS	log_occurrences_entries	15
+single-day-access-log-standard		COUNTS	log_stats_entries	15
+single-day-access-log-standard		CONFIG	terminal_width	200
+single-day-access-log-standard		CONFIG	terminal_height	24
+single-day-access-log-standard		CONFIG	max_log_message_length	200
+single-day-access-log-standard		CONFIG	time_bucket_size	60
+single-day-access-log-standard		CONFIG	bucket_size_seconds	3600.00
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	version	0.14.4
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	lines_read	930031
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	lines_included	930028
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	read_files	38.024
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	initialize_buckets	0.000
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	group_similar	4.935
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	calculate_statistics	0.003
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	heatmap_statistics	0.000
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	histogram_statistics	0.000
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	normalize_data	0.003
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	TIMING	total	42.965
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	rss_peak	241270784
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_clusters	3738296
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_key_message	3717942
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_key_trigrams	65248362
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_key_trigrams_norm	10920069
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_ngram_index	63745676
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_patterns	497578
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_posting_size	1688882
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	consolidation_unmatched	2241530
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_data	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_data_hl	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_raw	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	heatmap_raw_hl	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	histogram_values	576
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_analysis	232
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_messages	3335663
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_occurrences	57953
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_sessions	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_stats	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	log_threadpools	232
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	threadpool_activity	762
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY	udm_last_value	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	log_messages	726422
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	log_analysis	232
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_clusters	3738296
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_patterns	497578
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_key_message	131128
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	MEMORY_FINAL	consolidation_key_trigrams_norm	8248
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	COUNTS	log_messages_entries	1304
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	COUNTS	log_occurrences_entries	53
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	COUNTS	log_stats_entries	53
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	terminal_width	200
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	terminal_height	24
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	max_log_message_length	200
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	time_bucket_size	480
+multi-day-application-logs-top25-consolidate	-bs 480 -n 25 -g	CONFIG	bucket_size_seconds	28800.00
+multi-day-application-logs-top25	-bs 480 -n 25	version	0.14.4
+multi-day-application-logs-top25	-bs 480 -n 25	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-top25	-bs 480 -n 25	lines_read	930031
+multi-day-application-logs-top25	-bs 480 -n 25	lines_included	930028
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	read_files	7.681
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	initialize_buckets	0.000
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	group_similar	0.000
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	calculate_statistics	0.203
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	heatmap_statistics	0.000
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	histogram_statistics	0.000
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	normalize_data	0.001
+multi-day-application-logs-top25	-bs 480 -n 25	TIMING	total	7.885
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	rss_peak	118636544
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_clusters	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_key_message	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_key_trigrams	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_ngram_index	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_patterns	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_posting_size	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	consolidation_unmatched	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_data	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_data_hl	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_raw	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	heatmap_raw_hl	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	histogram_values	576
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_analysis	232
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_messages	48030790
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_occurrences	57953
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_sessions	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_stats	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	log_threadpools	232
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	threadpool_activity	762
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY	udm_last_value	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	log_messages	48030790
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	log_analysis	232
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_clusters	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_patterns	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_key_message	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-application-logs-top25	-bs 480 -n 25	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-application-logs-top25	-bs 480 -n 25	COUNTS	log_messages_entries	105902
+multi-day-application-logs-top25	-bs 480 -n 25	COUNTS	log_occurrences_entries	53
+multi-day-application-logs-top25	-bs 480 -n 25	COUNTS	log_stats_entries	53
+multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	terminal_width	200
+multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	terminal_height	24
+multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	max_log_message_length	200
+multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	time_bucket_size	480
+multi-day-application-logs-top25	-bs 480 -n 25	CONFIG	bucket_size_seconds	28800.00
+multi-day-application-logs-standard	-bs 480	version	0.14.4
+multi-day-application-logs-standard	-bs 480	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-16.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-17.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-18.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-19.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.1.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.10.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.11.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.12.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.13.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.14.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.15.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.16.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.17.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.2.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.3.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.4.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.5.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.6.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.7.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.8.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-20.9.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-21.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-22.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-23.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-24.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-25.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-26.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-27.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-28.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-29.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-30.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-01-31.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-01.0.log;/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/archives/ApplicationLog.2026-02-02.0.log	329814559
+multi-day-application-logs-standard	-bs 480	lines_read	930031
+multi-day-application-logs-standard	-bs 480	lines_included	930028
+multi-day-application-logs-standard	-bs 480	TIMING	read_files	7.639
+multi-day-application-logs-standard	-bs 480	TIMING	initialize_buckets	0.000
+multi-day-application-logs-standard	-bs 480	TIMING	group_similar	0.000
+multi-day-application-logs-standard	-bs 480	TIMING	calculate_statistics	0.185
+multi-day-application-logs-standard	-bs 480	TIMING	heatmap_statistics	0.000
+multi-day-application-logs-standard	-bs 480	TIMING	histogram_statistics	0.000
+multi-day-application-logs-standard	-bs 480	TIMING	normalize_data	0.001
+multi-day-application-logs-standard	-bs 480	TIMING	total	7.826
+multi-day-application-logs-standard	-bs 480	MEMORY	rss_peak	117964800
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_clusters	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_key_message	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_key_trigrams	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_key_trigrams_norm	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_ngram_index	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_patterns	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_posting_size	120
+multi-day-application-logs-standard	-bs 480	MEMORY	consolidation_unmatched	120
+multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_data	120
+multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_data_hl	120
+multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_raw	120
+multi-day-application-logs-standard	-bs 480	MEMORY	heatmap_raw_hl	120
+multi-day-application-logs-standard	-bs 480	MEMORY	histogram_values	576
+multi-day-application-logs-standard	-bs 480	MEMORY	log_analysis	232
+multi-day-application-logs-standard	-bs 480	MEMORY	log_messages	48030790
+multi-day-application-logs-standard	-bs 480	MEMORY	log_occurrences	58017
+multi-day-application-logs-standard	-bs 480	MEMORY	log_sessions	120
+multi-day-application-logs-standard	-bs 480	MEMORY	log_stats	120
+multi-day-application-logs-standard	-bs 480	MEMORY	log_threadpools	232
+multi-day-application-logs-standard	-bs 480	MEMORY	threadpool_activity	762
+multi-day-application-logs-standard	-bs 480	MEMORY	udm_last_value	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	log_messages	48030790
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	log_analysis	232
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_clusters	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_patterns	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_key_message	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_unmatched	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_ngram_index	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_key_trigrams	120
+multi-day-application-logs-standard	-bs 480	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+multi-day-application-logs-standard	-bs 480	COUNTS	log_messages_entries	105902
+multi-day-application-logs-standard	-bs 480	COUNTS	log_occurrences_entries	53
+multi-day-application-logs-standard	-bs 480	COUNTS	log_stats_entries	53
+multi-day-application-logs-standard	-bs 480	CONFIG	terminal_width	200
+multi-day-application-logs-standard	-bs 480	CONFIG	terminal_height	24
+multi-day-application-logs-standard	-bs 480	CONFIG	max_log_message_length	200
+multi-day-application-logs-standard	-bs 480	CONFIG	time_bucket_size	480
+multi-day-application-logs-standard	-bs 480	CONFIG	bucket_size_seconds	28800.00
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.4
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	lines_read	479904
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	lines_included	479904
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	6.259
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	0.279
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.000
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.000
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	0.000
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.002
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	6.539
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	128614400
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	448005
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	2752580
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams	30710979
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams_norm	17150061
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_ngram_index	31120670
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	55576
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_posting_size	881550
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	1599064
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	576
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	232
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	2401065
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	22310
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	137524
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	232
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	448005
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	55576
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	65592
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams	32824
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams_norm	32824
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	136
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	24
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	24
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	24
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
+single-day-application-log-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
+single-day-application-log-heatmap-histogram	-hm -hg	version	0.14.4
+single-day-application-log-heatmap-histogram	-hm -hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-heatmap-histogram	-hm -hg	lines_read	479904
+single-day-application-log-heatmap-histogram	-hm -hg	lines_included	479904
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	read_files	3.543
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.006
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.000
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	0.000
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
+single-day-application-log-heatmap-histogram	-hm -hg	TIMING	total	3.550
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	rss_peak	35160064
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams_norm	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_ngram_index	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_posting_size	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	histogram_values	576
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_analysis	232
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_messages	2872100
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	22310
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_stats	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	2872100
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	232
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-application-log-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-application-log-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	6512
+single-day-application-log-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	24
+single-day-application-log-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	24
+single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
+single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	terminal_height	24
+single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
+single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
+single-day-application-log-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
+single-day-application-log-histogram	-hg	version	0.14.4
+single-day-application-log-histogram	-hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-histogram	-hg	lines_read	479904
+single-day-application-log-histogram	-hg	lines_included	479904
+single-day-application-log-histogram	-hg	TIMING	read_files	3.595
+single-day-application-log-histogram	-hg	TIMING	initialize_buckets	0.000
+single-day-application-log-histogram	-hg	TIMING	group_similar	0.000
+single-day-application-log-histogram	-hg	TIMING	calculate_statistics	0.006
+single-day-application-log-histogram	-hg	TIMING	heatmap_statistics	0.000
+single-day-application-log-histogram	-hg	TIMING	histogram_statistics	0.000
+single-day-application-log-histogram	-hg	TIMING	normalize_data	0.001
+single-day-application-log-histogram	-hg	TIMING	total	3.603
+single-day-application-log-histogram	-hg	MEMORY	rss_peak	34783232
+single-day-application-log-histogram	-hg	MEMORY	consolidation_clusters	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_key_message	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_key_trigrams	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_key_trigrams_norm	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_ngram_index	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_patterns	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_posting_size	120
+single-day-application-log-histogram	-hg	MEMORY	consolidation_unmatched	120
+single-day-application-log-histogram	-hg	MEMORY	heatmap_data	120
+single-day-application-log-histogram	-hg	MEMORY	heatmap_data_hl	120
+single-day-application-log-histogram	-hg	MEMORY	heatmap_raw	120
+single-day-application-log-histogram	-hg	MEMORY	heatmap_raw_hl	120
+single-day-application-log-histogram	-hg	MEMORY	histogram_values	576
+single-day-application-log-histogram	-hg	MEMORY	log_analysis	232
+single-day-application-log-histogram	-hg	MEMORY	log_messages	2872100
+single-day-application-log-histogram	-hg	MEMORY	log_occurrences	22310
+single-day-application-log-histogram	-hg	MEMORY	log_sessions	120
+single-day-application-log-histogram	-hg	MEMORY	log_stats	120
+single-day-application-log-histogram	-hg	MEMORY	log_threadpools	232
+single-day-application-log-histogram	-hg	MEMORY	threadpool_activity	762
+single-day-application-log-histogram	-hg	MEMORY	udm_last_value	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	log_messages	2872100
+single-day-application-log-histogram	-hg	MEMORY_FINAL	log_analysis	232
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_clusters	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_patterns	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_key_message	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_unmatched	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-application-log-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-application-log-histogram	-hg	COUNTS	log_messages_entries	6512
+single-day-application-log-histogram	-hg	COUNTS	log_occurrences_entries	24
+single-day-application-log-histogram	-hg	COUNTS	log_stats_entries	24
+single-day-application-log-histogram	-hg	CONFIG	terminal_width	200
+single-day-application-log-histogram	-hg	CONFIG	terminal_height	24
+single-day-application-log-histogram	-hg	CONFIG	max_log_message_length	200
+single-day-application-log-histogram	-hg	CONFIG	time_bucket_size	60
+single-day-application-log-histogram	-hg	CONFIG	bucket_size_seconds	3600.00
+single-day-application-log-heatmap	-hm	version	0.14.4
+single-day-application-log-heatmap	-hm	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-heatmap	-hm	lines_read	479904
+single-day-application-log-heatmap	-hm	lines_included	479904
+single-day-application-log-heatmap	-hm	TIMING	read_files	3.547
+single-day-application-log-heatmap	-hm	TIMING	initialize_buckets	0.000
+single-day-application-log-heatmap	-hm	TIMING	group_similar	0.000
+single-day-application-log-heatmap	-hm	TIMING	calculate_statistics	0.006
+single-day-application-log-heatmap	-hm	TIMING	heatmap_statistics	0.000
+single-day-application-log-heatmap	-hm	TIMING	histogram_statistics	0.000
+single-day-application-log-heatmap	-hm	TIMING	normalize_data	0.001
+single-day-application-log-heatmap	-hm	TIMING	total	3.554
+single-day-application-log-heatmap	-hm	MEMORY	rss_peak	34897920
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_clusters	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_key_message	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_key_trigrams	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_key_trigrams_norm	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_ngram_index	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_patterns	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_posting_size	120
+single-day-application-log-heatmap	-hm	MEMORY	consolidation_unmatched	120
+single-day-application-log-heatmap	-hm	MEMORY	heatmap_data	120
+single-day-application-log-heatmap	-hm	MEMORY	heatmap_data_hl	120
+single-day-application-log-heatmap	-hm	MEMORY	heatmap_raw	120
+single-day-application-log-heatmap	-hm	MEMORY	heatmap_raw_hl	120
+single-day-application-log-heatmap	-hm	MEMORY	histogram_values	576
+single-day-application-log-heatmap	-hm	MEMORY	log_analysis	232
+single-day-application-log-heatmap	-hm	MEMORY	log_messages	2872100
+single-day-application-log-heatmap	-hm	MEMORY	log_occurrences	22310
+single-day-application-log-heatmap	-hm	MEMORY	log_sessions	120
+single-day-application-log-heatmap	-hm	MEMORY	log_stats	120
+single-day-application-log-heatmap	-hm	MEMORY	log_threadpools	232
+single-day-application-log-heatmap	-hm	MEMORY	threadpool_activity	762
+single-day-application-log-heatmap	-hm	MEMORY	udm_last_value	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	log_messages	2872100
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	log_analysis	232
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-application-log-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-application-log-heatmap	-hm	COUNTS	log_messages_entries	6512
+single-day-application-log-heatmap	-hm	COUNTS	log_occurrences_entries	24
+single-day-application-log-heatmap	-hm	COUNTS	log_stats_entries	24
+single-day-application-log-heatmap	-hm	CONFIG	terminal_width	200
+single-day-application-log-heatmap	-hm	CONFIG	terminal_height	24
+single-day-application-log-heatmap	-hm	CONFIG	max_log_message_length	200
+single-day-application-log-heatmap	-hm	CONFIG	time_bucket_size	60
+single-day-application-log-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
+single-day-application-log-top25-consolidate	-n 25 -g	version	0.14.4
+single-day-application-log-top25-consolidate	-n 25 -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-top25-consolidate	-n 25 -g	lines_read	479904
+single-day-application-log-top25-consolidate	-n 25 -g	lines_included	479904
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	read_files	6.320
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	group_similar	0.288
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.000
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.001
+single-day-application-log-top25-consolidate	-n 25 -g	TIMING	total	6.610
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	rss_peak	126648320
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	448047
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	2752580
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams	29746322
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams_norm	16364065
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_ngram_index	31117982
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	55660
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_posting_size	881550
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	1599064
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_analysis	232
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_messages	2401065
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	22310
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_stats	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	137524
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	232
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	448047
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	55660
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	65592
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams	32824
+single-day-application-log-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams_norm	32824
+single-day-application-log-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	136
+single-day-application-log-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	24
+single-day-application-log-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	24
+single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
+single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	terminal_height	24
+single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
+single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
+single-day-application-log-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
+single-day-application-log-top25	-n 25	version	0.14.4
+single-day-application-log-top25	-n 25	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-top25	-n 25	lines_read	479904
+single-day-application-log-top25	-n 25	lines_included	479904
+single-day-application-log-top25	-n 25	TIMING	read_files	3.574
+single-day-application-log-top25	-n 25	TIMING	initialize_buckets	0.000
+single-day-application-log-top25	-n 25	TIMING	group_similar	0.000
+single-day-application-log-top25	-n 25	TIMING	calculate_statistics	0.007
+single-day-application-log-top25	-n 25	TIMING	heatmap_statistics	0.000
+single-day-application-log-top25	-n 25	TIMING	histogram_statistics	0.000
+single-day-application-log-top25	-n 25	TIMING	normalize_data	0.001
+single-day-application-log-top25	-n 25	TIMING	total	3.582
+single-day-application-log-top25	-n 25	MEMORY	rss_peak	35209216
+single-day-application-log-top25	-n 25	MEMORY	consolidation_clusters	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_key_message	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_key_trigrams	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_key_trigrams_norm	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_ngram_index	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_patterns	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_posting_size	120
+single-day-application-log-top25	-n 25	MEMORY	consolidation_unmatched	120
+single-day-application-log-top25	-n 25	MEMORY	heatmap_data	120
+single-day-application-log-top25	-n 25	MEMORY	heatmap_data_hl	120
+single-day-application-log-top25	-n 25	MEMORY	heatmap_raw	120
+single-day-application-log-top25	-n 25	MEMORY	heatmap_raw_hl	120
+single-day-application-log-top25	-n 25	MEMORY	histogram_values	576
+single-day-application-log-top25	-n 25	MEMORY	log_analysis	232
+single-day-application-log-top25	-n 25	MEMORY	log_messages	2872100
+single-day-application-log-top25	-n 25	MEMORY	log_occurrences	22310
+single-day-application-log-top25	-n 25	MEMORY	log_sessions	120
+single-day-application-log-top25	-n 25	MEMORY	log_stats	120
+single-day-application-log-top25	-n 25	MEMORY	log_threadpools	232
+single-day-application-log-top25	-n 25	MEMORY	threadpool_activity	762
+single-day-application-log-top25	-n 25	MEMORY	udm_last_value	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	log_messages	2872100
+single-day-application-log-top25	-n 25	MEMORY_FINAL	log_analysis	232
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-application-log-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-application-log-top25	-n 25	COUNTS	log_messages_entries	6512
+single-day-application-log-top25	-n 25	COUNTS	log_occurrences_entries	24
+single-day-application-log-top25	-n 25	COUNTS	log_stats_entries	24
+single-day-application-log-top25	-n 25	CONFIG	terminal_width	200
+single-day-application-log-top25	-n 25	CONFIG	terminal_height	24
+single-day-application-log-top25	-n 25	CONFIG	max_log_message_length	200
+single-day-application-log-top25	-n 25	CONFIG	time_bucket_size	60
+single-day-application-log-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	version	0.14.4
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	lines_read	288025
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	lines_included	288025
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	read_files	6.700
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	group_similar	4.341
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	calculate_statistics	0.000
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	normalize_data	0.001
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	TIMING	total	11.043
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	rss_peak	258850816
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_clusters	200881
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_message	3202280
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams	75187152
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_key_trigrams_norm	67365471
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_ngram_index	69935877
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_patterns	25503
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_posting_size	628846
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	consolidation_unmatched	1814791
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	histogram_values	576
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_analysis	232
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_messages	2654134
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_occurrences	4619
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_sessions	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_stats	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	log_threadpools	232
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	threadpool_activity	762
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY	udm_last_value	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_messages	100953
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_clusters	200881
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_patterns	25503
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_message	65592
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_unmatched	232
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams_norm	65592
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_messages_entries	72
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	COUNTS	log_stats_entries	5
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_width	200
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	terminal_height	24
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	max_log_message_length	200
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	time_bucket_size	60
+humungous-log-uniqueness-heatmap-histogram-consolidate	-hm -hg -g	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	version	0.14.4
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	lines_read	288025
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	lines_included	288025
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	read_files	2.260
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	group_similar	0.000
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	calculate_statistics	0.288
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	normalize_data	0.001
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	TIMING	total	2.549
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	rss_peak	209993728
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_clusters	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_message	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_ngram_index	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_patterns	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_posting_size	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	consolidation_unmatched	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_data	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	histogram_values	576
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_analysis	232
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_messages	133188237
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_occurrences	4619
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_sessions	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_stats	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	log_threadpools	232
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	threadpool_activity	762
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY	udm_last_value	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_messages	133188237
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_clusters	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_patterns	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_message	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_unmatched	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	COUNTS	log_messages_entries	286659
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	COUNTS	log_stats_entries	5
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	terminal_width	200
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	terminal_height	24
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	max_log_message_length	200
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	time_bucket_size	60
+humungous-log-uniqueness-heatmap-histogram	-hm -hg	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-histogram	-hg	version	0.14.4
+humungous-log-uniqueness-histogram	-hg	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-histogram	-hg	lines_read	288025
+humungous-log-uniqueness-histogram	-hg	lines_included	288025
+humungous-log-uniqueness-histogram	-hg	TIMING	read_files	2.299
+humungous-log-uniqueness-histogram	-hg	TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-histogram	-hg	TIMING	group_similar	0.000
+humungous-log-uniqueness-histogram	-hg	TIMING	calculate_statistics	0.305
+humungous-log-uniqueness-histogram	-hg	TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-histogram	-hg	TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-histogram	-hg	TIMING	normalize_data	0.001
+humungous-log-uniqueness-histogram	-hg	TIMING	total	2.605
+humungous-log-uniqueness-histogram	-hg	MEMORY	rss_peak	210550784
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_clusters	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_key_message	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_key_trigrams	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_ngram_index	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_patterns	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_posting_size	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	consolidation_unmatched	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_data	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_raw	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	histogram_values	576
+humungous-log-uniqueness-histogram	-hg	MEMORY	log_analysis	232
+humungous-log-uniqueness-histogram	-hg	MEMORY	log_messages	133188237
+humungous-log-uniqueness-histogram	-hg	MEMORY	log_occurrences	4619
+humungous-log-uniqueness-histogram	-hg	MEMORY	log_sessions	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	log_stats	120
+humungous-log-uniqueness-histogram	-hg	MEMORY	log_threadpools	232
+humungous-log-uniqueness-histogram	-hg	MEMORY	threadpool_activity	762
+humungous-log-uniqueness-histogram	-hg	MEMORY	udm_last_value	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	log_messages	133188237
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_clusters	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_patterns	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_key_message	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_unmatched	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams	120
+humungous-log-uniqueness-histogram	-hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-histogram	-hg	COUNTS	log_messages_entries	286659
+humungous-log-uniqueness-histogram	-hg	COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-histogram	-hg	COUNTS	log_stats_entries	5
+humungous-log-uniqueness-histogram	-hg	CONFIG	terminal_width	200
+humungous-log-uniqueness-histogram	-hg	CONFIG	terminal_height	24
+humungous-log-uniqueness-histogram	-hg	CONFIG	max_log_message_length	200
+humungous-log-uniqueness-histogram	-hg	CONFIG	time_bucket_size	60
+humungous-log-uniqueness-histogram	-hg	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-heatmap	-hm	version	0.14.4
+humungous-log-uniqueness-heatmap	-hm	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-heatmap	-hm	lines_read	288025
+humungous-log-uniqueness-heatmap	-hm	lines_included	288025
+humungous-log-uniqueness-heatmap	-hm	TIMING	read_files	2.263
+humungous-log-uniqueness-heatmap	-hm	TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-heatmap	-hm	TIMING	group_similar	0.000
+humungous-log-uniqueness-heatmap	-hm	TIMING	calculate_statistics	0.276
+humungous-log-uniqueness-heatmap	-hm	TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-heatmap	-hm	TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-heatmap	-hm	TIMING	normalize_data	0.001
+humungous-log-uniqueness-heatmap	-hm	TIMING	total	2.540
+humungous-log-uniqueness-heatmap	-hm	MEMORY	rss_peak	211173376
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_clusters	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_key_message	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_key_trigrams	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_ngram_index	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_patterns	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_posting_size	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	consolidation_unmatched	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_data	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_raw	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	histogram_values	576
+humungous-log-uniqueness-heatmap	-hm	MEMORY	log_analysis	232
+humungous-log-uniqueness-heatmap	-hm	MEMORY	log_messages	133188237
+humungous-log-uniqueness-heatmap	-hm	MEMORY	log_occurrences	4619
+humungous-log-uniqueness-heatmap	-hm	MEMORY	log_sessions	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	log_stats	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY	log_threadpools	232
+humungous-log-uniqueness-heatmap	-hm	MEMORY	threadpool_activity	762
+humungous-log-uniqueness-heatmap	-hm	MEMORY	udm_last_value	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	log_messages	133188237
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_clusters	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_patterns	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_key_message	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_unmatched	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams	120
+humungous-log-uniqueness-heatmap	-hm	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-heatmap	-hm	COUNTS	log_messages_entries	286659
+humungous-log-uniqueness-heatmap	-hm	COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-heatmap	-hm	COUNTS	log_stats_entries	5
+humungous-log-uniqueness-heatmap	-hm	CONFIG	terminal_width	200
+humungous-log-uniqueness-heatmap	-hm	CONFIG	terminal_height	24
+humungous-log-uniqueness-heatmap	-hm	CONFIG	max_log_message_length	200
+humungous-log-uniqueness-heatmap	-hm	CONFIG	time_bucket_size	60
+humungous-log-uniqueness-heatmap	-hm	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	version	0.14.4
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	lines_read	288025
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	lines_included	288025
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	read_files	6.489
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	group_similar	4.306
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	calculate_statistics	0.000
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	normalize_data	0.001
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	TIMING	total	10.796
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	rss_peak	259424256
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_clusters	200881
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_message	3202280
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams	75241713
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_key_trigrams_norm	67378836
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_ngram_index	69936453
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_patterns	25503
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_posting_size	628846
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	consolidation_unmatched	1814791
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_data	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	histogram_values	576
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_analysis	232
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_messages	2653664
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_occurrences	4619
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_sessions	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_stats	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	log_threadpools	232
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	threadpool_activity	762
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY	udm_last_value	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_messages	100953
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_clusters	200881
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_patterns	25503
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_message	65592
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_unmatched	232
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	MEMORY_FINAL	consolidation_key_trigrams_norm	65592
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	COUNTS	log_messages_entries	72
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	COUNTS	log_stats_entries	5
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	terminal_width	200
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	terminal_height	24
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	max_log_message_length	200
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	time_bucket_size	60
+humungous-log-uniqueness-top25-consolidate	-n 25 -g	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-top25	-n 25	version	0.14.4
+humungous-log-uniqueness-top25	-n 25	FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-top25	-n 25	lines_read	288025
+humungous-log-uniqueness-top25	-n 25	lines_included	288025
+humungous-log-uniqueness-top25	-n 25	TIMING	read_files	2.307
+humungous-log-uniqueness-top25	-n 25	TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-top25	-n 25	TIMING	group_similar	0.000
+humungous-log-uniqueness-top25	-n 25	TIMING	calculate_statistics	0.281
+humungous-log-uniqueness-top25	-n 25	TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-top25	-n 25	TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-top25	-n 25	TIMING	normalize_data	0.001
+humungous-log-uniqueness-top25	-n 25	TIMING	total	2.588
+humungous-log-uniqueness-top25	-n 25	MEMORY	rss_peak	211124224
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_clusters	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_key_message	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_key_trigrams	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_ngram_index	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_patterns	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_posting_size	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	consolidation_unmatched	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_data	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_raw	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	histogram_values	576
+humungous-log-uniqueness-top25	-n 25	MEMORY	log_analysis	232
+humungous-log-uniqueness-top25	-n 25	MEMORY	log_messages	133188237
+humungous-log-uniqueness-top25	-n 25	MEMORY	log_occurrences	4619
+humungous-log-uniqueness-top25	-n 25	MEMORY	log_sessions	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	log_stats	120
+humungous-log-uniqueness-top25	-n 25	MEMORY	log_threadpools	232
+humungous-log-uniqueness-top25	-n 25	MEMORY	threadpool_activity	762
+humungous-log-uniqueness-top25	-n 25	MEMORY	udm_last_value	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	log_messages	133188237
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_clusters	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_patterns	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_key_message	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_unmatched	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams	120
+humungous-log-uniqueness-top25	-n 25	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-top25	-n 25	COUNTS	log_messages_entries	286659
+humungous-log-uniqueness-top25	-n 25	COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-top25	-n 25	COUNTS	log_stats_entries	5
+humungous-log-uniqueness-top25	-n 25	CONFIG	terminal_width	200
+humungous-log-uniqueness-top25	-n 25	CONFIG	terminal_height	24
+humungous-log-uniqueness-top25	-n 25	CONFIG	max_log_message_length	200
+humungous-log-uniqueness-top25	-n 25	CONFIG	time_bucket_size	60
+humungous-log-uniqueness-top25	-n 25	CONFIG	bucket_size_seconds	3600.00
+humungous-log-uniqueness-standard		version	0.14.4
+humungous-log-uniqueness-standard		FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/HundredsOfThousandsOfUniqueErrors.log	101746807
+humungous-log-uniqueness-standard		lines_read	288025
+humungous-log-uniqueness-standard		lines_included	288025
+humungous-log-uniqueness-standard		TIMING	read_files	2.325
+humungous-log-uniqueness-standard		TIMING	initialize_buckets	0.000
+humungous-log-uniqueness-standard		TIMING	group_similar	0.000
+humungous-log-uniqueness-standard		TIMING	calculate_statistics	0.313
+humungous-log-uniqueness-standard		TIMING	heatmap_statistics	0.000
+humungous-log-uniqueness-standard		TIMING	histogram_statistics	0.000
+humungous-log-uniqueness-standard		TIMING	normalize_data	0.001
+humungous-log-uniqueness-standard		TIMING	total	2.638
+humungous-log-uniqueness-standard		MEMORY	rss_peak	211091456
+humungous-log-uniqueness-standard		MEMORY	consolidation_clusters	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_key_message	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_key_trigrams	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_ngram_index	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_patterns	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_posting_size	120
+humungous-log-uniqueness-standard		MEMORY	consolidation_unmatched	120
+humungous-log-uniqueness-standard		MEMORY	heatmap_data	120
+humungous-log-uniqueness-standard		MEMORY	heatmap_data_hl	120
+humungous-log-uniqueness-standard		MEMORY	heatmap_raw	120
+humungous-log-uniqueness-standard		MEMORY	heatmap_raw_hl	120
+humungous-log-uniqueness-standard		MEMORY	histogram_values	576
+humungous-log-uniqueness-standard		MEMORY	log_analysis	232
+humungous-log-uniqueness-standard		MEMORY	log_messages	133188237
+humungous-log-uniqueness-standard		MEMORY	log_occurrences	4619
+humungous-log-uniqueness-standard		MEMORY	log_sessions	120
+humungous-log-uniqueness-standard		MEMORY	log_stats	120
+humungous-log-uniqueness-standard		MEMORY	log_threadpools	232
+humungous-log-uniqueness-standard		MEMORY	threadpool_activity	762
+humungous-log-uniqueness-standard		MEMORY	udm_last_value	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	log_messages	133188237
+humungous-log-uniqueness-standard		MEMORY_FINAL	log_analysis	232
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_clusters	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_patterns	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_key_message	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_unmatched	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_ngram_index	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_key_trigrams	120
+humungous-log-uniqueness-standard		MEMORY_FINAL	consolidation_key_trigrams_norm	120
+humungous-log-uniqueness-standard		COUNTS	log_messages_entries	286659
+humungous-log-uniqueness-standard		COUNTS	log_occurrences_entries	5
+humungous-log-uniqueness-standard		COUNTS	log_stats_entries	5
+humungous-log-uniqueness-standard		CONFIG	terminal_width	200
+humungous-log-uniqueness-standard		CONFIG	terminal_height	24
+humungous-log-uniqueness-standard		CONFIG	max_log_message_length	200
+humungous-log-uniqueness-standard		CONFIG	time_bucket_size	60
+humungous-log-uniqueness-standard		CONFIG	bucket_size_seconds	3600.00
+single-day-application-log-standard		version	0.14.4
+single-day-application-log-standard		FILES	/Users/geva/Documents/GitHub/logtimeline/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log	89111117
+single-day-application-log-standard		lines_read	479904
+single-day-application-log-standard		lines_included	479904
+single-day-application-log-standard		TIMING	read_files	3.526
+single-day-application-log-standard		TIMING	initialize_buckets	0.000
+single-day-application-log-standard		TIMING	group_similar	0.000
+single-day-application-log-standard		TIMING	calculate_statistics	0.007
+single-day-application-log-standard		TIMING	heatmap_statistics	0.000
+single-day-application-log-standard		TIMING	histogram_statistics	0.000
+single-day-application-log-standard		TIMING	normalize_data	0.001
+single-day-application-log-standard		TIMING	total	3.534
+single-day-application-log-standard		MEMORY	rss_peak	35028992
+single-day-application-log-standard		MEMORY	consolidation_clusters	120
+single-day-application-log-standard		MEMORY	consolidation_key_message	120
+single-day-application-log-standard		MEMORY	consolidation_key_trigrams	120
+single-day-application-log-standard		MEMORY	consolidation_key_trigrams_norm	120
+single-day-application-log-standard		MEMORY	consolidation_ngram_index	120
+single-day-application-log-standard		MEMORY	consolidation_patterns	120
+single-day-application-log-standard		MEMORY	consolidation_posting_size	120
+single-day-application-log-standard		MEMORY	consolidation_unmatched	120
+single-day-application-log-standard		MEMORY	heatmap_data	120
+single-day-application-log-standard		MEMORY	heatmap_data_hl	120
+single-day-application-log-standard		MEMORY	heatmap_raw	120
+single-day-application-log-standard		MEMORY	heatmap_raw_hl	120
+single-day-application-log-standard		MEMORY	histogram_values	576
+single-day-application-log-standard		MEMORY	log_analysis	232
+single-day-application-log-standard		MEMORY	log_messages	2872100
+single-day-application-log-standard		MEMORY	log_occurrences	22310
+single-day-application-log-standard		MEMORY	log_sessions	120
+single-day-application-log-standard		MEMORY	log_stats	120
+single-day-application-log-standard		MEMORY	log_threadpools	232
+single-day-application-log-standard		MEMORY	threadpool_activity	762
+single-day-application-log-standard		MEMORY	udm_last_value	120
+single-day-application-log-standard		MEMORY_FINAL	log_messages	2872100
+single-day-application-log-standard		MEMORY_FINAL	log_analysis	232
+single-day-application-log-standard		MEMORY_FINAL	consolidation_clusters	120
+single-day-application-log-standard		MEMORY_FINAL	consolidation_patterns	120
+single-day-application-log-standard		MEMORY_FINAL	consolidation_key_message	120
+single-day-application-log-standard		MEMORY_FINAL	consolidation_unmatched	120
+single-day-application-log-standard		MEMORY_FINAL	consolidation_ngram_index	120
+single-day-application-log-standard		MEMORY_FINAL	consolidation_key_trigrams	120
+single-day-application-log-standard		MEMORY_FINAL	consolidation_key_trigrams_norm	120
+single-day-application-log-standard		COUNTS	log_messages_entries	6512
+single-day-application-log-standard		COUNTS	log_occurrences_entries	24
+single-day-application-log-standard		COUNTS	log_stats_entries	24
+single-day-application-log-standard		CONFIG	terminal_width	200
+single-day-application-log-standard		CONFIG	terminal_height	24
+single-day-application-log-standard		CONFIG	max_log_message_length	200
+single-day-application-log-standard		CONFIG	time_bucket_size	60
+single-day-application-log-standard		CONFIG	bucket_size_seconds	3600.00
 month-single-server-access-logs-standard	-bs 1440	version	0.14.4
 month-single-server-access-logs-standard	-bs 1440	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
 month-single-server-access-logs-standard	-bs 1440	lines_read	7749167


### PR DESCRIPTION
## Summary

- The committed `tests/baseline/results/v0.14.4.tsv` had 17 of 49 tests captured against the 0.14.3 binary (pre-#150, pre-version-bump), and the other 32 captured ~1 minute before #171 merged, so all 49 lacked #171's 7 new consolidation_* MEMORY/MEMORY_FINAL metrics.
- Re-ran all 35 std-tier tests against `release/0.14.4` HEAD; every std row now reports `version=0.14.4` and includes #171's added metrics (51 rows/test). The 14 XL `month-*` rows are preserved from the original capture (44 rows/test) because the XL corpus wasn't available on the machine doing this backfill.
- Filed #209 for a related portability issue (the benchmark records absolute file paths in FILES rows). `compare-results.sh` ignores FILES rows so the mixed paths in this baseline don't affect downstream comparisons.

## Test plan

- [ ] Inspect `tests/baseline/results/v0.14.4.tsv`: all 49 tests present, all `version=0.14.4`, 35 std rows at 51 metrics, 14 XL `month-*` rows at 44 metrics.
- [ ] Run `tests/baseline/compare-results.sh tests/baseline/results/v0.14.3-pre-release-135-137.tsv tests/baseline/results/v0.14.4.tsv` and confirm the report renders without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)