### PR TITLE
Fix #209: preserve caller-supplied file paths in benchmark TSV

### DIFF
--- a/ltl
+++ b/ltl
@@ -49,7 +49,6 @@ use Devel::Size qw(total_size);
 # Proc::ProcessTable is loaded conditionally in get_memory_usage() based on platform
 # On Windows, Win32::API calls K32GetProcessMemoryInfo directly (kernel32.dll)
 use List::Util qw(min max);
-use Cwd qw(abs_path);
 use File::Spec;
 use Text::CSV;
 use Text::CSV_PP;
@@ -7418,14 +7417,13 @@ sub print_verbose_output {
     print "=== BENCHMARK DATA ===\n";
     print "version\t$version_number\n";
 
-    # File metadata
+    # File metadata — preserve the paths as provided by the caller so baseline
+    # TSVs are portable across contributors / machines (issue #209).
     my $total_file_size = 0;
-    my @abs_paths;
     for my $f (@files_processed) {
         $total_file_size += (-s $f) // 0;
-        push @abs_paths, abs_path($f);
     }
-    print "FILES\t" . join(';', @abs_paths) . "\t$total_file_size\n";
+    print "FILES\t" . join(';', @files_processed) . "\t$total_file_size\n";
 
     print "lines_read\t$total_lines_read\n";
     print "lines_included\t$total_lines_included\n";

--- a/tests/baseline/run-benchmark.sh
+++ b/tests/baseline/run-benchmark.sh
@@ -17,9 +17,14 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../.."
 LTL="$SCRIPT_DIR/../../ltl"
 RESULTS_DIR="$SCRIPT_DIR/results"
-LOGS_DIR="$SCRIPT_DIR/../../logs"
+# Run from repo root so file args expand to repo-relative paths (issue #209).
+# ltl records whatever paths it was given in the FILES rows of the TSV, so
+# this is what makes baselines portable across contributors / machines.
+cd "$REPO_ROOT" || exit 1
+LOGS_DIR="logs"
 
 # Default label is timestamp
 LABEL="$(date +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
## Summary

- `ltl -V` was calling `abs_path()` on every input file before printing the `FILES` row, so baseline TSVs always recorded absolute paths and were machine-locked.
- `ltl` now preserves the paths as supplied by the caller; `tests/baseline/run-benchmark.sh` `cd`s to the repo root and uses repo-relative globs so new baseline captures record paths like `logs/ThingworxLogs/...` instead of `/Users/<whoever>/.../logs/...`.
- Existing committed baselines are intentionally left untouched as historical captures.

## Test plan

- [x] Run `./tests/baseline/run-benchmark.sh single-day-application-log-standard --label test` from repo root — FILES row is `logs/ThingworxLogs/...`.
- [x] Run the same from `/tmp` (script invoked via absolute path) — same relative FILES row, script is CWD-independent.
- [x] Run `./ltl --disable-progress -V <relative-path>` — relative path preserved.
- [x] Run `./ltl --disable-progress -V <absolute-path>` — absolute path preserved (whatever caller passed in).
- [x] Run `./tests/baseline/compare-results.sh tests/baseline/results/v0.14.4.tsv <new-tsv>` — produces a normal comparison report (FILES rows are filtered out, so format mix doesn't matter).

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)