### PR TITLE
Issue #225: research deliverables for all 9 sub-tasks + branch-naming rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,12 +146,30 @@ Hidden CLI options: `--disable-progress` (ALWAYS use from Claude Code), `--termi
 
 ## Development Workflow
 
-Each issue gets its own branch: `{issue-number}-{short-description}`. **CRITICAL: Verify branch before making code changes.** Do not write production code until implementation plan is approved.
+### Branch Naming (MANDATORY)
+
+Each issue gets its own branch named `{issue-number}-{semantic-slug-from-issue-title}`. The slug MUST be derived from the GitHub issue's title (kebab-cased, semantically tight) — **never** from the activity being performed on the branch.
+
+**Why this matters:** Branches outlive their initial purpose. A branch named after the current activity becomes misleading once it grows into other work. A branch named after the issue stays accurate through the whole lifecycle.
+
+**Examples:**
+- Issue #224 "Percentile-value regression test harness with tiered tolerance" → `224-percentile-value-harness` ✓
+- Issue #225 "Test-harness coverage gaps: high-priority additions..." → `225-test-harness-coverage-gaps` ✓
+
+**Anti-patterns — DO NOT use:**
+- `225-research` / `225-research-deliverables` — activity name, not issue title
+- `225-scaffolding` / `225-grounding` / `225-cleanup` — activity names
+- `225-fix-it` — vague activity description
+- Issue number without any slug — ambiguous
+
+If multiple branches are genuinely needed for one issue (rare), differentiate with a numeric suffix like `225-test-harness-coverage-gaps-2`, **not** with an activity name.
 
 ### Branch Verification (MANDATORY FIRST STEP)
 ```bash
-git branch --show-current  # Must match issue number
+git branch --show-current  # Must start with the issue number AND match the issue's semantic title
 ```
+
+**CRITICAL:** Verify branch before making code changes. Do not write production code until implementation plan is approved.
 
 ### GitHub Issue Updates (MANDATORY)
 Update issues throughout development: when starting, during investigation, on design decisions, and when complete. Close with `gh issue close <number> --reason completed`.

--- a/features/225-binary-smoke.md
+++ b/features/225-binary-smoke.md
@@ -1,0 +1,265 @@
+# Feature: Packaged-binary smoke-test harness (#227)
+
+## Overview
+
+This document is the **research and scoping deliverable** for issue #227, a sub-task of the [#225](https://github.com/gregeva/logtimeline/issues/225) umbrella for high-priority test-harness coverage gaps. #227 specifically covers smoke-testing the **PAR::Packer-bundled binaries** that the release workflow ships — not the `perl ltl` script that already runs under every other test in `tests/`.
+
+The failure mode this harness targets is: *`pp` succeeds, an artifact lands on disk, the build job exits 0, the GitHub Release attaches the file — and the binary segfaults or aborts on first invocation on a user's machine.* Today the only post-build assertion is `<binary> -version` greps for `[0-9]+\.[0-9]+\.[0-9]+`; that catches gross failures but not the broader class of runtime-only failures listed in §3.
+
+Framework dependency on [#226](https://github.com/gregeva/logtimeline/issues/226) (`-V` section selectivity) is weak. Smoke assertions can be limited to "binary runs, exits with the expected code, stdout is non-empty / contains a stable marker"; they do not require `-V` parsing.
+
+This is **scoping only** — no harness or production code is written here.
+
+## GitHub Issue
+
+[#227](https://github.com/gregeva/logtimeline/issues/227) (sub-task of [#225](https://github.com/gregeva/logtimeline/issues/225); weak dep on [#226](https://github.com/gregeva/logtimeline/issues/226)).
+
+## Sources
+
+- `build/macos-package.sh` (95 lines) — macOS native build.
+- `build/ubuntu-package.sh` (102 lines) — Ubuntu Docker build, amd64 + arm64.
+- `build/windows-package.sh` (173 lines) — Strawberry Perl under Wine, amd64 only.
+- `build/macos-setup.sh` — Homebrew Perl + PAR::Packer setup.
+- `build/generate-cpanfile.sh` — `use`/`require` scanner producing `build/cpanfile` and `build/cpanfile.windows`.
+- `.github/workflows/release-build.yml` (176 lines) — release pipeline.
+- `tests/validate-help-layout.sh` — sibling harness style reference.
+- `ltl:64` — `$version_number = "0.14.5"`; `ltl:1856` — `print "Version: $version_number\n\n"` (the literal currently grepped by the build scripts).
+
+## § 1. Build-pipeline inventory
+
+| Build script | Platform / arch | Tool invocation | Output filename | Build host requirements |
+|---|---|---|---|---|
+| `build/macos-package.sh` | macOS arm64 *or* x86_64 (must match host) | `perl -S pp -o $PACKAGE_NAME ltl` (line 60) | `ltl_static-binary_macos-{arch}` | Homebrew Perl on PATH, PAR::Packer, cpanfile installed. No cross-compile (line 49–57 warns and exits if host arch ≠ target). |
+| `build/ubuntu-package.sh` | Linux amd64 *or* arm64 | Inside `ubuntu:20.04` Docker, `--platform=linux/$arch`: `pp -o $PACKAGE_NAME ltl` (line 65) | `ltl_static-binary_ubuntu-{arch}` | Docker / Rancher Desktop; QEMU for arm64 emulation on amd64 hosts. Ubuntu 20.04 chosen for "broad glibc compatibility" (line 20). |
+| `build/windows-package.sh` | Windows amd64 only | Inside `ubuntu:20.04` Docker: `wine perl.exe -S pp -o ../$PACKAGE_NAME.exe ../ltl` (line 133) | `ltl_static-binary_windows-amd64.exe` | Docker + Wine + Strawberry Perl portable ZIP (downloaded fresh per run). Windows arm64 explicitly unsupported (line 29–31). |
+
+All three scripts already run a `-version` smoke check inside the build container (`macos-package.sh:79–89`, `ubuntu-package.sh:85–95`, `windows-package.sh:154–166`) and grep for `[0-9]+\.[0-9]+\.[0-9]+`. That check confirms the binary launches at all and emits *a* version line. It does not exercise log parsing, optional code paths, or error handling.
+
+Note: `windows-package.sh` is "best-effort" — its grep failure is downgraded to `[warn]` (line 164) and proceeds, because the Wine-on-CI environment is fragile. This is the single biggest blind spot in the current pipeline.
+
+## § 2. CI workflow inventory
+
+`.github/workflows/release-build.yml` triggers on `push` of any `v*` tag, or `workflow_dispatch`. Four build jobs, then one `release` job:
+
+| Job | Runner | Steps | Artifact uploaded |
+|---|---|---|---|
+| `build-macos` | `macos-latest` | `macos-setup.sh` → `macos-package.sh arm64` → `./ltl_static-binary_macos-arm64 -version` (line 40) | `ltl_static-binary_macos-arm64` |
+| `build-ubuntu` (matrix amd64+arm64) | `ubuntu-latest` | `generate-cpanfile.sh` → `ubuntu-package.sh $arch` → for amd64 `./binary -version`; for arm64 only `file` (line 76–82) | `ltl_static-binary_ubuntu-{arch}` |
+| `build-windows` | `ubuntu-latest` | `generate-cpanfile.sh` → `windows-package.sh` (Wine-based `-version` check is internal to script) | `ltl_static-binary_windows-amd64.exe` |
+| `release` | `ubuntu-latest`, `needs: [...]`, tag-only | Download all artifacts → flatten into `release/` → `softprops/action-gh-release@v2` attaches them | — |
+
+What is **already asserted** about each binary today:
+- macOS arm64: `-version` on the actual runner (line 39–40).
+- Ubuntu amd64: `-version` on the actual runner (line 79–81). Ubuntu arm64: only `file` (line 77–78) — no execution because the runner is amd64 and QEMU-emulated execution of a PAR-packed binary is unreliable.
+- Windows amd64: `-version` *inside the build Docker container under Wine*, with grep failure downgraded to warning. The artifact itself is **never executed on a real Windows host**.
+
+What is **never asserted** today:
+- Heatmap/histogram/percentile code paths exercising modules that `pp` may not have detected statically.
+- Error-path exit codes (e.g. nonexistent input file).
+- Architecture / format consistency between the artifact and the platform label (the build scripts trust the build host but the upload step does not re-verify).
+- Ubuntu arm64 actual execution.
+- Windows execution on a real Windows host.
+
+## § 3. PAR::Packer failure modes
+
+These are the classes of "build succeeds but binary fails" that a smoke harness can plausibly catch. Drawn from PAR::Packer issue tracker, project `build_notes`, and direct experience with this codebase.
+
+| Class | Cause | Detection cost |
+|---|---|---|
+| **Missing bundled module** | `pp`'s static `Module::ScanDeps` misses a runtime-only `require` (common with `eval "require ..."` or dynamic class loading). Reproduced historically with `Win32::API`, `PDL::*` (per `build/packaging-notes:53–67`). | A single full-flow invocation against a small log catches almost all of these. |
+| **Architecture mismatch** | arm64 binary handed to an x86_64 user, or vice-versa. macOS would refuse with "Bad CPU type"; Linux with `Exec format error`. | A simple `file` check + `-version` execution on the matching arch covers this. |
+| **glibc / libc version mismatch** | Binary built on newer Linux (glibc 2.39) fails on user's older Linux (glibc 2.31) with `version 'GLIBC_2.34' not found`. Ubuntu-20.04-as-build-base (line 20) is the existing mitigation. | Detected only by running on the *oldest supported* target. Beyond pure smoke; flag as a separate concern (see §11 open questions). |
+| **Inline::C cache pollution** | Stray `_Inline/` directory carried into the PAR archive causes `pp` to bundle stale compiled `.so` files. Per `MEMORY.md`, `_Inline/` is now `.gitignored`. The prototype's `--inline-c` path is opt-in, so production `ltl` should not embed compiled C — but a regression here would slip past `pp`. | A clean checkout in CI normally avoids this. Local-iteration story (§10) must spell out: never copy `_Inline/` into the `pp` working directory. |
+| **Encoding / locale dependency** | `Encode::*` sub-modules not bundled, surfacing only on non-ASCII input or unset `LC_ALL`. | The Windchill Apache fixture contains UTF-8 paths and would catch this. |
+| **Missing shared library** | `Term::ReadKey`, `Proc::ProcessTable`, etc. link against system `.so` files that PAR cannot bundle. On a stripped-down user host (alpine, BusyBox) the binary aborts. | Out of scope for in-repo smoke (no minimal-base CI runner today). Note in §11. |
+| **`Cwd::abs_path` / `__FILE__` resolution** | PAR rewrites `$0` to a temp extraction path; code that does `dirname(__FILE__) . "/patterns/"` finds nothing. ltl reads pattern files via `-if/-ef/-hf`, so this is a *user-data* concern, not a packaging one — but worth a one-line probe. | A `-ef patterns/probes <log>` invocation would catch it. |
+| **Wine-only artifact divergence** | The Windows binary is *built under Wine*. Wine's Perl behaves; native Windows Perl may differ on path-separator and `binmode` edge cases. | Only catchable by running on a real Windows runner (`windows-latest`). |
+
+## § 4. Minimum-viable smoke assertions
+
+Ranked by signal-per-second:
+
+1. **`<binary> --help` → exit 0, stdout contains `ltl` and `Usage:`.** Cheapest; catches "binary won't launch at all" and "help renderer crashed". Already partially exercised by `tests/validate-help-layout.sh`, but only against the Perl script.
+2. **`<binary> -v` (or `--version`) → exit 0, stdout matches `^Version: \d+\.\d+\.\d+`.** Already done; keep.
+3. **`<binary> --disable-progress <tiny-log>` → exit 0, stdout non-empty, contains the standard banner `,:: ltl ::'`.** This is the smallest end-to-end invocation that exercises file open, regex compile, and bar-graph render. Catches the largest set of "missing module" cases.
+4. **`<binary> --disable-progress -hm duration <tiny-log>` → exit 0, stdout non-empty.** Exercises the heatmap code path, which uses different modules than the default bar graph. Cheap insurance against `pp` missing an optional dependency.
+5. **`<binary> /nonexistent-file 2>&1` → exit non-zero.** Negative-case; see §9.
+
+Stretch (skip for v1):
+- `-hg latency` (histogram) — overlaps heatmap, marginal additional coverage.
+- `-V <tiny-log>` — depends on #226 stabilising the section format; not required.
+
+**Recommended v1 set: assertions 1, 2, 3, 5.** Assertion 4 is *recommended* but acknowledged as overlapping with 3 once #226 is in; defer to "post-#226" if budget pressure.
+
+## § 5. Test-log fixture
+
+Candidates and trade-offs:
+
+| Candidate | Size | Issue |
+|---|---|---|
+| `logs/AccessLogs/localhost_access_log.2025-03-21.txt` | 2.6 MB | **Do not use** — MEMORY.md flags corruption (`feedback_test_logs.md`). |
+| `logs/Codebeamber/codebeamer_access_log.2025-10-29.txt` | 83 KB (741 lines) | Smallest clean access log in the repo. Real-world data; exercises Tomcat access-log parser. |
+| `logs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log` | larger | Already used elsewhere as a "known-good" fixture; overkill for smoke. |
+| New `tests/smoke-fixtures/binary-smoke.log` | hand-crafted, ~10 lines | Deterministic, minimal, easy to diff. But synthetic — risk of not matching any real log format ltl supports. |
+
+**Recommendation: a new hand-crafted fixture at `tests/smoke-fixtures/binary-smoke.log` (~10 lines, Tomcat access format with millisecond durations).** Rationale: (a) deterministic output is essential when the harness greps stdout, (b) it should not change when an unrelated `logs/` file is re-organised, (c) it should be small enough that any noticeable change in execution time signals a real problem, (d) the Codebeamer file is 741 lines and would still produce ~100ms of output to grep through. Synthesise it once, commit it, never touch it.
+
+Output assertion against this fixture is the *banner*, not statistics — keeping the harness immune to format changes.
+
+## § 6. CI integration design
+
+Three options:
+
+| Option | Shape | Pros | Cons |
+|---|---|---|---|
+| **(a) Per-platform inline** | Add a `Smoke test` step to each `build-*` job, before `Upload artifact`. | Fails fast; the failing job's logs explain which platform broke. Minimal new infra. | Duplicate harness wiring across four jobs (mitigated by a shared script). |
+| **(b) Unified post-build job** | New `smoke` job, `needs: [build-macos, build-ubuntu, build-windows]`, downloads all artifacts, runs harness inside a matrix of runners (macos-latest, ubuntu-latest, ubuntu-24.04, windows-latest). | Tests on the *intended user runtime*, not the build host. Catches the Wine-vs-native-Windows class. Single harness invocation. | Adds ~3 min to release; another job to debug if it fails. |
+| **(c) Both** | Inline per-platform sanity (a) + unified parity (b). | Belt-and-suspenders. | Doubles smoke runtime; mostly redundant. |
+
+**Recommendation: (b) unified post-build job, with a `windows-latest` runner specifically to validate the Wine-built `.exe` on real Windows.** Rationale: the Ubuntu arm64 and Windows artifacts today are *not actually executed on their target platforms anywhere in CI* (§2). A unified post-build job is the smallest change that closes both gaps. The existing inline `-version` checks in the build scripts can stay as a fast-fail filter; they already are.
+
+The new job matrix should include at minimum: `{os: macos-latest, artifact: macos-arm64}`, `{os: ubuntu-latest, artifact: ubuntu-amd64}`, `{os: windows-latest, artifact: windows-amd64.exe}`. Ubuntu arm64 actual execution is harder (no native arm64 runner on free tier) — defer with an explicit `file`-only check, same as today.
+
+## § 7. Cross-platform mechanics
+
+The harness must handle three target runtimes:
+
+- **macOS arm64** — bash, native shell-out fine. Use `bash`.
+- **Linux amd64** — bash, native. Use `bash`.
+- **Windows amd64** — `windows-latest` GitHub runner ships Git Bash, PowerShell, and `pwsh`. PAR-packed `ltl_static-binary_windows-amd64.exe` is a self-extracting exe; it runs from any of them. Path separator is `\`; `--disable-progress -- <log>` argument passing is unaffected.
+
+**Recommendation: bash harness, invoked via Git Bash on Windows (`shell: bash` in GitHub Actions).** Git Bash is preinstalled on `windows-latest`. This keeps one harness script. Alternatives considered:
+- *PowerShell + bash twins*: doubles maintenance. Rejected.
+- *Perl driver*: would need Perl installed on the smoke runner; the whole point is that the user does not have Perl. Rejected.
+
+Caveats for Windows specifically:
+- Capture exit code via `$?` after the command, not via `;` chaining (cmd.exe semantics leak through some Git Bash builds).
+- Use forward slashes in paths — Git Bash translates.
+- Expect the `.exe` extension; the artifact filename already includes it.
+
+## § 8. Failure-handling story
+
+When a platform's smoke fails:
+
+| Posture | Behaviour | Recommendation |
+|---|---|---|
+| Block entire release | Any smoke failure → `release` job does not run → no Release attached. | **Yes, default.** Shipping a known-broken binary to users is worse than a delayed release. |
+| Per-platform partial-release | Failing platform's artifact omitted from the GitHub Release; others ship. | Tempting but adds complexity; the `softprops/action-gh-release@v2` step would need conditional `files:` patterns. Users on the omitted platform have no signal that they should wait. Reject for v1. |
+| Warn-and-decide | Smoke job records failure but does not block. Human reviews and re-runs / overrides. | Useful as a *transient* posture during initial rollout, when the harness might have false positives. Implement as a `continue-on-error: true` toggle that defaults to `false`. |
+
+**Recommendation: block by default, with a `workflow_dispatch` input `allow-smoke-failure` for emergency overrides.** This keeps the safe default while leaving an audited bypass.
+
+## § 9. Negative tests
+
+`<binary> /nonexistent-file 2>&1; echo $?` asserts exit code is non-zero.
+
+Why bother: catches the failure mode where `pp` packaging mangles `die` handlers such that the binary silently exits 0 on a missing input. This has happened with PAR-packed Perl in the wild (truncated stderr, exit code reset by the PAR loader stub). It is cheap to add — one extra invocation.
+
+**Recommendation: include.** Worst case it asserts the obvious; best case it catches a class of regression that nothing else will. Pair it with a stdout check (`grep -i "no such file\|cannot open"`) for slightly stronger signal — but exit-code-only is sufficient for v1.
+
+## § 10. Local-iteration story
+
+A developer mid-investigation needs the same harness against a binary they just rebuilt:
+
+```
+./build/macos-package.sh arm64
+tests/validate-binary-smoke.sh ./ltl_static-binary_macos-arm64
+```
+
+The harness must:
+1. Take the binary path as `$1` (so the same script serves CI and local).
+2. Auto-detect platform from `uname` only when `$1` is omitted; otherwise trust `$1`.
+3. Look up the smoke fixture relative to `$0` (the harness path), not `$PWD`.
+4. Print pass/fail counts and exit non-zero on any fail.
+
+CI invocation is then just `tests/validate-binary-smoke.sh artifacts/ltl_static-binary_${os}-${arch}`.
+
+**Recommendation: single-script reuse, no separate CI/local entry points.** Mirrors the pattern of `tests/validate-help-layout.sh`.
+
+## § 11. Application-observability gaps
+
+Reviewed for completeness; mostly empty.
+
+| Possible addition | Recommendation |
+|---|---|
+| `-V version` section emitting `version<TAB>0.14.5` | Already exists at `ltl:7419` inside `=== BENCHMARK DATA ===`. Sufficient. `225-help-content.md §6a` reached the same conclusion. Do not duplicate. |
+| `--smoke` mode running internal self-checks | Overkill. The smoke surface is "does it run at all", which is observable by *running it*. Reject. |
+| Banner-line stable marker (`,:: ltl ::'` at `ltl:1571`) | Already stable; harness can grep it. No code change. |
+| Stable error-marker on file-not-found | Not currently grep-asserted; if §9 negative test wants a stdout pattern, the existing `die` message suffices. No change. |
+
+## § 12. ltl code changes required
+
+**None.** The harness is purely external observation. The existing `-v`, `-version`, `--help`, and banner output give the harness everything it needs.
+
+Optional (zero-cost, non-blocking): co-locate the smoke fixture at `tests/smoke-fixtures/binary-smoke.log` so the path is stable across release branches.
+
+## § 13. Harness-shape proposal
+
+**Filename**: `tests/validate-binary-smoke.sh`.
+
+**Usage**:
+```
+tests/validate-binary-smoke.sh [<path-to-binary>]
+```
+Default `$1`: auto-detect (`./ltl_static-binary_$(uname -s)-$(uname -m)`).
+
+**Outline** (no implementation):
+
+1. Resolve binary path; assert existence and executable bit.
+2. Resolve fixture path (`$SCRIPT_DIR/smoke-fixtures/binary-smoke.log`); assert exists.
+3. Assertion A: `<binary> --help` exits 0, stdout contains `Usage:` and `ltl`.
+4. Assertion B: `<binary> -v` exits 0, stdout matches `^Version: \d+\.\d+\.\d+`.
+5. Assertion C: `<binary> --disable-progress <fixture>` exits 0, stdout contains banner marker `,:: ltl ::'`.
+6. Assertion D: `<binary> --disable-progress -hm duration <fixture>` exits 0, stdout non-empty. *(optional v1)*
+7. Assertion E (negative): `<binary> /nonexistent-file-xyz` exits non-zero.
+8. Print `PASS N / N` summary; exit 0 iff all pass.
+
+**Cross-platform notes**: pure POSIX-friendly bash; no GNU-only flags. Use `command -v file` defensively (Git Bash may not have `file`). Wrap binary invocations with explicit `2>&1` so Windows stderr funnels into the captured stdout.
+
+**CI wiring** (`.github/workflows/release-build.yml`):
+
+```yaml
+smoke:
+  needs: [build-macos, build-ubuntu, build-windows]
+  strategy:
+    matrix:
+      include:
+        - {os: macos-latest, artifact: ltl_static-binary_macos-arm64}
+        - {os: ubuntu-latest, artifact: ltl_static-binary_ubuntu-amd64}
+        - {os: windows-latest, artifact: ltl_static-binary_windows-amd64.exe}
+  runs-on: ${{ matrix.os }}
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with: {name: '${{ matrix.artifact }}', path: .}
+    - shell: bash
+      run: |
+        chmod +x ${{ matrix.artifact }} || true
+        ./tests/validate-binary-smoke.sh ./${{ matrix.artifact }}
+```
+
+Then update `release` job's `needs:` to include `smoke`.
+
+## § 14. Open questions for human review
+
+1. **Ubuntu arm64 actual execution** — GitHub Actions has no free-tier native arm64 Linux runner. Options: (a) accept the `file`-only check we already have; (b) self-hosted runner; (c) QEMU emulation in CI. Recommend (a) for v1; revisit after the harness lands.
+2. **Smoke-fixture format** — synthesise a 10-line Tomcat access log? Or include both an access log and a Java-style application log to exercise both timestamp regexes? Single fixture keeps the harness simple; two doubles surface coverage. Recommend one to start, add second only if a failure escapes that the second would have caught.
+3. **Windows native vs. Wine parity** — should the harness compare *stdout byte-for-byte* between Wine-built `.exe` running under Wine in build and the same `.exe` running on `windows-latest`? Tempting but brittle. Recommend: same assertion set, not byte-diff.
+4. **Block-vs-warn on smoke failure** — confirm §8 recommendation (block by default) is acceptable.
+5. **glibc compatibility check** — the harness as scoped runs on the *latest* `ubuntu-latest` runner, which has the newest glibc. The old-glibc protection lives entirely in `ubuntu:20.04` as the build base. Worth adding a separate `ubuntu-22.04` or container-based smoke step to catch glibc regressions? Defer; raise as a follow-up issue if it ever bites.
+6. **Negative-test stdout grep** (§9) — exit-code-only, or also assert stderr contains "no such file"? Recommend exit-code-only for v1.
+
+## § 15. Effort estimate
+
+**Overall: LOW–MEDIUM.**
+
+| Component | Effort |
+|---|---|
+| `tests/smoke-fixtures/binary-smoke.log` (hand-crafted ~10 lines) | 30 min |
+| `tests/validate-binary-smoke.sh` implementation | 2–3 h |
+| `.github/workflows/release-build.yml` smoke job (matrix + wiring) | 1 h |
+| First-run CI debugging (cross-platform path quirks, Windows-specific) | 1–2 h |
+| Documentation (one paragraph in `build/build_notes` or README, optional) | 15 min |
+| **Total** | **~half-day to one full day** |
+
+No prototypes or experiments needed. The risk is concentrated in (a) Windows path handling in Git Bash and (b) Wine-built `.exe` behaviour on real Windows — both deferred to first-run debugging.

--- a/features/225-cli-validation.md
+++ b/features/225-cli-validation.md
@@ -1,0 +1,275 @@
+# Feature: CLI option-parsing and flag-interaction harness (#231)
+
+## Overview
+
+Research/scoping deliverable for #231 (sub-task of #225). Covers four contracts with no automated regression coverage today: value validation (out-of-range, wrong-type, unknown-enum), flag-interaction rules (conflict/precedence/implication), invalid-input handling, and error-message quality. Sibling deliverables `features/225-help-content.md` and `features/225-pattern-files.md` already enumerated the GetOptions surface and filter loading; this picks up from the *resolution and validation* phase inside `adapt_to_command_line_options()`.
+
+Framework dependency: **#226** (`-V` section/category selectivity). The harness itself is unblocked; the highest-value assertion class — a `-V option-resolution` per-flag annotation — needs #226 first.
+
+## § 1. Option-resolution code: structure and citations
+
+`adapt_to_command_line_options()` lives at **`ltl:4080–4418`** (339 lines). Read end-to-end, it executes the following phases in source order:
+
+| Phase | Lines | Concern |
+|------:|-------|---------|
+| 1 | 4081–4088 | Capture `@ORIGINAL_ARGV`; splice `LTL_CONFIG` env tokens at the front of `@ARGV` via `shellwords`. |
+| 2 | 4090 | Legacy alias rewrite: `-?`, `/help`, `/?` → `--help`. |
+| 3 | 4092–4168 | `GetOptions(...)` — 75 entries (see `225-help-content.md` § 1); single `or die print_usage(...)` exit. |
+| 4 | 4170–4171 | Promote `--start` / `--end` into `%filter_range`. |
+| 5 | 4174–4189 | Consolidation (`-g`) value resolution: empty-string default → 85; numeric clamp to 50..99; non-numeric value treated as positional (pushed back to `@ARGV`). |
+| 6 | 4192–4216 | Heatmap (`-hm`) value resolution: empty → `duration`; unknown built-in metric routed to UDM-or-filename branch; `time` aliased to `duration`; auto-detect light bg unless overridden. |
+| 7 | 4222–4239 | Histogram value validation: four independent clamps (`-hgbpd<1`, `-hgb<0`, `-hgh<3`, `-hgw<20`/`>100`), each emits a `warn` and overrides to a known-good default. |
+| 8 | 4248–4265 | Percentile-mode (`-pp` / `-pbpd`) resolution per features/187 § Decision 2 + features/189 § C7. Sets `$percentile_precision_source` for the `=== BIN-COUNTER MODE ===` -V section. |
+| 9 | 4267–4275 | Enum validation (hard die): `-du` (`ns\|us\|ms\|s`), `-ru` (`s\|m\|h\|d`). |
+| 10 | 4277–4287 | Build compiled filter matchers (`-i/-e/-h` + `-if/-ef/-hf`). |
+| 11 | 4289–4300 | Push merged filter regex strings into `@verbose_output`. |
+| 12 | 4302–4310 | Short-circuit exits: `-v` → `print_version` + `exit`; `--help` → `print_help` + `exit`. |
+| 13 | 4312–4318 | In-process glob; reject non-file entries; die if `@in_files` empty. |
+| 14 | 4319–4349 | `-so` value validation: hard die unless in the 23-entry whitelist; map to internal `$sort_key`. |
+| 15 | 4351–4392 | UDM parse + heatmap/histogram UDM-metric resolution (hard die on unknown). |
+| 16 | 4394 | `$output_timestamp_format` extension for `-s`/`-ms`. |
+| 17 | 4395–4415 | Reconstruct positional argument list for CSV header (`$csv_file_args`). |
+
+**Not a uniform validator**: GetOptions is syntactic; phases 5–8 do semantic clamps with `warn`; phases 9, 14, 15 do enum validation with `die`; phase 13 does I/O validation. The closest thing to a central error helper is `print_usage($msg)` (`ltl:1579–1586`), used by five `die` sites (4168, 4269, 4274, 4318, 4319). The two hard-die sites at 4362 and 4381 print raw `Error: ...` strings instead — minor inconsistency.
+
+## § 2. Flag-interaction inventory
+
+Every interaction rule, located in source, with current behavior:
+
+| # | Flags involved | Rule | Behavior | Line |
+|---|---|---|---|------|
+| 1 | `-pbpd` vs `--percentile-precision` | `-pbpd` wins | Warn-equivalent (annotated in `-V` only) | 4256–4259 |
+| 2 | `--percentile-precision` value | Must be 1..9 | Warn + clamp to 5 | 4250–4253 |
+| 3 | `-pbpd` value range | Must be 4..616 | Warn + clamp to 53 | 4261–4265 |
+| 4 | `--exact-percentiles` | Disables bin-counter consumers | Silent (annotated in `-V`) | 1281–1286, 1322 |
+| 5 | `-g` value (`group-similar:s`) | Empty → 85; clamp 50..99; non-numeric → pushed back | Silent clamp + ARGV rewrite | 4174–4189 |
+| 6 | `-hm` value (`heatmap:s`) | Empty → `duration`; `time` → `duration`; unknown built-in → UDM-or-filename | Silent default + ARGV rewrite | 4192–4210 |
+| 7 | `-hgbpd` | Must be ≥1 | Warn + reset to 8 | 4223–4226 |
+| 8 | `-hgb` | Must be ≥0 | Warn + reset to 0 | 4227–4230 |
+| 9 | `-hgh` | Must be ≥3 | Warn + clamp to 3 | 4231–4234 |
+| 10 | `-hgw` | Must be 20..100 | Warn + reset to 95 | 4235–4238 |
+| 11 | `-du` | Must be `ns\|us\|ms\|s` | Hard die via `print_usage` | 4268–4271 |
+| 12 | `-ru` | Must be `s\|m\|h\|d` | Hard die via `print_usage` | 4274–4275 |
+| 13 | `-so` | Must be one of 23 enum values | Hard die via `print_usage` | 4319 |
+| 14 | `-hm <udm>` | UDM name must exist after `parse_udm_configs` | Hard die, custom message | 4354–4363 |
+| 15 | `-hg <udm>` | Same as #14 | Hard die, custom message | 4367–4382 |
+| 16 | `-s` vs `-ms` | Both set both → `-ms` wins | Silent: elsif at 4484 | 4482–4488 |
+| 17 | `-hs` vs `-is` | Compatible (different layers) | Silent | n/a |
+| 18 | `--help` | Short-circuit, suppresses all later validation | exit 0 | 4307–4310 |
+| 19 | `-v` / `--version` | Short-circuit, suppresses all later validation | exit (status from `exit;`) | 4302–4305 |
+| 20 | Unknown built-in metric name to `-hg` | Warn + skip | Warn-and-continue | 4073 |
+| 21 | Positional file arg: non-existent path | Glob expands to empty; `@in_files` empties; hard die "unable to open any files" | Hard die | 4313–4318 |
+| 22 | Positional file arg: directory | Filtered out by `grep { -f $_ }` at 4316 | Silent skip; if no files remain, dies #21 | 4316 |
+| 23 | `LTL_CONFIG` env var | Tokens prepended to `@ARGV` | Silent (echoed only under `-V`) | 4084–4088, 4292–4294 |
+| 24 | `-bs` with `-ms` | `bucket_size_seconds = bs/1000`; no minimum | Silent; no clamp (potential bug) | 4485 |
+| 25 | `-tw` (hidden) overrides `GetTerminalSize()` | Direct assignment | Silent | 4163 + read in `adapt_to_terminal_settings` |
+
+Notes: row 1's `-V`-only annotation is the **#189 prototype** at `ltl:1278–1327` — the model for this issue's annotation contract. Rows 21–22 share a single diagnostic ("unable to open any files"). `-hm` and `-hg` are *not* mutually exclusive; layout code at `ltl:1332–1337` treats them as additive.
+
+## § 3. Current user-feedback categorization
+
+| Category | Examples (row #s) | Count |
+|---|---|---|
+| **Hard error + non-zero exit** (`die`) | 2 (GetOptions parse), 11–15, 21 | 7 distinct sites |
+| **Warning + override** (`warn` to stderr, run continues) | 2, 3, 7–10, 20 | 7 |
+| **Silent override** (no message, behavior changes) | 1, 4, 5, 6, 16, 24, 25 | 7 |
+| **Silent ignore** | 17, 22 (when other files supplied), 23 (LTL_CONFIG without `-V`) | 3 |
+| **Annotated in `-V` only** | 1, 4 (these overlap "silent" until user runs `-V`) | 2 |
+
+**Exit codes.** All `die` sites in this subroutine exit `255` (Perl's `$! || 255` default). No `exit(1)`/`exit(2)` tiering exists. See § 8.
+
+## § 4. Silent-override gaps
+
+Highest-priority candidates for a `warn` or a `-V option-resolution` annotation:
+
+1. **`-pbpd` overriding `--percentile-precision`** (row 1). Annotated in `=== BIN-COUNTER MODE ===` only — non-`-V` users see nothing. Recommend stderr warn *and* `-V` annotation.
+2. **`--exact-percentiles`** (row 4) — documented as deprecated. A deprecation warning on every run is appropriate.
+3. **`-g <non-numeric>` pushed back into `@ARGV`** (row 5, `ltl:4181`). `ltl -g logfile` silently sets threshold=85 and feeds `logfile` back as positional. If user meant `-g 90`, no feedback.
+4. **`-hm <unknown>` pushed back as filename** (row 6, `ltl:4202`). Same shape.
+5. **`-g` clamped to 50..99** (`ltl:4186–4187`). Silent.
+6. **`-s` + `-ms` both passed** (row 16). Silent; `-ms` wins.
+7. **`-bs` with `-ms` accepting tiny values** (row 24). `-bs 1 -ms` yields a 1ms bucket. Out of scope to fix; harness should pin current behavior.
+8. **`LTL_CONFIG` injection** (row 23). Echoed only under `-V`. Recommend `-V option-resolution` row carrying `(env LTL_CONFIG)` annotation; keeps stderr clean by default.
+
+## § 5. Observable surface today
+
+What's testable today:
+
+- **`=== BIN-COUNTER MODE ===`** (`ltl:1278–1327`) — structured `key: value (source)` lines covering `--exact-percentiles`, `-pp`, `-pbpd`. Prototype pattern.
+- **`=== Verbose ===`** (`ltl:4291–4299`) — four merged-regex lines (`include`/`exclude`/`highlight`/`threadpool-activity`). Free-form; no per-flag attribution.
+- **`=== BENCHMARK DATA ===`** (`ltl:7418–7481`) — TSV `CONFIG\t<key>\t<value>` rows for `terminal_width`, `time_bucket_size`, `bucket_size_seconds`, etc. **No source attribution** — `CONFIG terminal_width 120` doesn't reveal whether it came from `-tw 120` or `GetTerminalSize()`.
+- **stderr `warn(...)`** — interleaved with progress noise unless `--disable-progress`. Capturable; format-fragile.
+- **`die print_usage($msg)`** — stable two-line `Usage:` prefix + red `Error: $msg` (`ltl:1583`). Regex-matchable.
+
+Everything outside `=== BIN-COUNTER MODE ===` lacks source attribution; this is the gap.
+
+## § 6. Proposed `-V option-resolution` section
+
+### Scope decision
+
+Three options:
+
+- **(a) Full** — every flag's resolved value with source annotation.
+- **(b) Selective** — only flags whose resolved value differs from the default, plus override annotations.
+- **(c) Anomalies only** — only flags that triggered a conflict/override/clamp during resolution.
+
+**Recommendation: (b) Selective**, with (c) folded in as a guaranteed-emit subset. (a) means ~75 default-noise rows per run; (c) omits load-bearing context (e.g. effective bucket size). (b) bounds the section by what the user changed, includes every override by definition, and degrades to header-only on a defaults-everywhere run.
+
+### Proposed output
+
+For `ltl -V option-resolution -pp 5 -pbpd 100 -bs 60 logfile.log`:
+
+```
+=== OPTION RESOLUTION ===
+bucket-size: 60 (-bs 60)
+percentile-precision: 5 (--percentile-precision 5; overridden)
+percentile-buckets-per-decade: 100 (-pbpd 100)
+LTL_CONFIG: (empty)
+files: 1 matched (logfile.log)
+=== END OPTION RESOLUTION ===
+```
+
+For `ltl -V option-resolution -pbpd 9999 logfile.log` (clamp case):
+
+```
+=== OPTION RESOLUTION ===
+percentile-buckets-per-decade: 53 (-pbpd 9999 → clamped to default 53)
+files: 1 matched (logfile.log)
+=== END OPTION RESOLUTION ===
+```
+
+For `ltl -V option-resolution -g logfile.log` (push-back case):
+
+```
+=== OPTION RESOLUTION ===
+group-similar: 85 (-g without value → default 85)
+files: 1 matched (logfile.log)
+=== END OPTION RESOLUTION ===
+```
+
+Annotation tokens:
+
+- `(<flag> <value>)` — user-supplied.
+- `(default)` — would never emit under scope (b); listed for completeness.
+- `(<flag> <value>; overridden)` — user-supplied, then beaten by a higher-precedence flag.
+- `(<flag> <value> → clamped to default <N>)` — out-of-range, fell back to default.
+- `(<flag> <value> → clamped to <bound>)` — out-of-range, fell back to nearest bound.
+- `(env LTL_CONFIG)` — sourced from the env-var splice.
+
+### Dependency on #226
+
+The header `=== OPTION RESOLUTION ===` follows the #226 section-naming contract. Until #226 lands selectivity, emit unconditionally under `-V` (same as `=== BIN-COUNTER MODE ===` today). Acceptable interim.
+
+## § 7. Test matrix
+
+Table-driven. `EXIT` = exit code (current behavior). `STDERR_RE` = regex anchoring a match against the diagnostic. `-V ANNO` = expected row in `=== OPTION RESOLUTION ===` (post-implementation; "—" if no row expected).
+
+| # | Input fragment | EXIT | STDERR_RE | -V ANNO |
+|--:|---|--:|---|---|
+| 1 | `-pbpd 9999 <log>` | 0 | `Invalid -pbpd: 9999` | `percentile-buckets-per-decade: 53 (-pbpd 9999 → clamped to default 53)` |
+| 2 | `-pbpd 3 <log>` | 0 | `Invalid -pbpd: 3` | same shape, value 3 |
+| 3 | `-pbpd 617 <log>` | 0 | `Invalid -pbpd: 617` | same shape, value 617 |
+| 4 | `-pp 0 <log>` | 0 | `Invalid --percentile-precision: 0` | `percentile-precision: 5 (--percentile-precision 0 → clamped to default 5)` |
+| 5 | `-pp 10 <log>` | 0 | `Invalid --percentile-precision: 10` | same shape, value 10 |
+| 6 | `-pp 5 -pbpd 100 <log>` | 0 | (none today) | `percentile-precision: 5 (--percentile-precision 5; overridden)` + `percentile-buckets-per-decade: 100 (-pbpd 100)` |
+| 7 | `-bs abc <log>` | 255 | `^Value "abc" invalid for option bucket-size` (Getopt::Long) | n/a (die before annotation) |
+| 8 | `-bs -1 <log>` | 0 | (none today; runs with bs=-1; behavior undefined) | — (pin current behavior; raise separate ticket) |
+| 9 | `-so invalidfield <log>` | 255 | `Error: invalid sort type used` | n/a |
+| 10 | `-ru x <log>` | 255 | `Invalid rate unit 'x'` | n/a |
+| 11 | `-du x <log>` | 255 | `Invalid duration unit 'x'` | n/a |
+| 12 | `-hm bogus <log>` (no UDM) | 0 | (none today) | `heatmap: duration (-hm bogus → pushed back as positional)` |
+| 13 | `-hm bogus_udm <log> -udm 'real:ms:sum:/x/'` | 255 | `Error: Unknown heatmap metric 'bogus_udm'` | n/a |
+| 14 | `-hg bogus <log>` (no UDM) | 0 | `Unknown histogram metric: bogus` | `histogram: (no metrics selected; -hg bogus rejected)` |
+| 15 | `-g foo <log>` | 0 | (none today) | `group-similar: 85 (-g foo → non-numeric pushed back; default 85 applied)` |
+| 16 | `-g 49 <log>` | 0 | (none today) | `group-similar: 50 (-g 49 → clamped to 50)` |
+| 17 | `-g 100 <log>` | 0 | (none today) | `group-similar: 99 (-g 100 → clamped to 99)` |
+| 18 | `-hgbpd 0 -hg <log>` | 0 | `Invalid buckets-per-decade value: 0` | `histogram-buckets-per-decade: 8 (-hgbpd 0 → clamped to default 8)` |
+| 19 | `-hgh 1 -hg <log>` | 0 | `Histogram height too small: 1` | `histogram-height: 3 (-hgh 1 → clamped to 3)` |
+| 20 | `-hgw 19 -hg <log>` | 0 | `Invalid histogram width percent: 19` | `histogram-width: 95 (-hgw 19 → clamped to default 95)` |
+| 21 | `--bogus-flag <log>` | 255 | `Unknown option: bogus-flag` | n/a |
+| 22 | `-bs <log>` (no value) | 255 | `Option bucket-size requires an argument` | n/a |
+| 23 | `<no files>` | 255 | `Error: unable to open any files` | n/a |
+| 24 | `nonexistent.log` | 255 | `Error: unable to open any files` | n/a |
+| 25 | `/some/directory` | 255 | `Error: unable to open any files` | n/a |
+| 26 | `-s -ms <log>` | 0 | (none today) | `time-precision: ms (-ms; -s overridden)` |
+| 27 | `LTL_CONFIG="-bs 30" ltl <log>` | 0 | (none today, w/o -V) | `bucket-size: 30 (env LTL_CONFIG)` |
+| 28 | `LTL_CONFIG="--bogus" ltl <log>` | 255 | `Unknown option: bogus` | n/a |
+| 29 | `-ep <log>` | 0 | (recommend: deprecation warn) | `exact-percentiles: enabled (--exact-percentiles; deprecated)` |
+| 30 | `--help` (anywhere) | 0 | empty | n/a (short-circuit before section emission) |
+
+Rows 6, 12, 15–17, 26, 27 are **silent today**. Recommended two-stage rollout: ship the harness pinning current silent behavior as a regression baseline; flip those rows to assert the `-V option-resolution` annotation after #226 + § 6 lands.
+
+## § 8. Exit-code policy
+
+Three options:
+
+- **(a)** Decide here: tiered policy (0 success, 1 user input error, 2 system/I/O error).
+- **(b)** Document current ad-hoc behavior (everything = 255 via `die`) as the contract.
+- **(c)** File a separate issue; scope #231 to current behavior only.
+
+**Recommendation: (c) — file a separate issue.** Exit-code change is a backward-incompatible CLI contract that affects every shell pipeline using `ltl` in CI; deserves its own issue, release note, and deprecation path. #231's harness should pin current exit codes in column EXIT of § 7 so the future work has a regression baseline. Consistent with #225's deferred-items framing.
+
+## § 9. Backward-compatibility risk
+
+New stderr from § 4 warnings will diff any pipeline capturing `ltl 2>&1`. Mitigations:
+
+- The four high-value warnings (§ 4 rows 1, 5, 16) are gated on specific input shapes — users not passing the combo see no change.
+- `-V option-resolution` is gated on `-V`. Zero impact for non-`-V` runs.
+- The `--exact-percentiles` deprecation warning would hit every user of that flag — consistent with its documented-deprecated status.
+- Roll out in **one release**, called out in release notes. An `LTL_QUIET=1` escape hatch can be deferred unless someone complains.
+- Benchmark baselines (`tests/baseline/results/`) capture stderr via `2>&1`; release step 8/9 already re-baselines.
+
+## § 10. ltl code changes required
+
+| # | Item | Effort | Dep |
+|---|------|--------|-----|
+| 1 | Add `=== OPTION RESOLUTION ===` emitter (new sub `emit_option_resolution_verbose()`) following the `emit_bin_counter_mode_verbose()` template at `ltl:1275`. ~80 LoC. | S | #226 |
+| 2 | Track per-flag source string globals (mirrors `$percentile_precision_source` at `ltl:309`) for: `time_bucket_size`, `group_similar_sensitivity`, `heatmap_metric`, `histogram_*` (4 globals), `sort_type`, `print_seconds/print_milliseconds`, `terminal_width`, plus the env-var splice (LTL_CONFIG-sourced flags should carry the `(env LTL_CONFIG)` annotation). ~12 new globals. | M | — |
+| 3 | Replace the 7 `warn` calls at 4224, 4228, 4232, 4236, 4251, 4262, 4073 with a single helper `validation_warn($flag, $bad_value, $action)` that emits both stderr and an `@option_resolution_rows` entry. ~30 LoC. | S | — |
+| 4 | Add stderr warnings to 4 silent-override sites (§ 4 rows 1, 5, 16, plus a deprecation notice for `-ep` at GetOptions parse time). ~15 LoC. | S | — |
+| 5 | Normalize the two `die "Error: ..."` sites at 4362 and 4381 to use `die print_usage("Unknown heatmap metric ...")` for consistent error formatting. ~4 LoC. | XS | — |
+| 6 | Exit-code policy normalization | — | **Not in #231**; separate issue per § 8. |
+
+Net code change: **~140 LoC**, all inside `adapt_to_command_line_options()` + one new emitter sub. No data-structure changes outside the GLOBALS section.
+
+## § 11. Harness shape proposal
+
+**Filename**: `tests/validate-cli-options.sh` — bash, table-driven, mirroring `tests/validate-percentile-mode.sh`.
+
+**Fixture**: `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-4.2026-01-26.txt` truncated to 200 lines on first run. (Per MEMORY.md, avoid `localhost_access_log.2025-03-21.txt`.)
+
+**Steps**:
+
+1. Locate `ltl` relative to `$0`; abort if missing/non-executable. Truncate fixture to `tmp/`.
+2. Bash array of rows: `id\targs\texpect_exit\tstderr_regex\topt_res_regex` (the four columns of § 7).
+3. Per row, run `./ltl --disable-progress -V $args $sample`, capturing stdout/stderr to two temp files.
+4. **Assertion A**: exit code matches `expect_exit`.
+5. **Assertion B**: `grep -qE "$stderr_regex" stderr.txt` (skip if `-`).
+6. **Assertion C** (gated on `OPTION_RESOLUTION_AVAILABLE=1` until § 6 lands): extract `=== OPTION RESOLUTION ===` block; `grep -qE "$opt_res_regex"` (skip if `-`).
+7. One-line summary per row; non-zero exit on any failure.
+
+**Why bash**: shape matches `validate-percentile-mode.sh` (table-driven invocations + regex assertions), not `validate-help-content.sh` (source parsing). Each § 7 row maps 1:1 to a harness row — adding a flag interaction adds a row.
+
+## § 12. Open questions
+
+1. **Scope (b) vs (c) for `-V option-resolution`** (§ 6): selective (recommended) or anomalies-only? The default-everywhere run case is the disambiguator — should the section be empty (b) or just the header (c)?
+2. **Annotation grammar** (§ 6): is `(<flag> <value> → clamped to default <N>)` the right shape, or should clamps and overrides use distinct verbs (e.g. `; clamped` vs `; overridden`)? The locked #189 pattern uses semicolons exclusively.
+3. **Deprecation warning for `--exact-percentiles`** (§ 4 row 4): emit on every run or only under `-V`? Documented-as-deprecated argues for every run; harness-stability argues for `-V`-only.
+4. **Backward compatibility** (§ 9): is one-release rollout acceptable, or should the four new warnings be gated behind `LTL_STRICT=1` for one release before becoming unconditional?
+5. **Exit-code policy** (§ 8): confirm separate-issue scoping. If anyone objects, the harness has to assert specific tiered codes rather than current `255`-everywhere.
+6. **`-bs` with `-ms` and tiny values** (§ 2 row 24): out of scope, but should the harness pin current behavior with `-bs 1 -ms`? Recommend yes — captures any future regression.
+7. **`LTL_CONFIG` token attribution** (§ 4 item 8, § 6 example): when an env-supplied flag is overridden by a CLI flag of the same name, should the annotation be `(env LTL_CONFIG; overridden)` or `(env LTL_CONFIG; CLI override)`? Symmetry with the `-pbpd`/`-pp` pattern argues for the first.
+
+## § 13. Effort estimate
+
+**Overall: MEDIUM.**
+
+| Component | Effort |
+|-----------|--------|
+| ltl code changes (§ 10 items 1–5) | 1 day (gated on #226 for item 1) |
+| `tests/validate-cli-options.sh` implementation | 4–6 h |
+| CI wiring + first-run debugging | 1 h |
+| Backward-compatibility release-notes prose | 30 min |
+| **Total** | **1.5–2 days** (after #226) |
+
+The harness alone, pinning current behavior (including silent rows as current-state assertions), is **half a day** with no dependencies. Recommended path: ship the harness now; add the `-V option-resolution` section and flip assertions in a follow-up PR after #226. Preserves small-step iteration.

--- a/features/225-degenerate-inputs.md
+++ b/features/225-degenerate-inputs.md
@@ -1,0 +1,348 @@
+# Feature: Degenerate-input regression harness (#233)
+
+## Overview
+
+Research/scoping deliverable for **#233** (sub-task of **#225** — high-priority
+test-harness coverage gaps). #233 covers ltl's behavior on degenerate inputs:
+empty files, single-line files, files with no parseable timestamps, all-filtered
+runs, and time-range exclusions. The risks are division-by-zero in percentile /
+stats code, `Use of uninitialized value` warnings leaking to stderr, summary
+tables with nonsensical content (e.g. epoch-zero timestamps), and silent
+"success" exits on what is morally an empty result.
+
+This document **does not propose implementation**. It enumerates cases, traces
+current behavior through ltl source, defines expected behavior, and recommends
+how to wire assertions through the `-V` sections being designed by sibling
+sub-tasks #228, #229, #230, and #231.
+
+## § 1. Enumerated degenerate cases
+
+| # | Label | Description |
+|---:|---|---|
+| (a) | `empty-file` | 0-byte file |
+| (b) | `whitespace-only` | newlines/tabs/spaces, no content |
+| (c) | `single-line-parseable` | one valid timestamped line |
+| (d) | `single-line-unparseable` | one line with no recognizable timestamp |
+| (e) | `many-lines-unparseable` | N>>1 lines, none match any format regex |
+| (f) | `all-filtered-by-pattern` | `-i` / `-e` excludes every line |
+| (g) | `all-filtered-by-time` | `-st` / `-et` excludes every line |
+| (h) | `single-bucket-only` | all data falls into one bucket |
+| (i) | `nonexistent-file` | path doesn't exist (cross-check with #231 row 21) |
+| (j) | `directory-arg` | path is a directory (cross-check with #231 row 22) |
+| (k) | `binary-garbage` | non-text file (e.g. `/bin/ls`) — corruption case |
+| (l) | `negative-time-range` | `-st > -et` — degenerate range itself |
+
+Cases (i)–(l) are added by the research — (i)/(j) are already covered by #231
+shared-error-path work, but a harness still needs assertions for them.
+
+## § 2. Current behavior — traced through source
+
+`@in_files` is populated and validated at `ltl:4312–4318`; a non-existent path
+or directory `die`s with `"unable to open any files"` at 4318 (cases i, j).
+After that, every accepted file enters `read_and_process_logs()` at `ltl:4523`,
+streamed line-by-line through a 13-format regex cascade (`ltl:4564–4774`, see
+`features/225-format-detection.md` § 1). Each parsed line increments
+`$total_lines_read` (`ltl:4572`); each line passing the format regex and any
+`-i`/`-e`/`-st`/`-et` filter increments `$total_lines_included` (`ltl:5053`)
+and updates `$output_timestamp_min`/`$output_timestamp_max` (`ltl:5039–5040`).
+
+After the read loop, control reaches:
+
+1. `initialize_empty_time_windows()` at `ltl:6407`. Iterates from
+   `$output_timestamp_min` to `_max` in bucket steps. Defaults are `0`
+   (`ltl:151–152`). With no data, the loop iterates exactly once (bucket 0 ≤ 0)
+   and creates one empty bucket — silent, no warning.
+2. `calculate_all_statistics()` at `ltl:6055`. The loop is `foreach my $bucket
+   ... keys %log_analysis` — an empty hash means the loop never executes. Safe.
+3. `calculate_statistics()` at `ltl:6365–6371` is guarded:
+   `return unless $occurrences > 0` and `return unless ... @{...durations}`.
+   Percentile indexing at `ltl:6396–6402` is therefore unreachable when
+   `duration_count == 0`. **No division-by-zero risk under existing guards.**
+   The bin-counter `percentile()` at `ltl:804–834` is also guarded
+   (`return (undef, 'none') if $total_N == 0`).
+4. `normalize_data_for_output()` (`ltl:6823`) protects scaling with explicit
+   `!= 0` guards (`ltl:7045`, `ltl:7046`, `ltl:7061`).
+5. `print_bar_graph()` at `ltl:7484` is gated by `if ($total_lines_included)`
+   (`ltl:7488`). The empty-graph fallback (`ltl:7757`) prints:
+   `Read $total_lines_read lines, however no lines matched any of the
+   patterns within the timeframe.`
+6. `print_summary_table()` (`ltl:8438`) **runs unconditionally**. With no data
+   it calls `strftime(..., gmtime(0))` (`ltl:8451–8452`), so the summary shows
+   `1970-01-01 00:00:00` as both min and max — visually meaningless but not a
+   crash. `LINES INCLUDED 0`, `LINES READ N` are emitted as usual.
+
+### Per-case behavior summary
+
+| # | Case | Crash? | Friendly msg? | Exit | Notes |
+|---:|---|---|---|---:|---|
+| a | empty | no | yes, line 7757 | 0 | summary table shows 1970 epoch |
+| b | whitespace | no | yes | 0 | identical to (a) |
+| c | single-line parseable | no | full graph | 0 | one-bucket render; stats may show `min=mean=max` |
+| d | single-line unparseable | no | yes | 0 | identical to (a); no signal it was a *format* failure |
+| e | many unparseable | no | yes | 0 | identical to (d) at the user level — **the format mismatch is invisible** |
+| f | all filtered by `-i`/`-e` | no | yes | 0 | summary shows `LINES READ > LINES INCLUDED = 0` |
+| g | all filtered by `-st`/`-et` | no | yes | 0 | indistinguishable from (f) at output level |
+| h | single-bucket-only | no | full graph | 0 | one bar; CV/stddev may be 0 — odd but valid |
+| i | non-existent file | yes (`die`) | yes via `print_usage` | 255 | shared with #231 |
+| j | directory arg | yes (`die`) | yes via `print_usage` | 255 | message says "unable to open any files" — misleading |
+| k | binary garbage | no | yes (no lines parse) | 0 | identical to (e); no corruption signal |
+| l | negative time range | depends | warns | 0 | `calculate_start_end_filter_timestamps` accepts; `_min > _max` produces zero-bucket loop |
+
+**Key observation:** cases (a)/(b)/(d)/(e)/(f)/(g)/(k) all collapse to the same
+single output line. The user cannot tell *why* there is no data.
+
+## § 3. Expected behavior — recommendation per case
+
+Per #231's research, **exit-code policy is deferred to a separate ticket.**
+This sub-task respects that and proposes only that exit codes be **made
+observable as-is**, not changed.
+
+| # | Case | Expected stdout/stderr | Expected exit |
+|---:|---|---|---:|
+| a | empty | "no lines read from <file> (file is empty)" | preserve current (0) |
+| b | whitespace | "no lines read from <file> (whitespace only)" | preserve (0) |
+| c | parseable | full graph as today | preserve (0) |
+| d | unparseable | "read 1 line; no parseable timestamps found — log format unrecognized" | preserve (0) |
+| e | many unparseable | "read N lines; no parseable timestamps found — log format unrecognized" | preserve (0) |
+| f | all filtered | "read N lines; all N lines excluded by include/exclude patterns" | preserve (0) |
+| g | all time-filtered | "read N lines; all N lines outside time range [start..end]" | preserve (0) |
+| h | single bucket | normal output; **no special treatment** | preserve (0) |
+| i | nonexistent | inherits #231 `print_usage` cleanup | preserve (255 today) |
+| j | directory | inherits #231 — message should say "is a directory", not "unable to open any files" | preserve (255 today) |
+| k | binary | identical to (e); no special branch | preserve (0) |
+| l | neg time range | warn at parse, but treat as case (g) at output | preserve (0) |
+
+The summary table at `ltl:8451–8454` should be **suppressed when
+`$total_lines_included == 0`** (or print "n/a" for min/max timestamps) — the
+1970 epoch display is a soft bug, not a crash.
+
+## § 4. Code-quality gaps (bounded changes)
+
+| # | Cases | Change | Effort |
+|---:|---|---|---:|
+| 1 | a–g, k | At top of post-read flow, branch on `$total_lines_included == 0` and emit a case-specific message instead of the single generic one at `ltl:7757`. The case is determined by counters already available (`$total_lines_read`, format-match count, filter-rejection count). | low |
+| 2 | a, b, d, e, k | Suppress summary table or emit "(no data)" placeholders when `$total_lines_included == 0` instead of `1970-01-01` strftime output (`ltl:8451–8454`). | low |
+| 3 | a–g | Add a small `%degenerate_reason` accumulator during read (one of `empty`, `whitespace`, `no_timestamps`, `all_pattern_filtered`, `all_time_filtered`). | low |
+| 4 | j | Distinguish directory from missing-file in the `ltl:4314–4318` validation — currently both fail with the same message. | trivial |
+| 5 | l | In `calculate_start_end_filter_timestamps` (`ltl:4421`), warn when `_start > _end`. | trivial |
+| 6 | n/a | **No division-by-zero fixes needed** — existing guards (`ltl:6368`, `6371`, `7045–7046`, `7061`, `834`) cover the percentile/scale paths. The harness should **assert** this rather than fix something. | n/a |
+
+Total scope: roughly half a day of fixes plus harness work.
+
+## § 5. Synthetic fixture strategy
+
+**Recommendation: generate at test time inside the harness for all cases except
+(c), (e), (h).**
+
+Rationale: cases (a)–(b)/(d)/(k)/(l) are trivially expressible as `: >`,
+`printf "\n\n\t\n"`, `echo "no timestamp"`, `head -c 256 /usr/bin/ls`,
+`-st > -et` — checking these into the repo adds noise. Cases (c), (e), (h) are
+substantive enough (a real timestamped line, ~50 unparseable lines that *look*
+plausible, a 3-line single-bucket sample) that they deserve files under
+`tests/degenerate-fixtures/`.
+
+This mirrors #230's split: synthetic minimal-content fixtures under
+`tests/filter-fixtures/` are committed; trivial degenerate inputs are
+ephemeral.
+
+## § 6. Observable surface today
+
+Per § 2 and per `features/225-format-detection.md` § 3 and
+`features/225-filter-logic.md` § 5:
+
+- No `-V` section today reports degenerate-input state.
+- The empty-result message at `ltl:7757` is human-readable only — no
+  per-case slug, no machine-parseable form.
+- `=== BENCHMARK DATA ===` (`ltl:7430–7431`) carries `lines_read` /
+  `lines_included` — these distinguish (a/b/d/e) from (f/g) but not from each
+  other.
+- `print_summary_table()` (`ltl:8508–8509`) carries the same two counters in
+  human form.
+
+The format-detection deficit identified by #228 is the load-bearing gap for
+cases (d)/(e)/(k) — without per-file `match_type` observability, "no parseable
+timestamps" is indistinguishable from "empty file".
+
+## § 7. Application-observability — recommend Option C (coordinated)
+
+- **Option A** — single `no_data: yes/reason: <slug>` on `=== FILTER SUMMARY ===`
+  conflates format/parse failures with filter failures. Reject.
+- **Option B** — new `=== DEGENERATE INPUT ===` section. Cleanest, but
+  duplicates state that #228 (format match counts) and #230 (filter inclusion
+  counts) already need to emit.
+- **Option C (recommended)** — reuse #228's `=== FORMAT DETECTION ===` for
+  cases (d)/(e)/(k) (`matched_lines: 0` per file, plus a new section-level
+  `no_parseable_timestamps: yes` if every file is zero), and #229/#230's
+  `=== FILTER SUMMARY ===` for cases (f)/(g) (`included: 0` plus a new
+  `degenerate_reason: all_pattern_filtered|all_time_filtered|...`). Cases
+  (a)/(b) get a one-line `=== FILTER SUMMARY ===` field `input_lines_read: 0`.
+
+Option C costs one new enum field in each of two already-proposed sections, no
+new section. The single ltl owner field is `degenerate_reason`, surfaced in
+`filter-summary` when `included == 0`. Enum values:
+`empty_input | no_parseable_timestamps | all_pattern_filtered |
+all_time_filtered | mixed`.
+
+## § 8. Assertion strategy — worked examples
+
+For each case the harness asserts (1) exit code, (2) stdout/stderr content,
+(3) the relevant `-V` section field, and (4) **no Perl warnings on stderr**
+(`grep -E 'Use of uninitialized value|Argument .* isn.t numeric' stderr` must
+return 0 hits).
+
+```
+Case (a) — empty-file
+  in:  : > $TMP/empty.log
+  cmd: ltl --disable-progress -V filter-summary $TMP/empty.log
+  exit:    0
+  stderr:  empty (no Perl warnings)
+  stdout:  contains "no lines read"
+  -V:      FILTER SUMMARY > input_lines_read: 0
+           FILTER SUMMARY > degenerate_reason: empty_input
+
+Case (e) — many unparseable
+  in:  yes "not a log line" | head -50 > $TMP/garbage.log
+  cmd: ltl --disable-progress -V format-detection,filter-summary $TMP/garbage.log
+  exit:    0
+  stderr:  empty
+  stdout:  contains "no parseable timestamps"
+  -V:      FORMAT DETECTION > <file> > matched_lines: 0
+           FILTER SUMMARY   > degenerate_reason: no_parseable_timestamps
+
+Case (f) — all filtered by include pattern
+  cmd: ltl --disable-progress -V filter-summary -i 'NEVER_MATCH' \
+        tests/degenerate-fixtures/single-bucket.log
+  -V:      FILTER SUMMARY > input_lines_read: 3
+           FILTER SUMMARY > included: 0
+           FILTER SUMMARY > degenerate_reason: all_pattern_filtered
+
+Case (g) — all filtered by time range
+  cmd: ltl --disable-progress -V filter-summary -st 1999-01-01 -et 1999-01-02 \
+        tests/degenerate-fixtures/single-bucket.log
+  -V:      FILTER SUMMARY > degenerate_reason: all_time_filtered
+
+Case (h) — single-bucket-only
+  cmd: ltl --disable-progress -V format-detection \
+        tests/degenerate-fixtures/single-bucket.log
+  exit:    0
+  stderr:  empty
+  stdout:  must contain bar graph (one row), summary table with LINES INCLUDED 3
+  -V:      FORMAT DETECTION > matched_lines >= 3
+  Negative assertion: no division-by-zero warning; min/mean/max present.
+```
+
+The no-Perl-warnings assertion is the highest-value cheap signal — it catches
+silent regressions in the percentile / scaling guards if any future refactor
+removes them.
+
+## § 9. Coordination with other sub-tasks
+
+| Field | Owner | Sub-task |
+|---|---|---|
+| `=== FORMAT DETECTION ===` section spec | #228 | shared consumer here |
+| `matched_lines: 0` per-file detection | #228 | this sub-task asserts the field exists and is correct on cases (a)/(d)/(e)/(k) |
+| `=== FILTER SUMMARY ===` section spec | #229 + #230 | shared consumer here |
+| `input_lines_read`, `included`, `excluded` counters | #229/#230 | cases (f)/(g) assertions |
+| `degenerate_reason` enum field (NEW) | **#233** (this sub-task) | added under `=== FILTER SUMMARY ===`; values listed in § 7 |
+| `die` / `exit` formatting for cases (i)/(j) | #231 | this sub-task asserts post-#231 message text |
+| Distinguishing directory from missing file (case j) | #231 + #233 | message text change is #231's; assertion is here |
+
+The hard ordering: #226 (`-V` selectivity) → #228 + #229/#230 (sections
+exist) → **#233 wires assertions on top**. #233 itself adds one new field
+(`degenerate_reason`) into a section another sub-task owns; this is the
+minimum surface-area contribution.
+
+## § 10. ltl code changes required
+
+| Change | Owner | Effort |
+|---|---|---|
+| Branch the empty-result message at `ltl:7757` on a `%degenerate_reason` accumulator built during read | #233 | low |
+| Add `degenerate_reason` enum emission inside `=== FILTER SUMMARY ===` (`ltl:7430` area or new emitter) | #233 | low (sits on #229/#230 emitter) |
+| Suppress 1970-epoch timestamps in summary table when `$total_lines_included == 0` (`ltl:8451–8454`) | #233 | trivial |
+| Distinguish directory vs missing-file at `ltl:4314–4318` | #231 | trivial |
+| Warn when `-st > -et` in `calculate_start_end_filter_timestamps` (`ltl:4421`) | #233 | trivial |
+| Confirm and document existing div-by-zero guards (`ltl:6368, 6371, 7045, 7046, 7061, 834`) | n/a | docs only |
+
+No new sections, no new flags. Total ltl-side effort: **0.5–1 day**, blocked
+on #228/#229/#230 emitters landing first.
+
+## § 11. Harness shape proposal
+
+File: `tests/validate-degenerate-inputs.sh`. Bash, generates ephemeral inputs
+in `$TMP`, references committed fixtures for substantive cases.
+
+1. Define case table inline — `(label, generator_cmd_or_fixture_path,
+   extra_args, expected_exit, expected_stdout_grep, expected_filter_summary_kv,
+   expected_format_detection_kv)`.
+2. For each row:
+   a. Materialize input (run generator into `$TMP` or reference fixture).
+   b. Invoke `./ltl --disable-progress --terminal-width 200 -V format-detection,filter-summary <extra_args> <input>` with `LC_ALL=C`, capture stdout/stderr/exit.
+   c. Assert exit code matches expected.
+   d. Assert stderr contains **zero** Perl-warning patterns (uninitialized,
+      non-numeric, deep recursion).
+   e. Grep stdout for the case-specific user-facing string.
+   f. Parse `=== FILTER SUMMARY ===` and `=== FORMAT DETECTION ===`; assert
+      key/value expectations.
+3. Emit TAP summary; exit non-zero on any assertion failure.
+4. Reuse `tests/validate-regression.sh`'s LC/width/`--disable-progress`
+   isolation conventions.
+
+Coordinates with `tests/validate-format-detection.sh` (#228),
+`tests/validate-filter-logic.sh` (#230), `tests/validate-pattern-files.sh`
+(#229) — same `-V` parsing helpers should be factored into a shared bash
+library to avoid duplication.
+
+## § 12. Open questions
+
+1. **Should the summary table be suppressed entirely when there is no data,
+   or should it print with explicit `n/a` placeholders?** Suppression is
+   simpler; placeholders preserve column alignment for scripted consumers.
+2. **Is `degenerate_reason: mixed` worth the complexity** (multi-file run
+   where one file is empty and another is all-filtered), or should the
+   harness only cover single-file degenerate cases and defer mixed-input
+   cases to a follow-up?
+3. **Case (l) — negative time range** (`-st > -et`). Is this a hard error
+   (die at parse) or a soft warning (treat as all-filtered)? Today it's
+   silently accepted. Recommend: warn + accept, but pin the choice before
+   the harness ships.
+4. **Binary-garbage (case k) overlap with #227** (binary smoke tests).
+   #227 already proposes smoke-running the static binary; does #233's
+   binary-garbage *input* case duplicate #227's coverage, or is it a
+   distinct concern (input file is binary, vs ltl binary itself)?
+   Recommend: keep as a distinct degenerate-input case — #227 is about
+   the executable, #233 is about feeding garbage *to* it.
+5. **Does emitting a per-case `degenerate_reason` violate the existing
+   `=== FILTER SUMMARY ===` design contract being negotiated by #229/#230?**
+   The field name has to be agreed across all three sub-tasks before any
+   one of them ships its emitter.
+
+## § 13. Effort estimate
+
+- ltl changes (degenerate-reason accumulator + summary suppression +
+  directory-vs-missing): **0.5 day**, blocked on #229/#230 emitters.
+- Synthetic fixtures (3 committed files) + ephemeral-input generators:
+  **0.25 day**.
+- Harness script (`validate-degenerate-inputs.sh`): **0.5 day**.
+- Coordination overhead with #228/#229/#230/#231 (field naming, shared
+  parser): **0.25 day**.
+
+**Overall: low effort, ~1.5 days of focused work, blocked on the
+`=== FORMAT DETECTION ===` (#228) and `=== FILTER SUMMARY ===` (#229/#230)
+emitters and on #226's `-V` selectivity. The most valuable single
+contribution is the no-Perl-warnings stderr assertion — it locks in the
+already-correct division-by-zero guards documented in § 4 row 6.**
+
+## Related
+
+- **Blocks** #233 (this harness)
+- **Depends on** #226 (`-V` selectivity), #228 (`=== FORMAT DETECTION ===`),
+  #229/#230 (`=== FILTER SUMMARY ===`), #231 (error-message cleanup for cases i/j)
+- **References:** `ltl:4312–4318` (file validation), `ltl:4421–4457`
+  (time-range parsing), `ltl:4523–4774` (read/format cascade),
+  `ltl:5039–5053` (timestamp min/max + included counter), `ltl:6055–6404`
+  (statistics with existing zero-sample guards), `ltl:6407–6437`
+  (empty-bucket initialization), `ltl:7488` (graph-vs-message branch),
+  `ltl:7757` (current empty-result message), `ltl:8438–8517`
+  (summary table including 1970-epoch bug),
+  `features/225-format-detection.md`, `features/225-filter-logic.md`,
+  `features/225-pattern-files.md`, `features/225-cli-validation.md`.

--- a/features/225-doc-examples.md
+++ b/features/225-doc-examples.md
@@ -1,0 +1,417 @@
+# Doc Examples Verification (Issue #234)
+
+## Overview
+
+Sub-task of #225 (umbrella for high-priority test-harness coverage gaps). Adds an
+automated check that the `ltl` command-line examples shown in user-facing
+documentation actually parse and execute successfully. These have drifted before
+(option renames, sample-file moves, hidden-flag changes) and the wiki sync at
+release-step 15 has no gate that would catch broken examples before they ship
+to `https://github.com/gregeva/logtimeline/wiki`.
+
+## Status
+
+**Research / scoping** — no implementation yet. This document is the input to
+implementation on #234.
+
+## Framework dependency
+
+Weak dependency on #226 (`-V` selectivity). A few examples in `docs/usage.md`
+invoke `-V` (e.g. `usage.md:205`), but the vast majority do not. The harness can
+ship before #226 lands; the `-V` examples can be temporarily skipped or run as
+exit-code-only checks.
+
+---
+
+## 1. Documentation Surface Inventory
+
+Sources verified by reading each file end-to-end. Code-fence counts and
+representative `ltl` invocations follow.
+
+| File | Lines | Fenced blocks (approx.) | Blocks containing `ltl` | Notes |
+|------|-------|-------------------------|--------------------------|-------|
+| `README.md` | 85 | 5 | 2 (one structural, one comment-only build script) | Synopsis line + build instructions only |
+| `docs/usage.md` | 329 | ~14 | 13 | Canonical wiki source — the bulk of examples live here |
+| `docs/purpose.md` | 87 | 0 | 0 | Pure prose; inline `-flag` references but no fenced commands |
+| `docs/test-logs.md` | 215 | ~6 | 1 large block with 10 `./ltl` invocations (lines 174-201) | "Quick Test Commands" section |
+| `docs/perl-performance-optimization.md` | 198 | ~8 | 0 | Perl snippets + one `nytprofhtml` block; no `ltl` invocations |
+| `docs/regex-best-practices.md` | 143 | several | 0 | Perl-only |
+| `docs/similarity-engine-best-practices.md` | 168 | several | 0 | Perl-only |
+| `docs/staged-processing-pipeline.md` | 147 | a few | 0 | Tables + prose |
+| `docs/fuzzy-consolidation-lessons-learned.md` | 182 | a few | 0 | Prose retrospective |
+| `CLAUDE.md` | 192 | many | 1 structural (line 105-107) | Release-process and dev-workflow shell commands (build/git/gh) — not `ltl` examples |
+| `demo-use-cases.md` | 84 | 1 | 1 (line 67-69, real invocation with file paths) | Use-case scenarios |
+
+### Top doc to cover: `docs/usage.md`
+
+Concrete `ltl` example blocks (file is canonical for the wiki):
+
+- `docs/usage.md:11-15` — Files section (3 examples, two are pure glob/path forms)
+- `docs/usage.md:37-44` — Time & Buckets (3 examples)
+- `docs/usage.md:66-73` — Filtering (3 examples)
+- `docs/usage.md:92-99` — Recording & Processing (3 examples)
+- `docs/usage.md:117-124` — Message Grouping (3 examples)
+- `docs/usage.md:149-158` — Display & Output (4 examples)
+- `docs/usage.md:169-176` — Sorting (3 examples)
+- `docs/usage.md:194-209` — Percentile mode (5 examples, one with `-V | grep`)
+- `docs/usage.md:220-227` — Heatmap (3 examples)
+- `docs/usage.md:242-251` — Histogram (4 examples)
+- `docs/usage.md:272-279` — User-Defined Metrics (3 examples)
+- `docs/usage.md:290-297` — Thread Pool Activity (3 examples)
+
+Approximate total: **~40 distinct `ltl` invocation lines across `docs/usage.md`**.
+
+### Other relevant blocks
+
+- `docs/test-logs.md:174-201` — 10 `./ltl …` invocations, all referencing real
+  ship-in-repo files such as `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt`.
+- `demo-use-cases.md:67-69` — single concrete `ltl` invocation referencing
+  `./logs/GC/...` paths that may or may not exist in the repo.
+
+---
+
+## 2. Categorization by Executability
+
+Bucket definitions:
+
+- **EX (directly executable)** — log argument is a path that exists in this
+  repo's `logs/` tree (or no log path is needed and stdin works).
+- **PH (placeholder-substitutable)** — references generic names like
+  `access.log`, `app.log`, `error.log`, `logs/*/access.log`. Needs a
+  substitution policy to be runnable.
+- **ST (structural)** — synopsis like `ltl [options] <logfile(s)>`. Cannot and
+  should not be executed; documents grammar.
+- **EXT (external dependency)** — `gh`, `docker`, `cpanm`, `brew`,
+  `nytprofhtml`, `perl -d:NYTProf`. Out of scope for this harness.
+
+| File | EX | PH | ST | EXT |
+|------|----|----|----|-----|
+| `README.md` | 0 | 0 | 1 (l. 21) | 4 (build/install/setup-hooks blocks) |
+| `docs/usage.md` | 0 | ~36 | 2 (`l. 4`, default in synopsis sections) | 0 |
+| `docs/test-logs.md` | 10 | 0 | 0 | 0 |
+| `docs/perl-performance-optimization.md` | 0 | 0 | 0 | 1 (`nytprofhtml`) |
+| `demo-use-cases.md` | 1 (path-dependent, see open Q) | 0 | 0 | 0 |
+| `CLAUDE.md` | 0 | 0 | 1 (l. 105-107) | many |
+
+Net: ~36 PH and ~11 EX examples are the realistic harness target. Everything in
+`docs/usage.md` is PH because the canonical doc uses generic filenames
+(`access.log`, `app.log`) on purpose — those names render cleanly on the wiki
+and don't tie the doc to a private logs tree.
+
+---
+
+## 3. Placeholder Substitution Policy
+
+`docs/usage.md` uses generic names by design. Three options:
+
+**Option A — Implicit substitution table by filename.**
+Hardcode a mapping in the harness: `access.log` → a known repo file,
+`app.log` → another, etc. The mapping is invisible in the doc.
+
+**Option B — In-doc opt-in annotation.**
+Markdown comment immediately before the fence:
+```
+<!-- ltl-test: substitute access.log=logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log -->
+```bash
+ltl -i "POST" -e healthcheck access.log
+```
+```
+Per-example control. Requires touching ~40 examples in `docs/usage.md`.
+
+**Option C — Skip PH category entirely** and only test the ~11 EX examples in
+`docs/test-logs.md` plus any new examples that are added with real paths.
+
+### Recommendation: **Option A**, with one substitution table maintained in the
+harness.
+
+Rationale:
+- The doc stays clean for end users — generic filenames are easier to read.
+- The table lives in one place (`tests/validate-doc-examples.sh` or a sibling
+  `.tsv`), making the policy auditable and explicit.
+- Substitution candidates per MEMORY.md guidance (do NOT use
+  `logs/AccessLogs/localhost_access_log.2025-03-21.txt` due to corrupt lines):
+  - `access.log` → `logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log`
+    (658 KB, ships in repo, clean, both duration+bytes)
+  - `app.log` → `logs/ThingworxLogs/ApplicationLog.log` (5.8 MB, ships in repo)
+  - `error.log` → `logs/ThingworxLogs/ErrorLog.log` (3.7 MB)
+  - `logs/*/access.log` → glob substituted to the single Apache file above
+  - GC paths in `demo-use-cases.md:68` — likely don't exist in repo; either
+    add a fixture or mark the block as skip.
+
+---
+
+## 4. Stub Output Strategy
+
+Two extremes:
+
+**Exit-code-only.** Run the command, assert exit 0 (or expected non-zero for
+help/version), discard stdout. Easy to maintain, catches gross failures (option
+removed, file unreadable, regex syntax error in example), misses output drift.
+
+**Captured-output diff.** Like `tests/validate-regression.sh` does today
+(`tests/reference-output/`). Catches more, but doc examples produce variable
+output (timestamps, color, terminal width). Requires per-example normalization
+and regeneration discipline that gets stale fast.
+
+### Recommendation: **exit-code-only**, with two refinements.
+
+1. Also require `stdout` to be non-empty (catches silent no-ops where the
+   example produces no rows because the substituted file doesn't contain
+   matching lines).
+2. For examples with embedded shell pipelines (e.g. `ltl -V access.log | grep
+   -A 5 'BIN-COUNTER MODE'` at `usage.md:205`), pass-through the exit code of
+   the whole pipeline (i.e. `set -o pipefail`).
+
+This is the lowest-cost gate that catches the documentation-drift bugs we've
+historically seen: renamed options, removed flags, restructured output sections
+that break a `-V | grep` example. It does not catch silent output regressions —
+those are already covered by `validate-regression.sh`.
+
+---
+
+## 5. Markdown Parsing Approach
+
+Three styles:
+
+**Auto-detect every fenced block.** Run anything in ` ```bash ` / ` ```shell `.
+False positives: git/gh/build commands in `CLAUDE.md` and `README.md`.
+
+**First-word filter.** Run only fences whose first non-whitespace line starts
+with `ltl ` or `./ltl `. Cheap, conservative, no false positives. Misses
+multi-line examples where `ltl` is on line 2+ — but a quick scan shows all
+existing examples have `ltl` on the first command line of the block.
+
+**Opt-in annotation.** ` ```bash {test} ` or HTML comment. Highest precision,
+highest maintenance overhead, requires editing every existing example.
+
+### Recommendation: **first-word filter (`ltl ` or `./ltl ` as the first
+command in the fence)**.
+
+Rationale: matches the natural pattern in `docs/usage.md` (every example block
+is a series of `ltl …` lines, often with `#` comments interleaved), excludes
+non-ltl fences automatically, requires no doc edits. A literal-comment escape
+hatch like `# ltl-test: skip` on the line above the fence handles the
+known-bad cases (the GC example in `demo-use-cases.md` referencing paths that
+don't exist in the public repo).
+
+---
+
+## 6. Failure Semantics
+
+A failing doc example is a **documentation bug** — the option was renamed, the
+flag changed semantics, or the example was wrong from the start. CLAUDE.md's
+"Sweep all user-facing doc surfaces in one pass when closing a ticket" rule
+explicitly calls out `docs/usage.md`, `README.md`, `print_help()`, `CLAUDE.md`
+as having to move together. This harness becomes the *automation* for that
+rule. If it warns rather than fails, the rule keeps being violated quietly.
+
+### Recommendation: **fail the build / fail the release-gate** when any doc
+example fails.
+
+Failure must include: the file path, the line number of the opening fence,
+the substituted command actually executed, the exit code, and the first few
+lines of stderr. That's what makes the bug fix obvious from CI output alone.
+
+---
+
+## 7. Wiki Sync Interaction
+
+CLAUDE.md release step 15 clones `logtimeline.wiki`, copies `docs/usage.md` →
+`Home.md` and `docs/purpose.md` → `Purpose-and-Design-Philosophy.md`, commits
+and pushes. There is currently nothing between "release branch ready" and
+"wiki overwritten with possibly-broken examples".
+
+### Recommendation: **run `tests/validate-doc-examples.sh` before step 15.**
+
+Concretely, slot it into the release process as **step 8b** (after the version
+bump in step 7, immediately before the benchmark run in step 8). Failure
+aborts the release. It does not belong inside the benchmark step — it's much
+cheaper (seconds to minutes vs. an hour) and a different failure class.
+
+It should also be wired into the GitHub Actions workflow used by
+`.github/workflows/release-build.yml` so PRs that touch `docs/usage.md`,
+`README.md`, or the `ltl` script itself are gated.
+
+---
+
+## 8. Application-Observability Gaps
+
+Does `ltl` need new output to support this? Almost certainly **no**.
+
+Exit-code-only validation needs no new ltl support. Existing examples already
+emit a render to stdout, and a non-empty assertion plus a clean exit is
+sufficient. A `-V doc-example` mode (deterministic output) would let us
+graduate from exit-code-only to diff-based validation later, but introducing
+it now is premature optimization — wait until exit-code-only proves
+insufficient.
+
+### Recommendation: **no ltl changes for the initial version of this harness.**
+
+Revisit if the first generation of the harness exposes a class of
+documentation drift that exit codes cannot detect.
+
+---
+
+## 9. Concrete Walk-Through: 5 Examples
+
+Walking the harness through five real examples from the docs as a design
+validation:
+
+**Example 1 — `docs/usage.md:67-68`**
+```
+ltl -i "POST" -e healthcheck access.log
+```
+- Substitute `access.log` → `logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log`.
+- Inject `--disable-progress --terminal-width 120` to suppress progress and
+  stabilize layout.
+- Execute: `./ltl --disable-progress --terminal-width 120 -i "POST" -e healthcheck logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log`
+- Assert: exit 0, stdout non-empty.
+
+**Example 2 — `docs/usage.md:42-43`**
+```
+ltl -ms -bs 100 -st "2025-05-05 08:15:00.000" -et "2025-05-05 08:20:00.000" app.log
+```
+- Substitute `app.log` → `logs/ThingworxLogs/ApplicationLog.log`. Time range
+  may not match — the harness should treat exit 0 with zero buckets as
+  acceptable (because the assertion is *the command parsed and ran*).
+- Note: this is a case where exit-code-only is the right choice — the example
+  is illustrative, the time-range obviously isn't tied to the substituted file.
+
+**Example 3 — `docs/usage.md:205`**
+```
+ltl -V access.log | grep -A 5 'BIN-COUNTER MODE'
+```
+- Substitute `access.log` as above.
+- Run under `bash -o pipefail`.
+- Assert: pipeline exit 0. This catches the case where the `BIN-COUNTER MODE`
+  section is renamed/removed by an unrelated refactor.
+
+**Example 4 — `docs/test-logs.md:191`**
+```
+./ltl -n 10 logs/AccessLogs/localhost_access_log.2025-03-21.txt
+```
+- No substitution — direct execution.
+- BUT: MEMORY.md says don't use this file for new tests. The harness should
+  warn (not fail) on this and the user should update `docs/test-logs.md` to
+  reference a cleaner file. Out of scope for #234 but a finding to surface.
+
+**Example 5 — `demo-use-cases.md:68`**
+```
+ltl -st "2025-05-14 09:07" -et "2025-05-14 09:28" -oe -hg -hm ./logs/GC/logs-gc/gc-twx01-twx-thingworx-1.out.4 ...
+```
+- Paths `./logs/GC/logs-gc/*` may not ship in the repo.
+- First harness pass: mark this fence with `# ltl-test: skip` until a
+  decision is made about whether to add GC log fixtures.
+
+---
+
+## 10. ltl Code Changes Required
+
+**None expected.** Verified by walking 5 representative examples above. The
+harness drives ltl through its existing CLI surface and uses already-existing
+flags (`--disable-progress`, `--terminal-width`) to stabilize output.
+
+One follow-on observation surfaces from the walk-through: the small access
+log used in `docs/test-logs.md:191` and elsewhere is flagged as corrupt in
+MEMORY.md. That's a docs fix, not an ltl fix.
+
+---
+
+## 11. Harness Shape Proposal
+
+Sketch only — not implementation.
+
+**File:** `tests/validate-doc-examples.sh` (bash driver, matching the existing
+`validate-*.sh` family in `tests/`).
+**Helper:** `tests/extract-doc-examples.pl` (Perl extractor — same language as
+ltl, no new deps).
+
+**Driver flow:**
+1. Resolve repo root from `$0` like the other validate scripts.
+2. Declare the doc inventory:
+   ```
+   DOCS=( docs/usage.md docs/test-logs.md demo-use-cases.md README.md )
+   ```
+3. Declare the substitution table:
+   ```
+   SUBST="access.log=logs/AccessLogs/ApacheHTTP2Server-access_log-...
+          app.log=logs/ThingworxLogs/ApplicationLog.log
+          error.log=logs/ThingworxLogs/ErrorLog.log"
+   ```
+4. For each doc, invoke `extract-doc-examples.pl` to emit one JSON or TSV row
+   per testable fence: `(file, opening-fence-line, command-string)`.
+5. Apply substitutions and inject `--disable-progress --terminal-width 120`.
+6. Honor `# ltl-test: skip` annotation on the line above the fence.
+7. Execute each command under `bash -o pipefail`, redirecting stdout/stderr
+   to a per-test temp file.
+8. Assert exit 0 AND stdout non-empty.
+9. On failure, print: doc file + line, substituted command, exit code, first
+   20 lines of stderr.
+10. Print a summary: `N examples, M passed, K skipped, F failed.` Exit
+    non-zero if any failed.
+
+**Extractor (`extract-doc-examples.pl`):**
+- Streams the markdown line-by-line.
+- Tracks fence open/close (` ``` `).
+- For each fence, decide if testable: language must be `bash`/`sh`/`shell` or
+  empty, and the first non-comment line must start with `ltl ` or `./ltl `.
+- Honor the `# ltl-test: skip` magic comment immediately before the opening
+  fence.
+- Emit one TSV row per `ltl …` line inside qualifying fences.
+
+**Run target:** Add to `tests/validate-regression.sh`-equivalent CI step, and
+slot in as release-process step 8b.
+
+---
+
+## 12. Open Questions for Human Review
+
+1. **Substitution policy** — confirm Option A (hardcoded table in harness)
+   vs. Option B (per-example annotations in docs)? Memory comment on
+   "documentation sweep discipline" might favor B because it keeps the
+   per-example contract in the doc itself.
+
+2. **`demo-use-cases.md` scope** — is this file part of the user-facing doc
+   surface (it's at the repo root, not under `docs/`)? The GC paths it
+   references don't appear to ship in the repo. Skip the whole file, fix it,
+   or add GC fixtures?
+
+3. **`docs/test-logs.md:191`** — the example uses
+   `logs/AccessLogs/localhost_access_log.2025-03-21.txt` which MEMORY.md says
+   is corrupt and should not be used for new tests. Update the doc as part
+   of this work, or leave as a separate ticket?
+
+4. **CI integration** — should the harness run on every PR that touches
+   `docs/**` or `ltl`, or only as a release gate? Per-PR is safer but adds
+   ~30s-1min to every PR build.
+
+5. **`-V` examples** — `usage.md:205` invokes `-V`. If #226 (`-V` selectivity)
+   changes the `BIN-COUNTER MODE` section name or output, the example breaks.
+   Skip `-V` examples until #226 settles, or pin to current behavior?
+
+---
+
+## 13. Effort Estimate
+
+**Overall: low.**
+
+- Extractor (`extract-doc-examples.pl`): ~80 lines of Perl, ~2 hours.
+- Driver (`validate-doc-examples.sh`): ~120 lines of bash, ~2 hours.
+- Substitution table + initial pass over `docs/usage.md` (resolving each
+  example to a known-good file, flagging bad ones): ~3 hours.
+- CI wiring + release-process update in CLAUDE.md: ~1 hour.
+- Buffer for the first round of doc fixes the harness reveals: ~2 hours.
+
+**Timeline: 1-1.5 dev days.** Most of the time is in the substitution audit,
+not the code.
+
+---
+
+## Related
+
+- Umbrella issue #225 (test-harness coverage gaps)
+- Weak dependency: #226 (`-V` selectivity)
+- Release-process step 15 (`CLAUDE.md`) — wiki sync this harness gates
+- Existing sibling harnesses: `tests/validate-regression.sh`,
+  `tests/validate-help-layout.sh`, `tests/validate-histogram-ticks.sh`,
+  `tests/validate-percentile-mode.sh`, `tests/validate-index-readback.sh`

--- a/features/225-filter-logic.md
+++ b/features/225-filter-logic.md
@@ -1,0 +1,318 @@
+# Feature Requirements: Inline Filter Logic Regression Harness (#230)
+
+## GitHub Issues
+- [#230 — Validate `-include` / `-exclude` / `-highlight` truth table](https://github.com/gregeva/logtimeline/issues/230) (this work)
+- Parent: [#225 — Umbrella for high-priority test-harness coverage gaps]
+- Sibling: [#229 — Validate `patterns/` files via test harness](https://github.com/gregeva/logtimeline/issues/229) (`features/225-pattern-files.md`)
+- Depends on: [#226 — `-V` section/category selectivity]
+
+## Overview
+
+This research scopes a regression harness that validates the **grammar** of ltl's inline
+filter flags (`-i`, `-e`, `-h`) — particularly the `&` (AND), `|` (OR) and `&&` (literal `&`)
+operators introduced in #117 — via a truth-table fixture. It complements #229 (which
+validates content of the `patterns/*` files). No production code is written here.
+
+Read `features/225-pattern-files.md` first; it owns the foundational analysis of
+`build_filter_matcher()` and the `-V filter-summary` design.
+
+## 1. Documented Filter Grammar
+
+Source-of-truth: `parse_and_or_pattern()` (`ltl:1967–1989`), `build_filter_matcher()`
+(`ltl:1996–2041`), `match_filter()` (`ltl:2045–2066`), help text (`ltl:1697–1699`).
+
+### Inline forms (`-i` / `-e` / `-h`) — **REGEX**
+
+Each inline `-i ARG` is parsed by `parse_and_or_pattern`, then each AND term is
+compiled with `qr/$term/` (`ltl:2032` for the AND/OR path, `ltl:2037` for the
+single-regex fast path). Therefore each term is a **Perl regex**, with full
+metacharacter support (`.`, `*`, `[...]`, `\d`, anchors, etc).
+
+### File forms (`-if` / `-ef` / `-hf`) — **LITERAL substrings**
+
+Patterns loaded via `read_pattern_file()` are wrapped in `quotemeta()` (`ltl:2016`)
+before any compilation. File entries are literal substring matchers and do NOT
+support `&`/`|`/`&&` — those characters are themselves quoted into the regex.
+(Confirmed in `features/225-pattern-files.md` §1.)
+
+### Operators (inline only)
+
+| Operator | Meaning | Source |
+|---|---|---|
+| `\|` | OR — split into OR groups (`split(/\|/, …)`) | `ltl:1975` |
+| `&` | AND — split each OR group into AND terms (`split(/&/, …)`) | `ltl:1980` |
+| `&&` | Literal `&` — replaced by a NUL placeholder before splitting on `&`, then restored | `ltl:1971–1983` |
+
+Precedence: `&` binds tighter than `\|` (help text, `ltl:1697`): `A&B\|C&D` means
+`(A AND B) OR (C AND D)`. There is no parenthesis support. There is **no `!`
+negation** — `!` is not handled by `parse_and_or_pattern` and would be compiled
+into the regex as the literal character `!`.
+
+### Combination of `-i` and `-e` and `-h`
+
+These three filters are built independently (`ltl:4279–4281`) and applied in
+sequence inside the read loop:
+
+- `-e` first (`ltl:4991`) — line skipped if it matches `$exclude_filter`
+- `-i` next (`ltl:4992`) — line skipped if it does NOT match `$include_filter`
+- `-h` later (`ltl:5030`) — surviving lines are marked highlighted if they match
+
+So the effective predicate is `(include match) AND NOT (exclude match)`, with
+highlight as a post-filter tag. Repeated `-i` / `-e` / `-h` flags accumulate
+into `@include_args` / `@exclude_args` / `@highlight_args`, and each arg becomes
+its own OR group(s) within `parse_and_or_pattern`. Multiple `-i` flags therefore
+behave as OR (any one of them matching is sufficient).
+
+## 2. Existing Coverage
+
+`grep` of `tests/validate-*.sh` for `-i`/`-e`/`-h`/`--include`/`--exclude`/
+`--highlight` returns zero hits. The only filter-related signal anywhere in the
+test surface is the `lines_included` row in benchmark TSVs (e.g.
+`tests/baseline/results/comparison-v0.14.4-vs-v0.14.5.md`), which is an
+end-to-end aggregate — useless for catching grammar bugs. **No regression
+harness exercises filter logic today.**
+
+## 3. Truth Table
+
+Each row tests one independent code path through `parse_and_or_pattern` /
+`build_filter_matcher` / `match_filter`.
+
+| # | Invocation | Compiled form | Tests |
+|---:|---|---|---|
+| 1 | `-i A` | `qr/A/` fast path | single inline pattern |
+| 2 | `-i A -i B` | `qr/A\|B/` fast path | repeated `-i` ORs (2 args) |
+| 3 | `-i 'A\|B'` | `qr/A\|B/` fast path | OR inside single arg |
+| 4 | `-i 'A&B'` | AND/OR path, 1 group of 2 terms | AND of two |
+| 5 | `-i 'A&B&C'` | AND/OR path, 1 group of 3 | AND of three |
+| 6 | `-i 'A&B\|C&D'` | AND/OR path, 2 groups of 2 | precedence (`&` tighter than `\|`) |
+| 7 | `-i 'A&&B'` | `qr/A&B/` fast path | escaped literal `&` |
+| 8 | `-i 'A&&B&C'` | AND/OR path, 1 group of `[A&B, C]` | escape + real `&` mixed |
+| 9 | `-i 'A.*B'` | `qr/A.*B/` fast path | regex metachar (inline IS regex) |
+| 10 | `-i A -e B` | two independent filters | exclude wins over include |
+| 11 | `-i A -e B -h C` | three filters | highlight independent of include/exclude |
+| 12 | `-i A` + `-if FILE` | AND/OR groups merged | inline + file (file = literal) |
+| 13 | `-e 'A&B'` | exclude with AND | AND applies to exclude |
+| 14 | `-h 'A&B'` | highlight with AND | AND applies to highlight |
+
+Row 12 cross-checks the boundary with #229. Rows 13–14 confirm `&`/`&&` work
+identically for all three filter types (same `build_filter_matcher` call site).
+
+## 4. Synthetic Fixture
+
+Proposed file: `tests/filter-fixtures/truth-table.log` — 20 lines, each
+line tagged at column 0 with an ID so assertions can pick rows by `grep -c`.
+A timestamp prefix is required for ltl to accept the line (parser drops
+untimestamped lines).
+
+```
+2026-01-01 00:00:00.001 L01 plain A only
+2026-01-01 00:00:00.002 L02 plain B only
+2026-01-01 00:00:00.003 L03 plain C only
+2026-01-01 00:00:00.004 L04 plain D only
+2026-01-01 00:00:00.005 L05 has A and B together
+2026-01-01 00:00:00.006 L06 has A and C together
+2026-01-01 00:00:00.007 L07 has B and C together
+2026-01-01 00:00:00.008 L08 has A and B and C
+2026-01-01 00:00:00.009 L09 has C and D together
+2026-01-01 00:00:00.010 L10 has A and D together
+2026-01-01 00:00:00.011 L11 literal ampersand: A&B token
+2026-01-01 00:00:00.012 L12 literal ampersand: A&B and C
+2026-01-01 00:00:00.013 L13 regex bait: AxB
+2026-01-01 00:00:00.014 L14 regex bait: AyyB
+2026-01-01 00:00:00.015 L15 nothing relevant
+2026-01-01 00:00:00.016 L16 nothing relevant either
+2026-01-01 00:00:00.017 L17 only-file-pattern token FILEPAT
+2026-01-01 00:00:00.018 L18 FILEPAT and A together
+2026-01-01 00:00:00.019 L19 utf8 café résumé naïve A
+2026-01-01 00:00:00.020 L20 whitespace test:  A  B  (two spaces)
+```
+
+For each truth-table row, the expected set of surviving line-IDs is
+deterministic. Example: row 4 (`-i 'A&B'`) survives L05, L08, L18, L20
+(four lines containing both `A` and `B`); row 7 (`-i 'A&&B'`) survives L11
+and L12 (two lines containing the literal substring `A&B`).
+
+A companion file `tests/filter-fixtures/truth-table.expected.tsv` would
+encode `(row_id, included_count, excluded_count, highlighted_count, ids…)`.
+
+## 5. Observable Surface Today
+
+Same as #229 §3 — covered there, not duplicated. Summary: `total_lines_read`
+and `total_lines_included` are emitted (`ltl:7430–7431`) under
+`=== BENCHMARK DATA ===`, and the summary table prints `LINES INCLUDED`,
+`LINES READ`, `HIGHLIGHTED` (`ltl:8507–8509`). Nothing per-pattern, nothing
+broken-down by include-vs-exclude effect, nothing per-OR-group.
+
+## 6. Application-Observability Gaps — Coordination with #229
+
+**Recommendation: option (c) — one shared `filter-summary` section with
+clearly separated `inline_patterns:` and `*_files:` subsections.**
+
+Rationale:
+- Both tickets need the same totals (`included`/`excluded`/`highlighted`).
+  Splitting them creates duplicate aggregate counters.
+- The compiled-matcher view (`include (merged): …` at `ltl:4295`) already
+  combines inline + file patterns in one string — the `-V` consumer expects
+  one place to find filter state.
+- Section selectivity (#226) lets the harness ask for `filter-summary` once
+  and parse both blocks.
+
+Proposed combined layout (extends #229 §4):
+
+```
+=== FILTER SUMMARY ===
+input_lines_read: 1234567
+input_lines_filterable: 1230000
+included: 11520
+excluded: 0
+highlighted: 0
+include_inline:
+  "A&B": hits=4
+  "A&&B": hits=2
+exclude_inline: (none)
+highlight_inline: (none)
+include_files:
+  patterns/probes: status=ok loaded=2 hit_total=11520
+    /Thingworx/ready: 5760
+    /Thingworx/health: 5760
+exclude_files: (none)
+highlight_files: (none)
+dead_patterns: (none)
+```
+
+Per-OR-group reporting for inline patterns (`"A&B"`) is the new piece this
+ticket adds; the `*_files:` blocks are #229's territory.
+
+## 7. Assertion Strategy
+
+**Recommendation: (a) parse `-V filter-summary` counts**, with `(b)` `-o` CSV
+row count as a secondary cross-check on a smoke test.
+
+- (a) gives per-pattern + total visibility; required for the truth table.
+- (b) catches the case where `filter-summary` itself is wrong but the
+  end-to-end pipeline gives the right answer. One belt-and-braces row at
+  the top of the suite is enough.
+- (c) parsing the human summary table is brittle (depends on terminal width
+  and locale) — avoid.
+
+The harness should always pass `--disable-progress --terminal-width 200` and
+fix `LC_ALL=C` (see `tests/validate-regression.sh` for the established
+isolation pattern).
+
+## 8. Edge Cases Worth Testing
+
+Beyond the truth table:
+
+| Case | Recommendation |
+|---|---|
+| `-i ""` (empty) | **Test**: passes through `parse_and_or_pattern` and produces a single OR group `[""]` → `qr//` which matches every line. Document the behavior; do not assume it errors. |
+| `-i "&"` | **Test**: splits into `["", ""]` (AND of two empty terms) → both match every line → all lines pass. Likely surprising; capture as a smoke baseline. |
+| `-i "!"` | **Test**: `!` is not a grammar token. Compiles to `qr/!/`, matches literal `!` only. Confirms negation is unsupported. |
+| `-i "&&"` | **Test**: replaced to `\x00`, restored to `&`, single term `qr/&/`. Matches lines containing a literal `&`. |
+| `-i "A B"` (whitespace) | **Test**: ltl does NOT trim — confirmed by `split(/&/, $group, -1)` keeping all chars. Document. |
+| UTF-8 (`café`) | **Test**: Perl regex is bytewise by default; ensure source file is UTF-8 and ltl handles it the way it handles real logs. |
+| Regex metachars in inline (`A.*B`) | **Test (row 9 above)**: confirms inline IS regex, distinguishes inline from file form. |
+| Regex metachars in file (`A.*B`) | **Test**: quotemeta means `.` is literal `.`, NOT any-char. Cross-checks #229 contract. |
+| `-i 'A&B' -i 'C'` | **Test**: two args → two OR groups, mixed AND-1-term and AND-2-term groups in the compiled `@$matcher` arrayref. |
+
+The four invalid-looking-but-accepted forms (`""`, `"&"`, `"!"`, `"&&"`) are
+the most valuable additions because they pin down **undefined behaviour
+that we want to be defined behaviour going forward**.
+
+## 9. Coordination with #229
+
+Ownership split (proposed):
+
+| Concern | Owner |
+|---|---|
+| `-V filter-summary` section spec | **Joint** — one design doc, this file references #229 §4 |
+| `include_inline:` / `exclude_inline:` / `highlight_inline:` subsections | **#230** |
+| `include_files:` / `exclude_files:` / `highlight_files:` subsections | **#229** |
+| Aggregate totals (`input_lines_read`, `included`, `excluded`, `highlighted`) | **Joint** — built in whichever lands first |
+| `dead_patterns` field | **#229** (only meaningful for multi-pattern files) |
+| Fixture directory: `tests/filter-fixtures/` (synthetic truth-table log) | **#230** |
+| Fixture directory: `tests/pattern-fixtures/` (corrupted pattern files) | **#229** |
+| Harness scripts | **Two separate**: `tests/validate-filter-logic.sh` (#230) and `tests/validate-pattern-files.sh` (#229) |
+
+Two harnesses (not one) because the assertion granularity differs: #230
+asserts per-truth-table-row PASS/FAIL on a synthetic fixture, while #229
+asserts per-pattern hit counts against real log fixtures. Sharing one
+script would couple unrelated failure modes.
+
+## 10. ltl Code Changes Required
+
+- [ ] **`-V filter-summary` section emission for inline patterns** —
+  iterate `@include_args`, `@exclude_args`, `@highlight_args`, print each
+  with its hit count. Requires counting matches per OR group (see #229
+  §7 option (a) for the file-side analogue; the same approach applies
+  here). Effort: **low–med**, contingent on #229's counter wiring.
+- [ ] **Per-OR-group hit counter** — extend `match_filter()` to optionally
+  return which OR-group index matched, OR add a sidecar matcher pass when
+  `-V filter-summary` is active. Effort: **low** if sidecar-only.
+- [ ] **Document grammar edge cases in `docs/usage.md` and `print_help()`**
+  for the four under-specified forms (`""`, `"&"`, `"!"`, `"&&"`). Effort:
+  **low**.
+- [ ] *No grammar bugs uncovered by this research.* The lack of `!`
+  support is documented in help text by omission; nothing in source
+  suggests it was ever intended.
+
+Total ltl-side effort: **low**, contingent on the #229 / #226 stack.
+
+## 11. Harness Shape Proposal
+
+File: `tests/validate-filter-logic.sh`.
+
+Sketch — numbered steps, no bash code:
+
+1. Define the truth-table baseline as inline arrays / heredoc — one row
+   per case in §3 + §8, columns `(label, ltl_args, expected_included,
+   expected_excluded, expected_highlighted, expected_ids)`.
+2. Stage the synthetic fixture `tests/filter-fixtures/truth-table.log`
+   (committed) in a temp directory; never run against real logs.
+3. For each row:
+   a. Run `ltl --disable-progress --terminal-width 200 -V filter-summary
+      <ltl_args> -o tests/filter-fixtures/truth-table.log` capturing
+      stdout.
+   b. Parse the `=== FILTER SUMMARY ===` block; assert `included`,
+      `excluded`, `highlighted` match expected.
+   c. Parse the `-o` CSV and assert the surviving line-IDs equal
+      `expected_ids` (use `comm -23 <(sort got) <(sort expected)`).
+   d. On mismatch, print the failing row label, the args, expected vs got.
+4. Emit a TAP-style summary; exit non-zero on any assertion failure.
+5. Reuse `tests/validate-regression.sh`'s width/locale isolation
+   conventions.
+
+## 12. Open Questions
+
+1. **Empty-string and bare-operator semantics.** Should `-i ""`, `-i "&"`,
+   `-i "&&"` be (a) accepted and documented as match-everything, (b)
+   rejected with a clear error, or (c) silently treated as no-op? Today
+   they're accepted with surprising results. The harness needs to pin
+   one of these behaviours.
+2. **Negation support.** Issue #117 added `&` but did NOT add `!`. Is
+   negation a planned future feature, or is `-e PATTERN` (exclude) the
+   intended way to express NOT? If the former, the truth table needs
+   reserved rows; if the latter, document explicitly that `!` is literal.
+3. **Per-OR-group hit counting cost.** Should the per-group counter be
+   always-on, or only computed when `-V filter-summary` is requested?
+   #229 §7 recommends sidecar-only for the file path; same recommendation
+   here, but confirm before implementing.
+4. **Regex injection / DoS.** Inline `-i` accepts arbitrary regex, which
+   means a malicious or sloppy pattern (`(a+)+b`) could exhibit
+   catastrophic backtracking. Is this in scope for the harness, or
+   strictly a future hardening ticket?
+5. **Highlight intersection with exclude.** If a line matches both
+   `-e P` (excluded) AND `-h Q` (highlighted), the exclude wins
+   (`ltl:4991` runs before `ltl:5030`). Should the harness assert this
+   ordering explicitly as a row? (Recommend yes.)
+
+## 13. Effort Estimate
+
+- ltl changes (inline emission in `filter-summary`): **0.25 day**, on
+  top of #229's counter infrastructure.
+- Synthetic fixture + expected TSV: **0.25 day**.
+- Harness script (`validate-filter-logic.sh`): **0.5 day**.
+- Edge-case rows and grammar-doc updates: **0.25 day**.
+
+**Overall: low effort, ~1–1.5 days of focused work, blocked on #229's
+counter wiring and #226's section selectivity.**

--- a/features/225-format-detection.md
+++ b/features/225-format-detection.md
@@ -1,0 +1,248 @@
+# Feature Requirements: Format-Detection Regression Harness (#228)
+
+## Status
+
+- **Type:** Research deliverable (no implementation)
+- **Umbrella issue:** #225 (high-priority test-harness coverage gaps)
+- **Sub-task:** #228 (regression-testing log-format auto-detection)
+- **Hard dependency:** #226 (`-V` selectivity / per-section emission)
+- **Adjacent context:** `features/duration-unit-autodetection.md`, `features/log-format-registry.md` (#17, #23)
+
+## Background / Why This Matters
+
+ltl's parsing loop is a chained `if/elsif` regex cascade in `read_and_process_logs()` (`ltl:4564-4774`). The first pattern that matches wins, sets an implicit format identifier (`$match_type` 1-13), and routes downstream extraction. No format ID is ever written to output. The implicit knowledge "match_type 3 is a Tomcat access log with `%D`" is invisible to any test that does not eyeball the rendered graph.
+
+The risk this harness addresses: **a `%D` field is microseconds in Apache HTTP Server 2.x but milliseconds in Tomcat 9.** A 1000× off-by-unit error sails past percentile assertions because every percentile scales the same way — P50 still equals P50, just at the wrong absolute magnitude. Without a unit-level assertion, the regression is undetectable.
+
+## 1. Enumerated Built-in Formats
+
+Source: `ltl:4623-4774`. There are **13 numbered match types**, plus the CSV path that re-uses `match_type=13`. Each is identified by which regex matches first.
+
+| match_type | Canonical name (code comment) | Detection regex anchor (ltl line) | Fields extracted | Duration unit | Source of unit knowledge |
+|---:|---|---|---|---|---|
+| 1 | ThingWorx Standard Log Format | `^YYYY-MM-DD HH:MM:SS.sss±0000 [L: …] [O: …] [I: …] [U: …] [S: …] [P: …] [T: …] …` (4623) | timestamp, level, object, instance, user, session, platform, thread, message; opt. `bytes=`, `durationMS=` (4628-4629) | **ms** (pattern hint: `durationM[sS]=`) | implicit — embedded in ms-only regex |
+| 2 | ThingWorx Remote Access Client (RAC) | `^[?YYYY-MM-DDTHH:MM:SS.sss…] [L:?TRACE…]` (4660) | timestamp, level | n/a (no duration captured) | n/a |
+| 3 | Tomcat access log w/ `%D` + opt. `%I`, `%S` | `^(.+? ){3}[ts] "REQ" STATUS BYTES DURATION THREAD? SESSION?$` (4681) | timestamp, request, status, bytes, **duration**, thread, session | **ms (assumed)** | none — value passed through raw |
+| 4 | Tomcat / Nginx Common Access (no duration) | `^(.+? ){3}[ts] "REQ" STATUS BYTES$` (4695) | timestamp, request, status, bytes | n/a | n/a |
+| 5 | ThingWorx Connection Server JSON | `^{"@timestamp":"…","…","level":"…"` (4710) | timestamp, level | n/a | n/a |
+| 6 | Java 11 GC log (info-level pause) | `^[?ts]…[info][gc] GC(n) descr (from)->(to)(size) Nms` (4718) | timestamp, message, heap from/to/size, **duration** | **ms** (literal `ms` in regex) | explicit (regex literal) |
+| 7 | ThingWorx Analytics V2 (adaptor/sync/async) | `^LEVEL [ts] …` (4727) | level, timestamp, message | n/a | n/a |
+| 8 | ThingWorx Analytics worker | `^ts [thread] LEVEL …` (4737) | timestamp, thread, level, message | n/a | n/a |
+| 9 | JBoss / Jersey access log | `^… "REQ" STATUS BYTES "REFERER" "AGENT" DURATION$` (4745) | timestamp, request, status, bytes, **duration** | **ms (assumed)** | none |
+| 10 | ThingWorx Connection Server standard | `^ts [thread] LEVEL OBJECT - msg` + ` N milliseconds` (4643, 4648) | timestamp, thread, level, object, message, opt. **duration** | **ms** (literal ` milliseconds`) | explicit |
+| 11 | ThingWorx Edge C SDK | `^LEVEL ts message` (4757) | level, timestamp, object (`*.cpp:NN`), message | n/a | n/a |
+| 12 | Apache Tomcat / CodeBeamer `[%Dms] [%Ts]` | `^… [%Dms] [%Ts]` (4666) | timestamp, request, status, bytes, **duration**(`[Nms]`) | **ms** | explicit (literal `ms`) |
+| 13 | CSV (lazy two-line validation) | `detect_and_parse_csv_header()` invoked after two failed log-pattern matches (4776-4821) | timestamp col + UDM columns + opt. message cols; epoch detected at 4606 / 4797 | depends on `-du` and per-UDM unit declaration | user (`-du`) or per-UDM config |
+
+**Implicit "is access log" flag** (`$is_access_log`) is set by types 3, 4, 9, 12 unconditionally; by 1/10 only when a duration or bytes field actually parsed; by 6 always; by 13 always. It drives whether latency stats are computed. It is *not* a format ID.
+
+**Generic Java/Logback fallback** at `ltl:4655` re-uses `$match_type=1` for any line matching `^YYYY-MM-DD HH:MM:SS.sss+ZZZZ [L: LEVEL]` that did not match the full ThingWorx pattern. This collapses two distinct formats under one match_type.
+
+## 2. Duration-Unit Detection Deep-Dive
+
+There is **no value-range autodetection**. `features/duration-unit-autodetection.md` (architect review 2025-01-25) deferred it pending the format-registry refactor (#23). Today, unit knowledge comes from four sources:
+
+1. **Format-embedded literals.** Types 6, 10, 12 include the unit token (`milliseconds`, `ms`, `s`) in the regex itself.
+2. **Format-assumed default = ms.** Types 3, 9 capture a bare trailing integer and assume milliseconds. Apache HTTP Server 2.x with `%D` (microseconds) is silently misclassified — 1000× error.
+3. **Manual user override.** `-du ns|us|ms|s` (declared `ltl:1692`, parsed `ltl:4103/4128/4268-4270`, applied `ltl:4896-4898` via `convert_duration_to_ms()` at `ltl:2280-2290`). **Global only** — applied to every file in the run.
+4. **CSV epoch timestamps.** `ltl:4904-4908` divides the epoch column by `-du` factor, treating `-du` as the unit of the timestamp itself.
+
+The per-file index row carries `ts_precision` (`ltl:4541, 4968`) — that's **timestamp precision**, not duration unit. Detected by whether the timestamp string contained fractional seconds.
+
+`docs/test-logs.md` line 37 claims "ltl auto-detects the unit based on value ranges." **Incorrect** — fix as part of #228 prep.
+
+## 3. Observable Surface Today
+
+| Surface | Format ID emitted? | Duration unit emitted? |
+|---|---|---|
+| `-V` (existing sections: `=== Verbose ===`, `=== INDEX READ-BACK ===`, `=== BIN-COUNTER MODE ===`, `=== Consolidation Summary ===`) | no | no |
+| `=== BENCHMARK DATA ===` block (`ltl:7418-7481`) | no | no |
+| Bar graph header / scale | no | latency unit shown only as `format_time()` output magnitude (`ltl:3987-3988`: `us`/`ms`/`s`) — derived from value, not detection |
+| CSV (`-o`) column headers | no | no |
+| stderr | progress line shows filename only (`ltl:4595`) | no |
+| Index file `ltl-index.csv` | no | no (carries `ts_precision`, not duration unit) |
+| Internal `$match_type` | per-line only, never printed | n/a |
+
+**The harness cannot assert format detection today.** Only second-order signals (latency-column presence, value magnitude) are inferable — neither catches the ms-vs-µs trap.
+
+## 4. Proposed `-V format-detection` Section
+
+Modeled on `=== INDEX READ-BACK ===` (`ltl:1211-1268`): one section, per-file blocks, deterministic ordering, machine-parseable.
+
+```
+=== FORMAT DETECTION ===
+duration_unit_source: user      # user|default (no autodetect today)
+duration_unit_override: us      # value of -du, or "-" if unset
+files: 2
+file: logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log
+  format: tomcat_access_with_duration
+  match_type: 3
+  is_access_log: yes
+  ts_precision: s
+  duration_unit_assumed: ms     # the format's built-in assumption
+  duration_unit_applied: us     # after -du / -udm overrides
+  duration_field: trailing_integer
+  matched_lines: 9214
+  unmatched_lines: 0
+  first_match_line: 1
+file: logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log
+  format: thingworx_standard
+  match_type: 1
+  is_access_log: yes
+  ts_precision: ms
+  duration_unit_assumed: ms
+  duration_unit_applied: us     # -du is global, even if format embeds ms
+  duration_field: durationMS=
+  matched_lines: 281044
+  unmatched_lines: 132
+  first_match_line: 1
+=== END FORMAT DETECTION ===
+```
+
+Field locking (per `features/187-histogram-bin-counter-percentiles.md` §Decision 8): section name, field names, `format` enum values, `duration_unit_*` enum values are **contract-stable**; numeric values evolve freely. The `format` slug is the new public ID — today's `$match_type` 1-13 maps 1:1 to stable slugs via one central table. The harness asserts against slugs, not match_type numbers.
+
+## 5. Test-Fixture Mapping
+
+| format slug | match_type | Representative fixture (under `logs/`) | Notes |
+|---|---:|---|---|
+| `thingworx_standard` | 1 | `ThingworxLogs/ApplicationLog.2025-05-05.0.log` | no duration |
+| `thingworx_standard_with_metrics` | 1 (with `durationMS=`) | `ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log` | duration, bytes, count |
+| `thingworx_generic_logback` | 1 (fallback) | none confirmed; `ApplicationLog-improperlyRead.log` may overlap | **GAP — needs deliberate fixture** |
+| `thingworx_rac_client` | 2 | none in `logs/` | **GAP** |
+| `tomcat_access_with_duration` | 3 | `AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt` (Tomcat 9, ms) | primary ms baseline |
+| `tomcat_access_common` | 4 | none confirmed pure (most files have duration) | **GAP — needs trimmed sample** |
+| `connection_server_json` | 5 | none in `logs/` | **GAP** |
+| `java_gc_log` | 6 | none in `logs/` | **GAP** |
+| `tw_analytics_v2` | 7 | none in `logs/` | **GAP** |
+| `tw_analytics_worker` | 8 | none in `logs/` | **GAP** |
+| `jboss_access` | 9 | none in `logs/` | **GAP** |
+| `connection_server_standard` | 10 | none in `logs/` | **GAP** |
+| `tw_edge_c_sdk` | 11 | `UDM/rea-assets-5402_…trace_logs.log` (referenced in test-logs.md §UDM) | confirm format match |
+| `tomcat_codebeamer` | 12 | `Codebeamber/codebeamer_access_log.2025-10-29.txt` | explicit `[Nms]` |
+| `csv` | 13 | `UDM/connection-server-custom-metrics.csv`, `UDM/results_data_idonly-timestampMs.csv` | epoch-ms and human-ts variants |
+| `apache_httpd_microseconds` | 3 (today) | `AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log` | **Misclassified — same regex as Tomcat 9. Run with `-du us` today.** |
+
+**Gap count: 7 of 14 slugs have no fixture.** Fixture authoring is the heaviest single piece of #228.
+
+Per repo memory: do **not** use `localhost_access_log.2025-03-21.txt` (corrupt lines).
+
+## 6. Assertion Shape
+
+Driven from a TSV (`tests/format-detection/scenarios.tsv`) — `file, expected_format, expected_unit_applied, expected_match_count_min, notes`. Test runner invokes `ltl -V --disable-progress <file>`, parses the `=== FORMAT DETECTION ===` block, asserts equality.
+
+```
+assert_format Tomcat9-ms              \
+    logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt \
+    --expect-format tomcat_access_with_duration --expect-unit ms
+
+assert_format ApacheHTTP2-us          \
+    logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log \
+    -du us \
+    --expect-format tomcat_access_with_duration --expect-unit us
+
+assert_format CodeBeamer              \
+    logs/Codebeamber/codebeamer_access_log.2025-10-29.txt \
+    --expect-format tomcat_codebeamer --expect-unit ms
+
+assert_format ThingWorxScriptLog      \
+    logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log \
+    --expect-format thingworx_standard_with_metrics --expect-unit ms
+
+assert_format CSV-epoch-ms            \
+    logs/UDM/results_data_idonly-timestampMs.csv \
+    -du ms \
+    --expect-format csv --expect-unit ms
+```
+
+## 7. Format-Misdetection Canaries
+
+Negative-case fixtures that prove detection actually discriminates. Each is a hand-crafted ~50-line synthetic file under `tests/format-detection/canaries/`.
+
+| Canary | Construction | Expected outcome | Failure mode caught |
+|---|---|---|---|
+| `tomcat_with_microsecond_durations.log` | Tomcat 9 shape, trailing integers 100k-1M | `tomcat_access_with_duration`, unit ms (today). With `-du us`, P50 in ms-band; without, inflated 1000× | Future autodetect silently flipping unit |
+| `apache_with_millisecond_durations.log` | Same regex, values 1-2000 | `tomcat_access_with_duration`; no warning today | Future autodetect false-positive on legit ms Tomcat |
+| `thingworx_no_metrics.log` | ThingWorx without `durationMS=`/`bytes=` | `thingworx_standard`, `is_access_log: no` | Accidental access-log promotion |
+| `codebeamer_brackets_only_ms.log` | `[Nms]` present, `[Ts]` absent | Falls through to `tomcat_access_with_duration` | match_type 12 regex drift |
+| `csv_lookalike_log.log` | Comma-separated fields, line 2 also matches a log pattern | Detects as log format, not csv | Lazy-CSV regression (#107) |
+| `json_no_timestamp.log` | `{"level":"INFO",…}` no `@timestamp` | Unmatched | match_type 5 over-eager match |
+| `gc_log_no_unit_token.log` | GC line, bare numeric pause, no `ms` literal | Unmatched | Regex literal drift |
+
+## 8. Risk of Detection-Refactor Constraint
+
+The `=== BIN-COUNTER MODE ===` precedent shows that locking a `-V` section into the test suite creates a stability contract. For format-detection the trade-off is sharper because #23 will fully rewrite the detection path.
+
+**Recommended contract scope:**
+
+- **Locked:** section name, field names, `format:` slug values for existing formats, `duration_unit_*` enum (`ns|us|ms|s|-`), `duration_unit_source` enum.
+- **Free to evolve:** numeric counts, the heuristic that arrives at the slug, order in which patterns are tried, any new slugs added.
+- **Migration guarantee:** when #23 lands, every existing fixture must resolve to the **same slug** as before. Implementation under the slug may change completely.
+
+Narrower than the bin-counter contract — format detection only guarantees "this file → this slug → this unit answer." Heuristic internals are deliberately excluded.
+
+## 9. ltl Code Changes Required
+
+| Change | Effort | Notes |
+|---|---|---|
+| Add `=== FORMAT DETECTION ===` emitter (depends on #226) | medium | New `emit_format_detection_verbose()` modeled on `emit_index_readback_verbose()`. Per-file counters `%format_detection{$file}` accumulated in `read_and_process_logs()`. |
+| Define `%match_type_to_slug` table | low | One hash near `## GLOBALS ##`. Names must survive the #23 registry rewrite — they become the registry's primary keys. |
+| Track per-file format resolution | low | On first `$is_line_match`, record `match_type`/`first_match_line`. Per-file `matched_lines`/`unmatched_lines` counters in existing loop. |
+| Distinguish ThingWorx-standard vs generic-logback under match_type 1 | low | Add a sub-flag at `ltl:4655`. Without it the slug is ambiguous. |
+| Fix `docs/test-logs.md` line 37 autodetect claim | trivial | Docs only. |
+| Optional `--explain-detection` human-readable trace | medium | Likely overkill; skip in v1. |
+
+Total: **medium**. Risky part is slug names surviving the #23 rewrite.
+
+## 10. Harness Shape
+
+Directory: `tests/format-detection/`.
+
+```
+tests/format-detection/
+├── scenarios.tsv              # file, args, expected_format, expected_unit, min_matches
+├── canaries/                  # synthetic negative-case fixtures
+│   ├── tomcat_with_microsecond_durations.log
+│   ├── thingworx_no_metrics.log
+│   └── ...
+├── run.sh                     # iterates scenarios.tsv
+└── golden/                    # captured -V FORMAT DETECTION blocks per scenario
+```
+
+Numbered steps for `run.sh`:
+
+1. Read `scenarios.tsv`; for each row, invoke `./ltl -V --disable-progress <args> <file>` and extract the `=== FORMAT DETECTION ===` block.
+2. Parse `format:`, `duration_unit_applied:`, `matched_lines:` per file block.
+3. Assert against TSV expectations; record pass/fail.
+4. On fail, diff captured block against `golden/<scenario>.txt`.
+5. Exit non-zero on any failure; emit TSV summary for CI.
+
+Mirrors `tests/validate-regression.sh` shape so one CI job can run both.
+
+## 11. Open Questions
+
+1. **Slug naming.** Directive-shaped (`tomcat_access_combined_with_d`), server+version (`tomcat9_access_d_ms`), or semantic (`access_log_with_trailing_duration`)? Choice affects #23 registry YAML organization.
+2. **Per-file `-du`.** Today `-du` is global. A run mixing Apache (µs) and Tomcat 9 (ms) is unsolvable. Gate scenarios to one-file-per-run, or motivate a `-du <file>=us` syntax via #228?
+3. **Multi-file aggregation.** When two files have different formats, which "wins" for places that don't disambiguate per-file (latency-column header, CSV output)?
+4. **Generic-logback overlap.** match_type 1 covers both full ThingWorx and bare-prefix Logback. Split into two slugs, or keep as one bucket with a sub-field?
+5. **Apache HTTP Server misclassification.** It matches type 3 today. The harness will codify the misclassification. When the registry splits it, do we file a separate issue and update the harness in lockstep, or block the split on harness coverage?
+
+## 12. Effort Estimate
+
+| Piece | Effort |
+|---|---|
+| `-V` section emitter + slug table | low-medium (~1-2 days) |
+| Fixture authoring (7 missing formats + 7 canaries) | **medium-high (~3-5 days)** |
+| `scenarios.tsv` + `run.sh` | low (~0.5 day) |
+| Golden-file capture + review | low (~0.5 day) |
+| Documentation sweep | low |
+| **Overall** | **Medium** (~1 sprint) |
+
+**Critical path: missing fixtures.** Detection assertions are only as good as fixture coverage. Without closing the 7 gaps in §5, the harness asserts only the already-working formats.
+
+## Related
+
+- **Blocks #228** (this harness)
+- **Depends on #226** (`-V` selectivity — without it, the new section bloats every run)
+- **Coordinates with #23** (format registry rewrite — slug names become registry keys)
+- **Coordinates with #17** (duration-unit autodetection — when it ships, `duration_unit_source` enum gains `auto`)
+- **References:** `ltl:4564-4774` (match cascade), `ltl:2280-2290` (unit conversion), `ltl:4896-4908` (override application), `features/duration-unit-autodetection.md`, `features/log-format-registry.md`, `docs/test-logs.md`

--- a/features/225-heatmap-histogram-coverage.md
+++ b/features/225-heatmap-histogram-coverage.md
@@ -1,0 +1,408 @@
+# Feature: Extended heatmap/histogram rendering coverage in validate-regression.sh (#235)
+
+## Overview
+
+This research deliverable scopes the work for issue **#235** — extending
+`tests/validate-regression.sh` with heatmap and histogram fixture combinations
+that the current regression harness does not exercise. #235 is a sub-task of
+**#225** (umbrella for high-priority test-harness coverage gaps).
+
+The harness in question uses byte-identical rendered-output diff against
+fixture files under `tests/reference-output/`. It is **independent of #226**
+(which is about `-V` selectivity); no `-V` assertions are involved here.
+
+## GitHub Issue
+
+[#235](https://github.com/gregeva/logtimeline/issues/235) (parent: #225)
+
+---
+
+## 1. Existing coverage audit
+
+Read from `tests/validate-regression.sh` and `tests/capture-regression.sh`
+(both files mirror each other line-for-line in `run_test` invocations).
+
+`COMMON = --disable-progress -osum -n 1` is applied to every test below.
+
+### Access-log baseline (`tests/validate-regression.sh:69-74`)
+
+| Fixture | ltl options | Intent |
+|---|---|---|
+| `access-w80` | `--terminal-width 80 -os -od -ov` | Narrow width with manual column hides; baseline for narrow access-log render |
+| `access-w120` | `--terminal-width 120` | Mid-width access-log layout |
+| `access-w160` | `--terminal-width 160` | Standard-width access-log layout |
+| `access-w200` | `--terminal-width 200` | Wide access-log layout |
+
+### ScriptLog baseline (`validate-regression.sh:77-81`)
+
+| Fixture | ltl options | Intent |
+|---|---|---|
+| `scriptlog-w100` | `--terminal-width 100 -os -ov` | Narrow ScriptLog with manual column hides |
+| `scriptlog-w160` | `--terminal-width 160` | Standard ScriptLog layout |
+| `scriptlog-w200` | `--terminal-width 200` | Wide ScriptLog layout |
+
+### Heatmap (`validate-regression.sh:83-92`)
+
+| Fixture | ltl options | Intent |
+|---|---|---|
+| `heatmap-duration-w160` | `--exact-percentiles --terminal-width 160 -hm duration` | Duration heatmap palette + cell rendering |
+| `heatmap-bytes-w160` | `--exact-percentiles --terminal-width 160 -hm bytes` | Bytes palette |
+| `heatmap-count-w160` | `--exact-percentiles --terminal-width 160 -hm count` | Count palette |
+
+### Omit-flag column suppression (`validate-regression.sh:94-98`)
+
+| Fixture | ltl options | Intent |
+|---|---|---|
+| `omit-ov-w160` | `--terminal-width 160 -ov` | Hide overall column |
+| `omit-or-w160` | `--terminal-width 160 -or` | Hide rate column |
+| `omit-os-w160` | `--terminal-width 160 -os` | Hide stats column |
+| `omit-ov-or-w160` | `--terminal-width 160 -ov -or` | Hide overall + rate together |
+
+### Auto-hide / no-auto-hide (`validate-regression.sh:100-104`, issue #73)
+
+| Fixture | ltl options | Intent |
+|---|---|---|
+| `autohide-w80` | `--terminal-width 80` | Auto-hide engaged on access log at 80 |
+| `autohide-w100` | `--terminal-width 100` | Auto-hide engaged at 100 |
+| `noautohide-w80` | `--terminal-width 80 --no-auto-hide` | Force-off comparison at 80 |
+| `autohide-hm-w120` | `--exact-percentiles --terminal-width 120 -hm duration` | Heatmap + auto-hide interaction at 120 |
+
+### Millisecond precision (`validate-regression.sh:106-107`)
+
+| Fixture | ltl options | Intent |
+|---|---|---|
+| `ms-w160` | `--terminal-width 160 -ms -bs 1000 -st 00:00 -et 00:05` | ms bucket scale + time-range filter |
+
+**Total existing fixtures: 19.** Histogram coverage in this harness is zero;
+histograms are exercised only by `tests/validate-histogram-ticks.sh` which is
+a separate semantic-assertion harness (tick-vs-legend invariants), not a
+byte-identical diff harness, and operates exclusively against the corrupt
+`localhost_access_log.2025-03-21.txt`.
+
+---
+
+## 2. Combination space enumeration
+
+Read from `ltl --help` and the source dispatch at `ltl:5630-5635`,
+`ltl:4154-4158`, `ltl:251-252`.
+
+| Axis | Values | Notes |
+|---|---|---|
+| Heatmap metric (`-hm`) | `duration`, `bytes`, `count` | 3 modes, each maps to its own palette (yellow/green/cyan per `features/heatmap.md`) |
+| Heatmap width (`-hmw`) | int >= ~10, default 52 | Affects cell count; rendering-layer parameter |
+| Terminal width (`--terminal-width`) | 80, 100, 120, 160, 200 (project convention) | Drives auto-hide cascade |
+| Light background (`-lbg`) | flag (on/off) | Switches gradient direction; `$heatmap_light_bg` at `ltl:251` |
+| Histogram metric (`-hg`) | `duration`, `bytes`, `count` (+ UDM names) | Single or comma-list |
+| Multi-histogram (`-hg a,b[,c]`) | combos of the above | Independent panels stacked |
+| Histogram width (`-hgw`) | percent of terminal, default 95 | Layout |
+| Histogram height (`-hgh`) | rows, default 8, min 3 | Layout |
+| Histogram bpd (`-hgbpd`) | default 8 | Bin precision (covered elsewhere by `validate-percentile-mode.sh`) |
+| `--exact-percentiles` | flag | Forces sort-based percentile path; required for stability — see §5 |
+
+Full combinatorial expansion is on the order of 3 (metric) × 5 (term-width) ×
+2 (`-lbg`) × 3 (`-hmw` representatives) × 3 (histogram metric) × 4 (multi
+combos) × 3 (`-hgw` representatives) ≈ 1500+. Most of that is redundant; see §3.
+
+---
+
+## 3. Reduction to equivalence classes
+
+Independent code paths that must each be represented at least once:
+
+1. **Heatmap cell renderer × terminal width**. Auto-hide rebalances columns
+   around the heatmap strip. Representative narrow values are 80, 100, 120.
+   One metric (duration) is sufficient — the palette differs, but the cell
+   layout / autohide interaction is identical across metrics.
+2. **Heatmap palette per metric**. duration / bytes / count each select a
+   different gradient (`features/heatmap.md`). Width 160 already covers this
+   trio. No need to fan it out across every width.
+3. **`-hmw` custom width**. Two representative values bracketing the default
+   (52): a small one (30) and a large one (80). Single metric, single width.
+4. **`-lbg` light background**. Switches the colour table; rendering path is
+   identical. One representative heatmap fixture covers it. ANSI is stripped
+   by `strip_nondeterministic`, so colour codes do **not** survive into the
+   fixture — but the *character set* (block density indicators) does change
+   between dark and light palettes in some bands, so the fixture is still
+   meaningful. (Worth verifying experimentally during capture; if the
+   stripped output is byte-identical to the non-`-lbg` baseline, drop the
+   `-lbg` fixture and file the observation.)
+5. **Histogram single-metric × terminal width**. The histogram is rendered
+   by a path distinct from the heatmap. Cover three widths: 80 (narrow,
+   tests histogram suppression / squeeze), 120 (mid), 160 (standard).
+   Duration is the natural single-metric representative.
+6. **Histogram per metric**. bytes and count exercise different axis
+   formatters (KiB/MiB labels, integer labels). One fixture each, at 160.
+7. **Multi-histogram (`-hg duration,bytes` and `duration,bytes,count`)**.
+   Stacked-panel layout. Two fixtures cover (a) two-panel and (b) three-panel
+   stacking.
+8. **`-hgw` custom width**. Two representative values: 50 (squeeze) and 30
+   (very narrow histogram inside wide terminal).
+9. **`-hgh` custom height**. One representative (e.g. 4 rows).
+10. **Heatmap + histogram together** is a follow-on combination; the bar
+    graph + heatmap row + histogram strip composition is a distinct render
+    path. One fixture at width 160.
+
+Combining classes intelligently: 17 new fixtures (§4). Sub-25, well above the
+~3 we have today.
+
+---
+
+## 4. Proposed fixture list
+
+All heatmap fixtures use `--exact-percentiles` (see §5). Heatmap fixtures use
+`ScriptLog-DPMExtended-clean.log` (the canonical "all three metrics" file per
+`docs/test-logs.md`). Access-log scenarios use the
+`ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log` (microsecond
+durations, clean fixture). All command lines include `$COMMON`
+(= `--disable-progress -osum -n 1`).
+
+| # | Fixture name | ltl options (after `$COMMON`) | Log | Covers / why not redundant |
+|---|---|---|---|---|
+| 1 | `heatmap-duration-w80` | `--exact-percentiles --terminal-width 80 -hm duration` | ScriptLog-DPMExtended-clean | Heatmap cell layout at narrowest auto-hide tier; complements existing w120/w160 |
+| 2 | `heatmap-duration-w100` | `--exact-percentiles --terminal-width 100 -hm duration` | ScriptLog-DPMExtended-clean | Mid-narrow rung between 80 and 120 |
+| 3 | `heatmap-bytes-w120` | `--exact-percentiles --terminal-width 120 -hm bytes` | ScriptLog-DPMExtended-clean | Bytes palette at non-default width (existing w160 only covers w160) |
+| 4 | `heatmap-count-w100` | `--exact-percentiles --terminal-width 100 -hm count` | ScriptLog-DPMExtended-clean | Count palette under autohide; ensures count path doesn't render differently than duration at narrow width |
+| 5 | `heatmap-lbg-duration-w160` | `--exact-percentiles --light-background --terminal-width 160 -hm duration` | ScriptLog-DPMExtended-clean | Light-background gradient code path (`$heatmap_light_bg`, `ltl:251`) |
+| 6 | `heatmap-hmw30-duration-w160` | `--exact-percentiles --terminal-width 160 -hm duration -hmw 30` | ScriptLog-DPMExtended-clean | Custom heatmap width below default 52 |
+| 7 | `heatmap-hmw80-duration-w160` | `--exact-percentiles --terminal-width 160 -hm duration -hmw 80` | ScriptLog-DPMExtended-clean | Custom heatmap width above default 52 |
+| 8 | `hg-duration-w80` | `--exact-percentiles --terminal-width 80 -hg duration` | ApacheHTTP2 | Histogram panel at narrow width (suppression / squeeze behaviour) |
+| 9 | `hg-duration-w120` | `--exact-percentiles --terminal-width 120 -hg duration` | ApacheHTTP2 | Histogram at mid width |
+| 10 | `hg-duration-w160` | `--exact-percentiles --terminal-width 160 -hg duration` | ApacheHTTP2 | Histogram at standard width |
+| 11 | `hg-bytes-w160` | `--exact-percentiles --terminal-width 160 -hg bytes` | ApacheHTTP2 | Bytes axis formatter (KiB/MiB labels) |
+| 12 | `hg-count-w160` | `--exact-percentiles --terminal-width 160 -hg count` | ScriptLog-DPMExtended-clean | Count axis formatter |
+| 13 | `hg-multi-duration-bytes-w160` | `--exact-percentiles --terminal-width 160 -hg duration,bytes` | ApacheHTTP2 | Two-panel stacked histogram |
+| 14 | `hg-multi-all-w160` | `--exact-percentiles --terminal-width 160 -hg duration,bytes,count` | ScriptLog-DPMExtended-clean | Three-panel stacked histogram |
+| 15 | `hg-hgw30-duration-w160` | `--exact-percentiles --terminal-width 160 -hg duration -hgw 30` | ApacheHTTP2 | Custom histogram width (much narrower than default 95%) |
+| 16 | `hg-hgw50-multi-w160` | `--exact-percentiles --terminal-width 160 -hg duration,bytes -hgw 50` | ApacheHTTP2 | Custom histogram width combined with multi-metric |
+| 17 | `hg-hgh4-duration-w160` | `--exact-percentiles --terminal-width 160 -hg duration -hgh 4` | ApacheHTTP2 | Custom histogram height (4 rows; default is 8, min is 3 — `ltl:4231-4233`) |
+| 18 | `heatmap-hg-duration-w160` | `--exact-percentiles --terminal-width 160 -hm duration -hg duration` | ScriptLog-DPMExtended-clean | Heatmap + histogram in the same invocation (composition test) |
+
+**18 new fixtures**, bringing the harness from 19 → 37 fixtures. Within the
+"~15-25 fixtures" target.
+
+---
+
+## 5. `--exact-percentiles` policy for new fixtures
+
+`validate-regression.sh:84-92` documents the policy for heatmap fixtures:
+pin to the sort-based percentile path so the reference stays byte-stable
+while precision work (#34/#187/#201) lands. The unified bin-counter path is
+approximate within bin-resolution bound — fine for production, fragile for
+byte-identical diffs.
+
+**Histograms go through the same dispatch.** `calculate_histogram_buckets()`
+at `ltl:5630-5635`:
+
+```
+return $exact_percentiles_optout
+    ? calculate_histogram_buckets_exact()
+    : finalize_histogram_unified();
+```
+
+Same opt-out flag, same two-path structure. The histogram's percentile
+indicators (P50/P95/P99/P99.9 displayed on the histogram x-axis) and the
+bin counts themselves both shift between paths.
+
+**Recommendation: every new heatmap *and* histogram fixture uses
+`--exact-percentiles`.** This is consistent with the existing heatmap policy
+and avoids fixture churn when bin-counter precision is tuned.
+
+A future audit (separate issue) should re-capture all fixtures without
+`--exact-percentiles` once the unified path is locked, and migrate the
+harness off the deprecated flag.
+
+---
+
+## 6. Test log selection per fixture
+
+Constraint from `MEMORY.md` / `feedback_test_logs.md`: **do not use
+`logs/AccessLogs/localhost_access_log.2025-03-21.txt`** for new tests (corrupt
+lines). The existing harness uses it; new fixtures must not.
+
+Candidate logs from `docs/test-logs.md`:
+
+- **ScriptLog-DPMExtended-clean.log** (29 MB, ThingWorx CustomThingworxLogs):
+  "ideal for all heatmap types", carries duration, bytes, and count metrics.
+  Used for all heatmap fixtures and for histogram-count and three-panel
+  histogram fixtures.
+- **ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log** (658 KB,
+  Apache HTTP2, microsecond `%D` durations): clean Apache combined-log format
+  with duration + bytes. Used for access-log-flavoured histogram fixtures.
+
+Per-fixture assignment is in the §4 table. Two log files cover all 18
+fixtures.
+
+These two log files must be added as new variables to both
+`capture-regression.sh` and `validate-regression.sh` (see §8).
+
+---
+
+## 7. strip_nondeterministic considerations
+
+Current `strip_nondeterministic` (`validate-regression.sh:24-27`,
+`capture-regression.sh:35-38`):
+
+```
+perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g;
+          s/log timeline \[[0-9.]+\]/log timeline [VERSION]/'
+| perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/;
+            print unless $skip
+                     || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY
+                        |INITIALIZE EMPTY|CALCULATE STATISTICS|SCALE DATA/i'
+```
+
+Coverage today: ANSI escapes, version banner, top-overall section, timing
+and memory lines.
+
+**Non-determinism risk audit for new fixtures:**
+
+- **Heatmap header**: contains palette name only, no run-time data.
+  Deterministic.
+- **Histogram percentile values**: under `--exact-percentiles`, derived from
+  sorted raw arrays — deterministic for a given log file.
+- **Histogram axis labels**: derived from data min/max + log-scale boundaries
+  — deterministic.
+- **`-lbg` mode**: ANSI colour codes differ but get stripped; the *character
+  set* (block density characters) may differ. Both outcomes are
+  deterministic.
+- **Auto-detect**: `$heatmap_light_bg_auto` defaults to 1 (`ltl:252`) but is
+  skipped on Windows and gated through a terminal-query path at
+  `ltl:4212`. **Risk**: a TTY-attached run might detect a light background
+  on one developer's terminal and not on another's, perturbing the fixture.
+  Capture is via shell redirection (not a TTY) so the auto-detect path
+  should be inert, but this should be confirmed empirically when capturing
+  the `-lbg` fixture and the non-`-lbg` heatmap fixtures, and a
+  `NO_COLOR=1`-style environment override considered if any drift is
+  observed.
+
+**Conclusion**: no new strip patterns are required for fixture stability.
+File one observation for the implementer: re-run each new fixture twice
+on capture and diff before committing, to confirm idempotency. If any
+fixture proves non-deterministic, extend `strip_nondeterministic` then —
+not pre-emptively.
+
+---
+
+## 8. Capture script extension
+
+`tests/capture-regression.sh` is the mirror of `validate-regression.sh`.
+Both files need the same set of `run_test` calls; both files need the same
+two new log-file variables.
+
+Minimum diff to each script:
+
+1. Two new variables alongside `ACCESS_LOG` / `SCRIPT_LOG`
+   (`capture-regression.sh:23-24`):
+   ```
+   APACHE_LOG="$REPO_DIR/logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
+   DPM_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log"
+   ```
+   (Note: `SCRIPT_LOG` already points at this same DPM file by path. Either
+   reuse `SCRIPT_LOG` or rename. Recommend renaming to `DPM_LOG` in both
+   scripts for clarity, since existing heatmap fixtures already use it.)
+2. Add the file-existence check for `APACHE_LOG` in
+   `capture-regression.sh:27-32`.
+3. Append 18 new `run_test` lines (grouped by section: new heatmap, new
+   histogram, composition) to both scripts in lockstep.
+
+No structural changes. No new helper functions. No changes to
+`strip_nondeterministic`.
+
+---
+
+## 9. Application-observability gaps
+
+This harness is rendering-output diff, so observability gaps are minor.
+However, when a fixture diff fails in CI the implementer will want to
+inspect:
+
+- Which heatmap bin a cell landed in (currently visible only via colour, and
+  colour is stripped from the fixture).
+- Which histogram percentile maps to which axis column (currently visible
+  only via the legend and the tick character).
+- For multi-histogram, whether the panel ordering is stable across runs
+  (it should be: insertion order into `@histogram_udm_configs` is
+  deterministic).
+
+**Recommended (not required for #235)**: extend the `-V` output with a
+"render snapshot" block exposing heatmap-cell `(bucket,bin)` indices and
+histogram `(metric, column→percentile)` mapping. This belongs in #226's
+selectivity work, not here. File as a follow-on.
+
+---
+
+## 10. ltl code changes required
+
+**None.** Every option in §4 is shipped today. The work is harness +
+fixtures only.
+
+---
+
+## 11. Implementation steps proposal
+
+1. Rename `SCRIPT_LOG` to `DPM_LOG` and add `APACHE_LOG` variable in
+   `tests/validate-regression.sh` and `tests/capture-regression.sh`
+   (existing references move with the rename).
+2. Add 18 new `run_test` invocations (§4) to both scripts, grouped under
+   new section comments (`# --- Heatmap at narrow widths ---`,
+   `# --- Light-background heatmap ---`, `# --- Custom heatmap width ---`,
+   `# --- Histogram single-metric ---`, `# --- Multi-histogram ---`,
+   `# --- Custom histogram dimensions ---`, `# --- Composition ---`).
+3. Run `./tests/capture-regression.sh` to generate the 18 new fixture files.
+4. Visually inspect each new fixture for sanity (rendering looks correct,
+   no obvious truncation, percentile lines present, etc.). This is the
+   load-bearing manual step.
+5. Run `./tests/capture-regression.sh` a second time; `diff -r` the two
+   output directories to confirm idempotency. Investigate any
+   non-deterministic differences.
+6. Run `./tests/validate-regression.sh` and confirm 37/37 pass
+   (self-consistency check).
+7. Commit harness changes and fixtures together in one commit so the
+   harness and reference stay in sync.
+
+---
+
+## 12. Open questions for human review
+
+1. **`-lbg` capture environment.** Auto-detect may or may not engage when
+   stdout is piped to `strip_nondeterministic` (`ltl:4212`, `ltl:2305-2307`).
+   Should the capture script export `NO_COLOR=1` or similar to lock the
+   environment, or rely on the non-TTY pipe to disable auto-detect? Needs
+   a one-line empirical test.
+2. **Histogram with `-hgw` smaller than terminal histogram-suppression
+   threshold.** At `--terminal-width 80 -hgw 30` the histogram width is 24
+   columns; does ltl suppress the histogram at that width, render it
+   truncated, or render a tiny panel? Verify before committing fixture #15
+   (alternative: drop fixture #15 if the panel is suppressed and the
+   fixture would only test a "no panel" code path that's covered
+   elsewhere).
+3. **Whether to migrate the existing harness off
+   `localhost_access_log.2025-03-21.txt`.** The existing 19 fixtures all
+   use the corrupt file. New fixtures will not. Inconsistency is a smell;
+   a separate ticket should migrate the existing fixtures too, or this
+   research should expand to include re-capturing them on a clean log.
+4. **Fixture-name convention for combined heatmap+histogram.** Proposed
+   `heatmap-hg-duration-w160` (§4 row 18). Alternatives include
+   `combo-duration-w160` or `hm-hg-duration-w160`. Confirm or amend.
+5. **Whether to add a `-hgh` low-height fixture only, or also a high-height
+   (e.g. 16 rows) one.** §4 has only one `-hgh` fixture. If layout drift is
+   asymmetric between shrinking and growing the histogram, two are needed.
+
+---
+
+## 13. Effort estimate
+
+**Overall: low-medium.**
+
+| Activity | Estimate |
+|---|---|
+| Edit `validate-regression.sh` + `capture-regression.sh` (18 lines each, plus rename) | 30 min |
+| Run capture, produce 18 fixture files | 5 min wall-clock |
+| Visual review of each fixture | 60–90 min (this is the bulk of the work) |
+| Idempotency re-capture + diff | 10 min |
+| Investigate `-lbg` env determinism + open-question resolutions | 30 min |
+| Commit + push | 5 min |
+
+**Total**: half a day of focused effort, dominated by the visual review of
+fixtures. No new code, no tricky refactors, no test-of-test infrastructure.
+The work is mechanical; the cognitive load is the sanity-check pass.

--- a/features/225-help-content.md
+++ b/features/225-help-content.md
@@ -1,0 +1,232 @@
+# Feature: Help-content correctness harness (#232)
+
+## Overview
+
+This document is the **research and scoping deliverable** for issue #232, a sub-task of the #225 umbrella for high-priority test-harness coverage gaps. #232 covers two static-analysis assertions:
+
+1. Every flag declared in `GetOptions` appears in `print_help()` (and, by extension, in the canonical user-facing reference at `docs/usage.md`) — or is explicitly marked hidden.
+2. The version string reported by `-V` / `-v` matches `$version_number` declared in `ltl`.
+
+This is **scoping only** — no code changes are written here. The existing `tests/validate-help-layout.sh` already covers visual column alignment; this harness covers *content correctness*, which has a documented history of drift (CLAUDE.md observation 2026-02-07).
+
+## GitHub Issue
+
+[#232](https://github.com/gregeva/logtimeline/issues/232) (sub-task of [#225](https://github.com/gregeva/logtimeline/issues/225))
+
+## Sources
+
+- `ltl` lines 4092–4168 — `GetOptions` declaration block.
+- `ltl` lines 1588–1853 — `print_help()` subroutine.
+- `ltl` line 64 — `$version_number`.
+- `ltl` lines 1571, 1856, 7419 — emission sites for the version string.
+- `docs/usage.md` (lines 28–315) — canonical user-facing options reference (the wiki is overwritten from this file on each release).
+- `README.md` — short landing-page; references wiki for options.
+- `tests/validate-help-layout.sh` — sibling harness covering layout only.
+
+## § 1. GetOptions inventory
+
+The `GetOptions(...)` call (`ltl:4092–4168`) declares **75 distinct option entries**.
+
+| Form | Count | Notes |
+|------|-------|-------|
+| Both short and long forms | **66** | E.g. `'bucket-size|bs=i'`, `'verbose|V'`. |
+| Long-form only            | **9**  | `disable-progress`, `no-final-pass`, `consolidation-trigger`, `consolidation-ceiling`, `consolidation-max-patterns`, `final-threshold`, `debug-layout`, `validate-layout`, `help`. |
+
+Value-type spec breakdown (per `Getopt::Long` syntax):
+
+| Spec | Meaning                      | Count |
+|------|------------------------------|-------|
+| (none) | Boolean flag               | 38    |
+| `=i`   | Required integer           | 18    |
+| `=s`   | Required string            | 14    |
+| `:s`   | Optional string            | 3 (`-g`, `-hm`, `-hg`) |
+| `:i`   | Optional integer           | 0     |
+| sub-ref | Callback (not boolean)     | 5 (`-lbg`, `-hg`, `-hgw`, `-hgh`, `--no-final-pass`) |
+
+**Short-first ordering anomalies.** Five entries declare the *short form first* and the long form second: `hgbpd`, `hgb`, `pbpd`, `pp`, `ep` (lines 4158–4162). Every other entry is `long|short`. Functionally identical to Getopt::Long, but it matters for any naive parser that assumes "first token = long name". The harness must handle both orderings.
+
+**Hidden options (intentionally absent from `print_help`).** Cross-referenced from CLAUDE.md and code comments:
+
+- `--disable-progress` — internal/agent-only flag.
+- `--debug-layout`, `--validate-layout` — layout developer flags.
+- `--terminal-width|-tw` — hidden test/automation hook (per CLAUDE.md memory).
+- `--consolidation-trigger`, `--consolidation-ceiling`, `--consolidation-max-patterns`, `--final-threshold`, `--no-final-pass` — consolidation tuning knobs surfaced only via `-V` and `docs/usage.md` prose (not the canonical table).
+
+There is **no in-code annotation** that marks these as intentionally hidden today. The harness cannot mechanically distinguish "hidden by design" from "accidentally missing"; see § 8.
+
+## § 2. print_help() inventory
+
+`print_help()` (`ltl:1588–1853`) emits a structured help screen via a closure `$opt->($flags, $desc)` (line 1629). Sections, in source order:
+
+1. USAGE (single line)
+2. OPTIONS — subsections: *Time & Buckets*, *Filtering*, *Recording & Processing*, *Message Grouping*, *Display & Output*, *Sorting*, *Heatmap*, *Histogram*, *Percentile mode*, *User-Defined Metrics*, *Thread Pool Activity*.
+3. ENVIRONMENT (`LTL_CONFIG`)
+4. INFO (`-v / --version`, `--help`, `-mem / --memory-usage`)
+5. EXAMPLES
+
+Counting `$opt->("…,…", …)` calls that document a *real* CLI flag (excluding UDM sub-rows that document positional `name`/`unit`/`function`/`/regex/` fragments of `-udm`'s spec): **58 documented options**.
+
+The `$opt` closure parses the leading flags string with a regex anchored on `^(\S+,)\s+(.+)$` (line 1632) — i.e. it expects exactly `"-short, --long"`. Long-only entries use the alternate branch matching `^\s+(--\S.*)$` (line 1638). The harness can re-use the same regex to extract documented flags directly from a `--help` capture or from the `$opt->()` calls themselves.
+
+## § 3. Three-way mapping table
+
+GetOptions ⇄ `print_help()` ⇄ `docs/usage.md`. Verified by line-number citations in §1–2 plus `grep` against `docs/usage.md`.
+
+| Long name (GetOptions key)        | Short | In `print_help` | In `docs/usage.md` |
+|-----------------------------------|-------|-----------------|---------------------|
+| All 58 documented options         | (mix) | yes             | yes                 |
+| `terminal-width`                  | `-tw` | **NO**          | **NO**              |
+| `disable-progress`                | —     | **NO**          | **NO**              |
+| `debug-layout`                    | —     | **NO**          | **NO**              |
+| `validate-layout`                 | —     | **NO**          | **NO**              |
+| `no-final-pass`                   | —     | **NO**          | **NO**              |
+| `consolidation-trigger`           | —     | **NO**          | **NO**              |
+| `consolidation-ceiling`           | —     | **NO**          | **NO**              |
+| `consolidation-max-patterns`      | —     | **NO**          | **NO**              |
+| `final-threshold`                 | —     | **NO**          | **NO**              |
+| `histogram-buckets` (`-hgb`)      | `-hgb`| yes (1779)      | **NO** (only `-hgbpd` is in the table at usage.md:238) |
+
+### Findings
+
+- **Code-only orphans (9 long-form-only)**: All currently understood as intentionally hidden, but unmarked in source. Need explicit annotation (§ 8).
+- **Code-only orphan with a short form**: `-tw / --terminal-width` is in GetOptions only. Whether this is intentional is a judgement call — its CLAUDE.md memory note says hidden, but unlike `--debug-layout` it has a user-facing use case (driving ltl from a non-TTY context). **Open question**: surface it in help.
+- **Help-vs-README drift**: `-hgb / --histogram-buckets` is documented in `print_help()` but missing from the `docs/usage.md` Histogram table. This is the single clearest "real bug" the harness would have caught.
+- **No help-side orphans**: every flag documented in `print_help()` is declared in GetOptions. No help-documents-but-code-doesn't-declare cases were found.
+- **No short-form rendering inconsistencies** in the print_help text itself — every documented entry uses the `"-x, --long"` convention.
+
+## § 4. Version-string consistency
+
+`$version_number = "0.14.5"` at `ltl:64`. Emission and reference sites:
+
+| Site                             | Form                                       |
+|----------------------------------|--------------------------------------------|
+| `ltl:1571` (banner inside `print_usage`)   | `log timeline [$version_number]` — interpolated. |
+| `ltl:1856` (`print_version`)               | `Version: $version_number\n\n` — interpolated, triggered by `-v / --version`. |
+| `ltl:7419` (`print_verbose_output`)        | `version\t$version_number\n` — inside `=== BENCHMARK DATA ===` TSV block, triggered by `-V`. |
+| `releases/v0.14.5.md`                      | Hardcoded `0.14.5`. |
+| `CLAUDE.md`                                | Not pinned to a version. |
+| `README.md`                                | Not pinned. |
+| `build/*-package.sh`                       | Greps for "version number pattern" against `-version` output; not a hardcoded literal. |
+| `.github/workflows/release-build.yml`      | Driven by `v*` tag, not a literal. |
+
+**Status**: All in-binary emission sites interpolate `$version_number`; there is no hardcoded drift inside `ltl`. The only out-of-tree literal is the release-notes filename `releases/v0.14.5.md`, which is necessarily a per-release artifact, not drift. The harness should still assert this consistency mechanically because the risk surface is *adding a new emission site that forgets to interpolate*.
+
+## § 5. "Suspiciously short" help-entry heuristic
+
+Description-text quality drift is harder to catch than presence drift. Proposed heuristic, ordered by signal-to-noise:
+
+1. **Placeholder tokens** — case-insensitive match against `TODO`, `FIXME`, `XXX`, `undocumented`, `???`, `tk`, `TBD`. Near-zero false-positive rate.
+2. **Single-word descriptions** — `split(/\s+/, $desc) < 2`. Cheap, very few legitimate cases (currently none in `print_help`).
+3. **Description shorter than the long-form name** — `length($desc) < length($long_name)`. Indicates the author started typing the description but used the option name. Currently never triggered.
+4. **Description equals (or contains, ignoring case) only the option's long name with spaces** — e.g. description `"sort ascending"` for `--sort-ascending`. Tautology check.
+
+Heuristics (1) and (2) are recommended for v1 of the harness; (3) and (4) are nice-to-have but riskier on the heatmap-style short rows (e.g. `-hmw` has a 6-word description, well above any threshold). Avoid a raw "shorter than N characters" rule — too noisy on terse but valid entries like `--omit-rate`.
+
+## § 6. Application-observability gaps
+
+This harness is overwhelmingly static analysis of the Perl source and `--help` output. Two possible ltl-side additions were considered:
+
+### (a) `-V version` selectivity section (weak dep on #226)
+
+Today the version literal is emitted in three places (banner, `print_version`, `=== BENCHMARK DATA ===` TSV row). The TSV row (`version\t$version_number`) is already machine-parseable. A dedicated `-V version` section is **not required** — the harness can grep the existing TSV row or call `-v`.
+
+**Recommendation: do not add.** The TSV row at `ltl:7419` is sufficient.
+
+### (b) `--list-options` machine-parseable dump
+
+A flag that prints every GetOptions entry in TSV form (`long-name<TAB>short<TAB>spec<TAB>hidden`). Would simplify harness extraction.
+
+**Trade-off**: adds a permanent CLI surface just to support tests; gives the harness a stable contract against the *Perl source's* `GetOptions` block. But the GetOptions block is already trivially parseable with a 10-line Perl regex (the harness can be Perl, and the regex is robust because the block is hand-formatted one-per-line).
+
+**Recommendation: do not add `--list-options`.** Parse the source directly. Reconsider only if the static parse proves brittle in practice.
+
+## § 7. Assertion shape — one harness or two?
+
+The two concerns are independent in code but related in spirit:
+
+- (a) GetOptions ⇄ print_help ⇄ usage.md mapping.
+- (b) Version-string consistency.
+
+**Recommendation: one harness, two test stages**, mirroring `validate-help-layout.sh`'s style. Single file `tests/validate-help-content.sh` (or `.pl` — see § 10) emits two assertion groups, with `set -e` style early-exit on first failure. Rationale: both concerns share the same setup (locate `ltl`, run it, parse source); splitting them doubles the boilerplate without doubling the signal.
+
+## § 8. Edge cases and the "hidden option" convention
+
+**Problem.** The harness needs to know which GetOptions entries are *intentionally* absent from `print_help()`. Today this is implicit knowledge living in CLAUDE.md and code review.
+
+**Three candidate conventions**:
+
+1. **Inline comment annotation.** Append `# hidden` to the GetOptions line:
+   ```perl
+   'disable-progress' => \$disable_progress,  # hidden
+   ```
+   Pro: co-located with the declaration; survives copy-paste. Con: requires a tiny parser extension.
+
+2. **Separate sentinel array in source.** Declare `my @HIDDEN_OPTIONS = qw(disable-progress debug-layout validate-layout terminal-width ...)` near the top of the GLOBALS section. The harness reads it. Pro: one source of truth, mechanically trivial. Con: easy to forget to update when adding a new hidden flag — the same drift class this harness is trying to prevent.
+
+3. **External list in the harness itself.** Hardcode the hidden list inside `tests/validate-help-content.sh`. Pro: keeps `ltl` clean. Con: same forget-to-update risk plus loses co-location.
+
+**Recommendation: option 1 (inline `# hidden` comment).** Strongest co-location; harness extension is a one-line regex.
+
+**Other edge cases:**
+
+- The `light-background|lbg` and `no-final-pass` entries use a `sub { }` reference rather than a scalar destination. The harness's GetOptions parser must accept both `=> \$var` and `=> sub { ... }` and `=> \&named_sub` (e.g. `histogram|hg:s` → `\&handle_histogram_option` at line 4155).
+- The five "short-first" entries (`hgbpd`, `hgb`, `pbpd`, `pp`, `ep`) require the parser to split `key1|key2` and decide which is short and which is long by length (`length < 6` ≈ short, with manual override for borderline cases like `-osum`, `-tpas`, `-iqs`, `-uuid`, `-hgbpd`, `-pbpd`). Safer: declare short vs long by the convention that **short forms never contain `-`**. Test: `-hgbpd` has no hyphen ⇒ short; `histogram-buckets-per-decade` has hyphens ⇒ long. This rule correctly classifies all 75 entries.
+- `-V` (uppercase, verbose) vs `-v` (lowercase, version) — case-sensitive; the harness must preserve case.
+- `--help` is in GetOptions but its "short form" is the legacy `-?`, `/help`, `/?` mappings at `ltl:4090`. These should not be treated as drift; the harness should special-case `help`.
+
+## § 9. ltl code changes required
+
+| # | Item | Effort | Notes |
+|---|------|--------|-------|
+| 1 | Add `# hidden` comment to 10 GetOptions lines (the 9 long-only + `terminal-width`) | XS | One commit, no behavior change. Resolves "which are intentionally hidden". |
+| 2 | Decide: surface `-tw / --terminal-width` in `print_help` or keep hidden | XS | One-line judgement call; if surfaced, add to `print_help` and `usage.md`. |
+| 3 | Fix existing drift: add `-hgb / --histogram-buckets` row to `docs/usage.md` Histogram section | XS | One-line table addition; this is a *latent* bug the harness will surface. |
+| 4 | (Optional) Add docs/usage.md "Developer/hidden options" section listing the 10 hidden flags | S | Nice-to-have for transparency; not required by harness. |
+| 5 | `-V version` section | — | **Not recommended** (§ 6a). |
+| 6 | `--list-options` mode | — | **Not recommended** (§ 6b). |
+
+No production code paths change. Items 1–3 are all documentation/annotation edits.
+
+## § 10. Harness shape proposal
+
+**Filename**: `tests/validate-help-content.sh` (bash wrapper) calling `tests/validate-help-content.pl` (Perl, because parsing Perl source is what we're doing). Or single `.pl` with shebang and `set -eu`-equivalent `use strict; use warnings;`. Recommend **Perl-only** for symmetry with `validate-help-layout.sh`'s in-script `perl -ne`.
+
+**Steps**:
+
+1. Locate `ltl` relative to `$0`; abort if missing/non-executable.
+2. Read `ltl` source. Extract:
+   - `$version_number` literal from line ~64 (regex `^my\s+\$version_number\s*=\s*"([^"]+)"`).
+   - GetOptions block between `GetOptions(` and the next matching `) or die`.
+   - Per line: capture `'(...)'` first arg; split on `|`; classify each token as short (no hyphen) or long (has hyphen or len ≥ 6); detect trailing `=i`/`=s`/`:s` spec; detect trailing `# hidden` comment.
+3. Capture `ltl --help --terminal-width 120` with the same terminal-formatting strip used by `validate-help-layout.sh`. Parse using the same `^\s+(-\S+,)?\s+(--\S+)\s{2,}(.+)$` shape that `print_help()` produces.
+4. **Assertion A**: every non-hidden GetOptions long-form appears in the parsed help capture. Report orphans both ways.
+5. **Assertion B**: every help entry's short form (if any) matches the GetOptions short form for the same long name. (Catches typos like `-hb` vs `-bh`.)
+6. **Assertion C**: parse the `docs/usage.md` options tables (rows beginning with `| \`-`) and assert each non-hidden long form appears. Report orphans.
+7. **Assertion D**: capture `ltl -v` output; assert it matches `Version: $version_number` exactly.
+8. **Assertion E**: capture a quick `ltl -V <small-log>` and grep for `^version\t$version_number$` in the BENCHMARK DATA block.
+9. **Assertion F (soft)**: apply § 5 heuristics 1 and 2 to every help description; print warnings (not failures) to stderr unless `--strict`.
+10. Exit non-zero on any assertion-A/B/C/D/E failure; exit 0 on heuristic warnings (unless `--strict`).
+
+**Test log for D/E**: use a tiny `logs/` fixture; suggest `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-4.2026-01-26.txt` truncated to 100 lines via existing sample-capture pattern, or any sub-MB sample.
+
+## § 11. Open questions for human review
+
+1. **Hidden-option convention**: § 8 recommends inline `# hidden` comments. Acceptable, or prefer the sentinel array (option 2)?
+2. **`-tw / --terminal-width` disposition**: surface in `print_help` (and `usage.md`) or formally mark hidden? It has a documented user-facing use case (driving ltl from CI / non-TTY contexts), which argues for surfacing.
+3. **`docs/usage.md` scope**: should the harness treat `usage.md` as part of the contract (Assertion C is a hard failure) or as a soft warning? It's the canonical wiki source per CLAUDE.md, so a hard failure feels right — confirm.
+4. **Description-quality heuristic**: enable § 5 heuristics 1+2 as hard failures or stderr warnings only? Recommend warnings to start.
+5. **Harness language**: Perl (mirroring `validate-help-layout.sh`'s embedded Perl) or pure bash with `perl -ne` shell-outs? Recommend Perl for cleaner GetOptions parsing.
+6. **One harness or two** (§ 7): confirm single-file recommendation, or split version-consistency into its own file for granular CI failure attribution?
+
+## § 12. Effort estimate
+
+**Overall: LOW.**
+
+| Component                                       | Effort |
+|-------------------------------------------------|--------|
+| ltl annotation changes (§ 9 items 1–3)          | 30 min |
+| `tests/validate-help-content.pl` implementation | 3–4 h  |
+| CI wiring + first-run debugging                 | 1 h    |
+| **Total**                                       | **half-day to one day** |
+
+No prototypes or experiments needed. The static-analysis surface is well-bounded by the GetOptions block format. Risk is concentrated in (a) the hidden-option convention decision and (b) usage.md table-parsing robustness — both deferred to open questions above.

--- a/features/225-pattern-files.md
+++ b/features/225-pattern-files.md
@@ -1,0 +1,246 @@
+# Feature Requirements: Pattern File Regression Harness (#229)
+
+## GitHub Issues
+- [#229 — Validate `patterns/` files via test harness](https://github.com/gregeva/logtimeline/issues/229) (this work)
+- Parent: [#225 — Umbrella for high-priority test-harness coverage gaps]
+- Depends on: [#226 — `-V` section/category selectivity]
+
+## Overview
+Today nothing in CI verifies that the regex/literal entries in `patterns/` still match
+the log lines they were authored to filter. A broken entry (typo, deleted character,
+moved log format) would silently filter the wrong set and produce misleading reports.
+This document scopes a regression harness that asserts each `patterns/` file still
+produces the expected hit count against committed fixture logs.
+
+It is a research/scoping deliverable. No harness or production code is written here.
+
+## 1. Pattern File Inventory
+
+All files live in `patterns/`. Entries are loaded literally — `read_pattern_file()`
+returns lines as-is (line 1906–1913 of `ltl`), and `build_filter_matcher()` then wraps
+them with `quotemeta(...)` (line 2016). So every pattern is a **literal substring**,
+not a regex. This shapes the harness: each line is a substring-match probe, not a
+compiled regex.
+
+| File | Lines | Purpose | Target log family |
+|---|---:|---|---|
+| `patterns/probes` | 2 | Health/readiness probe URLs to exclude | Tomcat access log (ThingWorx) |
+| `patterns/metrics` | 3 | Metrics-scraping endpoints to exclude | Tomcat access log (ThingWorx) |
+| `patterns/thingworx` | 2 | ThingWorx core service endpoints | Tomcat access log (ThingWorx) |
+| `patterns/persistence-provider` | 6 (5 non-empty + trailing blank) | DB/connection-pool message substrings | ThingWorx ApplicationLog |
+| `patterns/intrustion-detector` | 5 | OWASP ESAPI intrusion markers | ThingWorx ApplicationLog/ErrorLog |
+| `patterns/navigate-app-calls` | 74 | Windchill Navigate API endpoints | Windchill Apache access log |
+
+Note: `intrustion-detector` is the file's actual on-disk name (typo). The harness
+should preserve the existing name; renaming is out of scope.
+
+Also note: `persistence-provider` has a trailing blank line, exercised by the
+empty-line skip at `ltl:1909`. The harness should treat the file as 6 patterns
+expected, with 5 effective post-load.
+
+## 2. Authoritative Match Examples
+
+Verified fixture coverage via grep against `logs/`:
+
+| Pattern file | Should-match fixture (in repo) | Most-important entry hits |
+|---|---|---|
+| `probes` | `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt` | `/Thingworx/ready` + `/Thingworx/health` together: **11,520** |
+| `metrics` | same as above | `/Thingworx/Metrics\|MetricsHC\|/metrics`: **7,059** |
+| `thingworx` | same as above | `/Thingworx/Things` + `/Services/GetNamedProperties`: **881,625** |
+| `persistence-provider` | `logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log` | `ThingworxPersistenceProvider`: 240; `database\|connections\|Connections`: 243 total. **`c3p0` and `C3P0` hit zero in this file** — first committed file with `c3p0` is `ApplicationLog.2025-05-06.0.log`. |
+| `intrustion-detector` | `logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log` | `SECURITY FAILURE`, `/ExampleApplication/`: present. **`IntrusionException` only found in untracked `logs/ThingworxLogs/archives/`**. **`Anonymous\:@unknown` (literal, backslash-escape preserved by quotemeta) matches zero files** under `logs/`. |
+| `navigate-app-calls` | `logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log` | `…/doDirectDownload`: 6; `…/servlet/odata` (substring of many entries): 637. Most of the 74 entries have not been spot-verified — likely partial coverage. |
+
+A should-NOT-match fixture for every file: any line from
+`logs/ThingworxLogs/ScriptLog.log` (pure scripting output, none of these substrings
+appear).
+
+**Fixture gaps that must be filled before the harness is useful:**
+1. `intrustion-detector` — three of five patterns have no committed fixture (one
+   tracked file with `IntrusionException`; one with `Anonymous\:@unknown`).
+2. `persistence-provider` — `c3p0`/`C3P0` need a tracked fixture; currently the
+   05-05 ApplicationLog covers only 3 of 6 entries.
+3. `navigate-app-calls` — only 3 of 74 entries have been spot-verified. Per-pattern
+   mode (see §6) would require finding or synthesising lines for the rest.
+
+## 3. Observable Surface Today
+
+What is computed and emitted regarding filter outcomes:
+
+| Signal | Source | Visible? |
+|---|---|---|
+| File-status indicator (`!` empty, `!!` error) appended to filename in command-line echo | `get_pattern_file_indicator()`, `ltl:2068`; printed at `ltl:8466–8484` | Always (echoed in the command-line block) |
+| Pattern count per loaded file | `%pattern_file_status{filter_type}{file}{count}`, `ltl:1928` | Stored but **never printed** |
+| Merged include/exclude/highlight regex string | Pushed to `@verbose_output` at `ltl:4295–4297` | Only under `-V` |
+| Per-pattern hit counts | — | **Not computed anywhere** |
+| Lines excluded / included / highlighted (running totals) | — | **Not computed anywhere** |
+
+Filter application sites are `ltl:4991` (exclude), `ltl:4992` (include), `ltl:5030`
+(highlight) — pure `match_filter()` predicates with no counter increment alongside.
+
+So today the harness has nothing to assert against beyond "ltl exits 0 and the
+overall row count in the output changes." That is too coarse for catching a single
+broken pattern.
+
+## 4. Application-Observability Gaps — Proposed `-V` Content
+
+Depends on #226's section selectivity. New named section: **`filter-summary`**.
+
+Proposed content for `ltl -V filter-summary -if patterns/probes <log>`:
+
+```
+=== FILTER SUMMARY ===
+input_lines_read: 1234567
+input_lines_filterable: 1230000        # post timestamp-parse, pre-filter
+included: 11520                         # only set when -if/--include* active
+excluded: 0
+highlighted: 0
+include_files:
+  patterns/probes: status=ok loaded=2 hit_total=11520
+    /Thingworx/ready: 5760
+    /Thingworx/health: 5760
+exclude_files: (none)
+highlight_files: (none)
+dead_patterns: (none)                   # patterns that loaded but hit 0 lines
+```
+
+Key contract points:
+- `hit_total` is the count of *post-pattern-match* lines, not lines per OR-branch
+  match (a single line that contains both substrings is counted once for the file).
+- Per-pattern counters (`/Thingworx/ready: 5760`) require running each pattern as
+  an independent regex during filter application, OR matching against the merged
+  regex with capture groups. See §7 for the implementation trade-off.
+- `dead_patterns` is the high-value catch — it surfaces entries that no longer
+  match anything in the corpus.
+- Section name `filter-summary` is consistent with §215/#226 lower-case kebab
+  convention (matching existing `=== INDEX READ-BACK ===`, `=== BIN-COUNTER MODE
+  ===`, `=== Verbose ===`).
+- When `-V filter-summary` is requested but no filter is active, emit
+  `filter_active: no` and nothing else.
+
+## 5. Negative-Case Fixtures
+
+The harness must also assert that a broken pattern file fails detectably. Concrete
+corruption types per file (description only — these files are NOT created here):
+
+| File | Corruption | Expected harness behaviour |
+|---|---|---|
+| `probes` | Drop the leading `/` from `/Thingworx/ready` | Per-pattern hit drops from 5760 to 0; harness flags dead pattern |
+| `metrics` | Replace `/Thingworx/Metrics` with `/Thingworx/Metric` (one char short) | Hit count drops below threshold |
+| `thingworx` | Delete `/Services/GetNamedProperties` entirely | File loaded with N-1 patterns; harness asserts loaded count |
+| `persistence-provider` | Insert null byte at byte 0 | `read_pattern_file()` already rejects as binary (`ltl:1892`); harness asserts stderr warning + `status=error` |
+| `intrustion-detector` | Mangle `Anonymous\:@unknown` to `Anonymous:@unknown` | Per-pattern hit count differs; both versions probably hit zero in the current corpus — see §2 gap |
+| `navigate-app-calls` | Truncate to 0 bytes | `read_pattern_file()` flags empty (`ltl:1916`); harness asserts `!` indicator + `status=empty` |
+
+**Strategy:** keep production `patterns/*` pristine. Place broken variants under
+`tests/pattern-fixtures/corrupted/` with descriptive suffixes
+(`probes.missing-slash`, `metrics.truncated`, etc.). The harness runs ltl against
+each corrupted file and asserts on the expected failure mode (specific stderr
+warning, specific `-V filter-summary` value, or a specific exit-code/row-count
+delta versus the pristine baseline).
+
+## 6. Per-Pattern vs Whole-File Assertions
+
+**Whole-file** assertion: run ltl once with `-if patterns/X`, assert total included
+count equals a baselined number. Cheap. Catches catastrophic damage. **Misses
+single-line breakage** if other patterns in the file pick up the slack (e.g.
+losing `/Thingworx/ready` looks fine if the test fixture also matches
+`/Thingworx/health`, because included-total drops by only 50%).
+
+**Per-pattern** assertion: assert each entry's hit count. Catches dead patterns
+and one-line drift. Requires either (a) running ltl 6+74+... times — slow, or
+(b) `filter-summary` exposing per-pattern counts.
+
+**Recommendation:** per-pattern, single ltl run per file, using the `filter-summary`
+output. The `navigate-app-calls` per-line maintenance cost is real but tolerable
+because we use a *threshold* rather than an exact equality:
+`hit >= 1` (alive) vs `hit == 0` (dead). For a handful of high-value entries
+(`probes/*`, `metrics/*`, the top-3 thingworx entries) the harness can additionally
+assert exact-equality against a baseline. Per-line exact-equality across all 74
+navigate entries should be opt-in (`--strict`), not the default.
+
+## 7. ltl Code Changes Required
+
+- [ ] **Add `-V filter-summary` section** — depends on #226 landing first. Wire
+  `filter_summary` into the section registry, gated behind `$verbose &&
+  section_enabled('filter-summary')`. Effort: **low** (boilerplate once #226 is
+  in).
+- [ ] **Per-pattern hit counting** — does not exist today. Two implementation
+  options:
+  - (a) Keep the merged-regex fast path; only when `-V filter-summary` is active
+    AND per-pattern detail requested, run each pattern as an independent
+    `index($line, $literal) >= 0` check on lines that already matched the merged
+    regex. Avoids slowing the hot path. Effort: **med**.
+  - (b) Always loop per-pattern, dropping the merged-regex optimisation. Simpler
+    code, measurable perf regression on large logs. **Not recommended.**
+  Recommend (a).
+- [ ] **Stable identifier per pattern file** — already present:
+  `%pattern_file_status{filter_type}{filename}`. Reuse this hash as the
+  identifier in `filter-summary` output. Effort: **none**.
+- [ ] **Lines-read / lines-included / lines-excluded totals** — counters
+  alongside `ltl:4991`, `ltl:4992`, `ltl:5030`. Effort: **low**.
+- [ ] **Empty/error indicators reachable from `-V`** — already in
+  `%pattern_file_status{...}{status}`. Effort: **none**.
+- [ ] **Help text + `docs/usage.md` updates** for new `-V` section. Effort: **low**.
+
+Total ltl-side effort: **low–med**, contingent on #226.
+
+## 8. Harness Shape Proposal
+
+File: `tests/validate-pattern-files.sh` (matching the existing
+`tests/validate-*.sh` pattern).
+
+Sketch — numbered steps, no bash code:
+
+1. Define a baseline table mapping `(pattern_file, filter_type, fixture_log)` to
+   expected per-pattern hit counts (alive/threshold) and total counts (exact).
+2. For each pattern file in `patterns/`:
+   a. Run `ltl --disable-progress -V filter-summary -<if|ef|hf> patterns/<file>
+      <fixture_log>` capturing stdout.
+   b. Parse the `=== FILTER SUMMARY ===` block.
+   c. Assert `status=ok` and `loaded=<expected count>`.
+   d. Assert per-pattern `hit > 0` for every line in the pattern file (alive).
+   e. For high-value entries, assert exact `hit` equals baseline.
+   f. Assert `dead_patterns: (none)`.
+3. For each corrupted fixture under `tests/pattern-fixtures/corrupted/`:
+   a. Run ltl with that pattern file, capturing stderr and the filter-summary.
+   b. Assert the expected failure mode (specific stderr token, specific
+      `status=empty|error`, or specific delta vs baseline).
+4. Emit a TAP-style summary; exit non-zero on any assertion failure.
+5. Reuse `tests/validate-regression.sh`'s helper conventions for
+   width/locale isolation.
+
+Out of scope for the harness itself: synthesising fixture logs (must be done
+manually as part of resolving §2 gaps).
+
+## 9. Open Questions for Human Review
+
+1. **Fixture-gap policy.** Three pattern files have entries with no tracked
+   fixture (intrusion-detector × 2, persistence-provider × 2, navigate-app-calls
+   × ~71 unverified). Do we (a) commit hand-crafted fixture files specifically
+   for the harness, (b) accept partial coverage and only assert on entries with
+   matches, or (c) defer #229 until fixture gaps are closed?
+2. **Strictness default.** Should the harness default to "alive" (hit ≥ 1) per
+   entry, with exact-equality opt-in via `--strict`? Or default to strict for
+   small files (`probes`, `metrics`, `thingworx`) and alive-only for
+   `navigate-app-calls`?
+3. **Section name and scope.** Is `filter-summary` the right name, or should
+   this be folded into an existing section (e.g. extend the current `===
+   Verbose ===` block in-place rather than adding a new named section)? #226
+   may already prescribe a naming convention we should match.
+4. **Per-pattern counting cost.** Acceptable to do the extra
+   `index($line,$literal)` pass only when `-V filter-summary` is on, OR is the
+   user happy to always pay it for the dead-pattern observability?
+5. **Untracked archive logs.** Should `logs/ThingworxLogs/archives/` be brought
+   under git (and LFS if needed) so harness fixtures are deterministic, or
+   should the harness use only currently-tracked logs?
+
+## 10. Effort Estimate
+
+- ltl changes (assuming #226 landed): **0.5 day** — counters + section emission.
+- Fixture gap resolution: **0.5–1 day** depending on how many entries need
+  hand-crafted lines vs found in existing logs.
+- Harness script (`validate-pattern-files.sh`): **0.5 day**.
+- Negative-case fixtures and assertions: **0.5 day**.
+
+**Overall: medium effort, ~2–3 days of focused work, blocked on #226.**


### PR DESCRIPTION
## Summary

- Adds 9 research markdown files under `features/` covering all sub-tasks of #225 (test-harness coverage gaps)
- Updates CLAUDE.md branch-naming rule to require semantic slugs derived from issue titles (anti-pattern: activity-based names)
- No code changes; research and convention-tightening only

## Research deliverables (one per sub-task)

| Sub-task | File | Headline finding |
|---|---|---|
| #227 binary smoke | `features/225-binary-smoke.md` | Windows binaries never executed on real Windows host in CI; arm64 Linux only inspected with `file` |
| #228 format detection | `features/225-format-detection.md` | Apache HTTP `%D` microseconds silently misinterpreted as ms (1000× error) — match types 3/9 default-ms with no autodetect |
| #229 pattern files | `features/225-pattern-files.md` | `patterns/*` are literal substrings (not regex) per `quotemeta()` at ltl:2016; two pattern files lack fixture coverage |
| #230 filter logic | `features/225-filter-logic.md` | Inline `-i`/`-e`/`-h` are regex; file `-if`/`-ef`/`-hf` are literal substrings; `!` negation does NOT exist despite #225 issue body's assumption |
| #231 CLI validation | `features/225-cli-validation.md` | 25 flag-interaction rules cataloged; 8 silent-override gaps where ltl ignores user flags without warning |
| #232 --help content | `features/225-help-content.md` | Concrete drift bug found: `-hgb` in GetOptions and `print_help` but missing from `docs/usage.md` |
| #233 degenerate inputs | `features/225-degenerate-inputs.md` | Existing zero-sample guards prevent div-by-zero; bogus epoch-zero timestamps in summary table when no data; 7 cases collapse to same message |
| #234 doc examples | `features/225-doc-examples.md` | `docs/test-logs.md:191` uses the corrupt 2025-03-21 log file in a documented example |
| #235 heatmap fixtures | `features/225-heatmap-histogram-coverage.md` | 18 new fixtures proposed across reduced equivalence classes; `--exact-percentiles` policy extends to histograms |

## Cross-cutting findings

The research surfaced **10 latent issues in production code or docs** not previously filed:
- Operationally serious: Windows binary not executed in CI, Apache `%D` ms-misinterpretation, 8 silent-override gaps
- Doc bugs: `docs/test-logs.md:37` false claim about autodetect, `docs/test-logs.md:191` uses corrupt file, `-hgb` missing from usage.md
- Minor: filename typo `intrustion-detector`, inconsistent error formatting

Each is candidate for a follow-up issue but is not in scope for this PR.

## CLAUDE.md change

Tightens branch-naming rule from `{issue-number}-{short-description}` to `{issue-number}-{semantic-slug-from-issue-title}` with explicit anti-patterns. The old phrasing allowed activity-based names like `225-research-deliverables` to drift from issue identity; the new phrasing forbids them.

## Test plan

- [x] All 9 deliverables on disk (verified)
- [x] Branch name derived from issue title per new rule
- [x] No code changes — research files and documentation update only
- [x] Pre-commit hook passed (no secrets staged)

## Next steps (out of scope for this PR)

After merge:
- Cross-link each research file to its sub-issue (#227-#235)
- Propose issue-body corrections for factual errors my original wording introduced (regex vs literal patterns, `!` negation, etc.)
- File the 10 latent bugs as separate issues
- Begin wave-0 implementation work (#226 framework, then #227/#232/#234/#235)

🤖 Generated with [Claude Code](https://claude.com/claude-code)