### PR TITLE
Issue #221: align -o CSV column names

### DIFF
--- a/features/fuzzy-message-consolidation.md
+++ b/features/fuzzy-message-consolidation.md
@@ -1076,8 +1076,8 @@ The prototype is 1.9× faster and uses 40% less memory than ltl -od. S1 inline m
    - Population variance: `sum_of_squares / N - mean^2` (not sample variance)
    - Mean: `int(total_duration / duration_count)` where `duration_count` is length of durations array
    - Percentiles: `int($sorted[int($n * fraction)])` index method
-   - MeanBytes: `int(total_bytes / occurrences + 0.5)` (rounded)
-   - StdDev formatted to 3 decimal places, CV to 2
+   - mean_bytes: `int(total_bytes / occurrences + 0.5)` (rounded)
+   - std_dev formatted to 3 decimal places, cv to 2
 
 6. **CSV output:** Prototype writes `/tmp/prototype-messages.csv` in ltl's MESSAGES CSV format for comparison.
 
@@ -1089,25 +1089,25 @@ Tested against ltl CSV baseline for two unconsolidated entries that exist in bot
 
 | Field | ltl | Prototype |
 |-------|-----|-----------|
-| Occurrences | 12466 | 12466 |
-| MeanBytes | 87 | 87 |
-| TotalBytes | 1078390 | 1078390 |
-| Min/Mean/Max | 0/1/13 | 0/1/13 |
-| StdDev | 1.181 | 1.181 |
-| P1/P50/P75/P90/P95/P99/P99.9 | 0/1/2/3/3/3/4 | 0/1/2/3/3/3/4 |
-| CV | 1.18 | 1.18 |
-| TotalDuration | 13829 | 13829 |
+| occurrences | 12466 | 12466 |
+| mean_bytes | 87 | 87 |
+| bytes | 1078390 | 1078390 |
+| min/mean/max | 0/1/13 | 0/1/13 |
+| std_dev | 1.181 | 1.181 |
+| p1/p50/p75/p90/p95/p99/p999 | 0/1/2/3/3/3/4 | 0/1/2/3/3/3/4 |
+| cv | 1.18 | 1.18 |
+| duration | 13829 | 13829 |
 
 **ThingWorx DPM — `GetMetricsList` (32 occurrences):**
 
 | Field | ltl | Prototype |
 |-------|-----|-----------|
-| Occurrences | 32 | 32 |
-| Min/Mean/Max | 949/1018/1149 | 949/1018/1149 |
-| StdDev | 62.659 | 62.659 |
-| P1/P50/P75/P90/P95/P99/P99.9 | 949/1016/1041/1070/1128/1149/1149 | 949/1016/1041/1070/1128/1149/1149 |
-| CV | 0.06 | 0.06 |
-| TotalDuration | 32606 | 32606 |
+| occurrences | 32 | 32 |
+| min/mean/max | 949/1018/1149 | 949/1018/1149 |
+| std_dev | 62.659 | 62.659 |
+| p1/p50/p75/p90/p95/p99/p999 | 949/1016/1041/1070/1128/1149/1149 | 949/1016/1041/1070/1128/1149/1149 |
+| cv | 0.06 | 0.06 |
+| duration | 32606 | 32606 |
 
 **All fields match exactly** across both log formats. The stats merging implementation is correct and matches ltl's computation.
 

--- a/ltl
+++ b/ltl
@@ -7459,7 +7459,7 @@ sub normalize_data_for_output {
             push @output_columns, $category_bucket;
         }
     }
-    push @output_columns, "totalOccurrences"; # if $category_bucket =~ /^err-rate$/;
+    push @output_columns, "occurrences"; # if $category_bucket =~ /^err-rate$/;
 
     # --- Layout engine (Phase 1): build and calculate but do NOT use for rendering ---
     {
@@ -7541,7 +7541,7 @@ sub normalize_data_for_output {
     foreach my $key (@graph_columns) {
         if (defined $max_total{$key} && $max_total{$key} != 0) {
             push @populated_graph_columns, $key;
-            push @output_columns, "${key}Nice" if $key =~ /^(duration|bytes)$/;
+            push @output_columns, "${key}_nice" if $key =~ /^(duration|bytes)$/;
             if ($key =~ /^count$/) {
                 push @output_columns, "${key}_occurrences", "${key}_min", "${key}_mean", "${key}_max", "${key}_sum" if !$omit_count;
             } elsif ($key =~ /^udm_/) {
@@ -8142,7 +8142,7 @@ sub print_bar_graph {
             # Add the log level message counts to the output CSV file
             foreach my $category_bucket ( @output_columns ) {
                next if $category_bucket =~ /^timestamp$/;								# skip the first column and get to the counts
-               last if $category_bucket =~ /^totalOccurrences$/;								# only fill in empty values up to the totalOccurrences
+               last if $category_bucket =~ /^occurrences$/;								# only fill in empty values up to the occurrences column
 
                if( exists $output_columns{$category_bucket} ) {								# if there was a count for this log level, add it to the list
                    push @csv_data, $output_columns{$category_bucket};
@@ -9783,7 +9783,7 @@ if( $write_messages_to_csv ) {                     # If write to CSV enabled, op
             push @udm_csv_headers, "${csv_prefix}_occurrences", "${csv_prefix}_min", "${csv_prefix}_mean", "${csv_prefix}_max", "${csv_prefix}_sum";
         }
     }
-    $csv->print($csv_fh, [qw(Category Message Occurrences MeanBytes TotalBytes TotalBytesNice count_occurrences count_min count_mean count_max count_sum MinDuration MeanDuration MaxDuration StdDev P1 P50 P75 P90 P95 P99 P99.9 CV TotalDuration TotalDurationNice Impact), @udm_csv_headers]);
+    $csv->print($csv_fh, [qw(category message occurrences mean_bytes bytes bytes_nice count_occurrences count_min count_mean count_max count_sum min mean max std_dev p1 p50 p75 p90 p95 p99 p999 cv duration duration_nice impact), @udm_csv_headers]);
 }
 
 print_message_summary();														                    # Print and write message summaries

--- a/prototype/96-fuzzy-consolidation.pl
+++ b/prototype/96-fuzzy-consolidation.pl
@@ -1659,7 +1659,7 @@ for my $i (0 .. $show_count - 1) {
 # Write MESSAGES CSV (matching ltl format for validation)
 my $csv_file = "/tmp/prototype-messages.csv";
 open my $csv_fh, '>', $csv_file or die "Cannot open $csv_file: $!";
-print $csv_fh "Category,Message,Occurrences,MeanBytes,TotalBytes,TotalBytesNice,count_occurrences,count_min,count_mean,count_max,count_sum,MinDuration,MeanDuration,MaxDuration,StdDev,P1,P50,P75,P90,P95,P99,P99.9,CV,TotalDuration,TotalDurationNice,Impact\n";
+print $csv_fh "category,message,occurrences,mean_bytes,bytes,bytes_nice,count_occurrences,count_min,count_mean,count_max,count_sum,min,mean,max,std_dev,p1,p50,p75,p90,p95,p99,p999,cv,duration,duration_nice,impact\n";
 
 for my $e (@all_entries) {
     my $s = $e->{stats};
@@ -1670,7 +1670,7 @@ for my $e (@all_entries) {
     # Format values matching ltl output
     my $mean_bytes     = defined $s->{mean_bytes}     ? $s->{mean_bytes}               : '';
     my $total_bytes    = defined $s->{total_bytes}     ? $s->{total_bytes}              : '';
-    my $total_bytes_n  = '';  # TotalBytesNice — cosmetic, skip for validation
+    my $total_bytes_n  = '';  # bytes_nice — cosmetic, skip for validation
     my $min_dur        = defined $s->{min}             ? $s->{min}                      : '';
     my $mean_dur       = defined $s->{mean}            ? int($s->{mean})                : '';
     my $max_dur        = defined $s->{max}             ? $s->{max}                      : '';
@@ -1684,7 +1684,7 @@ for my $e (@all_entries) {
     my $p999           = defined $s->{p999}            ? $s->{p999}                     : '';
     my $cv             = defined $s->{cv}              ? sprintf("%.2f", $s->{cv})      : '';
     my $total_dur      = defined $s->{total_duration}  ? $s->{total_duration}           : '';
-    my $total_dur_nice = '';  # TotalDurationNice — cosmetic, skip for validation
+    my $total_dur_nice = '';  # duration_nice — cosmetic, skip for validation
     my $impact         = '';  # Impact — derived, skip for now
 
     print $csv_fh "plain,\"$msg\",$occ,$mean_bytes,$total_bytes,$total_bytes_n,,,,,,$min_dur,$mean_dur,$max_dur,$std_dev,$p1,$p50,$p75,$p90,$p95,$p99,$p999,$cv,$total_dur,$total_dur_nice,$impact\n";

--- a/releases/v0.14.6.md
+++ b/releases/v0.14.6.md
@@ -1,5 +1,9 @@
 # Release v0.14.6
 
+## Breaking Changes
+
+- CSV outputs (`-o`) now use consistent snake_case lowercase column names across MESSAGES and STATS, aligned with internal metric identifiers (`%log_stats` keys). MESSAGES headers `MinDuration`, `MeanDuration`, `MaxDuration`, `StdDev`, `P1`–`P99.9`, `CV`, `TotalDuration`, `TotalDurationNice`, `TotalBytes`, `TotalBytesNice`, `MeanBytes`, `Occurrences`, `Category`, `Message`, `Impact` become `min`, `mean`, `max`, `std_dev`, `p1`–`p999`, `cv`, `duration`, `duration_nice`, `bytes`, `bytes_nice`, `mean_bytes`, `occurrences`, `category`, `message`, `impact`. STATS headers `totalOccurrences`, `bytesNice`, `durationNice` become `occurrences`, `bytes_nice`, `duration_nice`. External CSV consumers must update column references. (#221)
+
 ## What's New
 
 - `-V` now accepts an optional section argument so harnesses and humans can request specific diagnostic sections (`-V <name>`, `-V a,b`, `-V list`, `-V all`); section delimiters and names are stability-contracted (#226)


### PR DESCRIPTION
## Summary
- Align `-o` MESSAGES and STATS CSV column names with the internal `%log_stats` keys: snake_case lowercase everywhere
- MESSAGES: `P99.9`→`p999`, `MinDuration`→`min`, `MeanDuration`→`mean`, `MaxDuration`→`max`, `StdDev`→`std_dev`, `TotalDuration`→`duration`, `TotalDurationNice`→`duration_nice`, `TotalBytes`→`bytes`, `TotalBytesNice`→`bytes_nice`, `MeanBytes`→`mean_bytes`, `Occurrences`→`occurrences`, `Category`→`category`, `Message`→`message`, `Impact`→`impact`, `P1..P99`→`p1..p99`, `CV`→`cv`
- STATS: `totalOccurrences`→`occurrences`, `bytesNice`→`bytes_nice`, `durationNice`→`duration_nice`
- Hard cut, no dual-emit; documented under a new "Breaking Changes" section in `releases/v0.14.6.md`
- Also updates the validation reference table in `features/fuzzy-message-consolidation.md` and the CSV header emitted by `prototype/96-fuzzy-consolidation.pl` so the prototype keeps matching ltl's output

## Test plan
- [x] Regression suite passes (`tests/validate-regression.sh`: 38/38) — display path unaffected
- [x] Verified MESSAGES + STATS headers against the proposed mapping (small log run against `ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log`)
- [x] Spot-checked first data row alignment — `p999` column carries the value previously under `P99.9`
- [x] Full grep sweep across `ltl`, `tests/`, `docs/`, `features/`, `prototype/` — no stale old-name references outside historical release notes

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)