### PR TITLE
Issue #222: SRE-grade distribution-analysis columns; remove unused z_score

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -208,6 +208,23 @@ ltl -V histogram-bin-counters access.log
 ltl -ep access.log
 ```
 
+### Distribution shape (CSV columns)
+
+The `-o` CSV outputs (MESSAGES and STATS) carry three distribution-shape statistics alongside the percentile columns, enabling characterization of a latency distribution's *shape* — not just its quantile values:
+
+| Column | Range | Interpretation |
+|---|---|---|
+| `skewness` | typically -3 to +3 | Distribution asymmetry. 0 = symmetric (e.g. Gaussian); positive = right tail heavier (typical for latencies); negative = left tail heavier. |
+| `kurtosis` | typically -2 to ~30 | Excess kurtosis (normal = 0). Positive = heavier tails than a Gaussian; high values (> 10) indicate extreme outliers dominate. |
+| `bimodality_coef` | 0 to 1 | Sarle's bimodality coefficient. **Values > 5/9 ≈ 0.555 flag suspect multimodal distributions** (e.g. cache-hit vs. cache-miss populations within a single API). |
+
+Sample-size requirements:
+- All three statistics require `n ≥ 4`; emitted blank otherwise (BC denominator requires `n > 3`).
+- `bimodality_coef` is a *screening* statistic, not a test. At `n < 100` small-sample noise can produce false positives — treat low-sample bimodality flags as exploratory.
+- `p9999` is meaningful at `n ≥ ~100,000`; below that, it collapses toward `max`.
+
+The body percentile `p25` and the precomputed interquartile range `iqr` (= `p75 − p25`) are also emitted in both CSV files, completing the body/tail percentile pairing recommended in the Google SRE book.
+
 ### Heatmap
 
 Heatmap mode replaces the per-bucket latency statistics with a color-intensity visualization showing how values are distributed within each time bucket. Where percentile statistics reduce a distribution to a handful of numbers, the heatmap reveals its full shape — bimodal distributions (cache hits vs. misses), shifting modes over time, outlier clustering, and long tails all become visually apparent. Each cell represents a value range, with color intensity proportional to the number of entries falling within that range. Logarithmic bucket boundaries provide resolution across the full range of values, from sub-millisecond to multi-second durations.

--- a/features/219-baseline-anomaly-detection-research.md
+++ b/features/219-baseline-anomaly-detection-research.md
@@ -1,0 +1,159 @@
+# Baseline-driven anomaly detection — research foundation (#219)
+
+## Purpose
+
+Capture the research findings that bear on **#219 (baseline-driven anomaly detection)** and on the related but distinct goal of **per-API inflection-point detection**. The research was conducted while scoping #222 (SRE-grade distribution-analysis CSV columns); the shape-moment and tail columns landed under #222 are referenced here as the *upstream substrate* that future #219 work will consume.
+
+This file is a frozen research record. Implementation discussions for #219 belong in a separate planning document at the time #219 is scheduled.
+
+---
+
+## What #222 delivered (substrate)
+
+For each per-key (MESSAGES) row and each per-bucket (STATS) row, ltl now emits in the `-o` CSV:
+
+- **Body percentile fill:** `p25`, `iqr` (= `p75 − p25`)
+- **High-volume tail:** `p9999`
+- **Shape moments:** `skewness`, `kurtosis` (excess; normal = 0)
+- **Multimodality screening:** `bimodality_coef` (Sarle's BC; > 5/9 ≈ 0.555 → suspect multimodal)
+
+These columns are O(n) to compute on the existing sorted array inside `calculate_statistics`. They provide a **three-column shape fingerprint** (skewness + kurtosis + BC) at every row, which any downstream consumer — including the future #219 baseline comparator — can use to detect *distribution-shape change* in addition to *percentile-value change*.
+
+The unused `z_score` column was removed from STATS in the same commit; it was a rolling-window z-score on the bucket mean that no display path or internal logic consumed.
+
+---
+
+## Four SRE analysis goals the research surveyed
+
+1. **Load-shape mode characterization** — per API, identifying unimodal/bimodal/heavy-tail/bounded distributions; distinguishing populations within a single key (e.g. cache-hit vs cache-miss).
+2. **Mode evolution over time** — detecting that a key's shape is changing across time buckets (e.g. previously unimodal becoming bimodal; tail expansion while body stays stable).
+3. **Per-API inflection-point detection** — identifying the load level at which a key's latency knee occurs; the load-vs-latency curve.
+4. **Per-API certainty** — bounding the confidence of any "API X has degraded" assertion based on sample size and tail-quantile stability.
+
+Goals 1, 2, and 4 are addressable from MESSAGES (per-key totals) or STATS (per-bucket totals) with column additions — that's what #222 delivered. **Goal 3 is structurally unsolvable from those two CSV shapes** — and that finding is the focus of this document.
+
+---
+
+## The goal-3 structural gap
+
+| Existing CSV | Per-key partition? | Per-bucket time axis? | Sufficient for inflection? |
+|---|---|---|---|
+| MESSAGES | ✓ | ✗ (totals over the whole run) | No |
+| STATS | ✗ (totals across all keys) | ✓ | No |
+
+Per-API inflection-point detection requires *all three axes at once*:
+- A **per-key partition** (so the per-API curve is isolable)
+- A **per-bucket time axis** (so load varies)
+- A **load metric** alongside latency in the same row (so the curve is fittable)
+
+Neither MESSAGES nor STATS carries all three. MESSAGES has the per-key partition but no time; STATS has time but no per-key partition. **Adding columns to either cannot close the gap** — the missing dimension is in the CSV's row shape, not its column list.
+
+This is why the original #222 research recommended splitting goal 3 into a follow-up issue. #219 (baseline-driven anomaly detection) is the closest existing ticket; the recommendation is that #219's design conversation pick up the structural finding rather than #222 dragging it in.
+
+---
+
+## Literature/practice grounding (sources)
+
+The full source list is in the research report at `/tmp/222-research.md` (working copy; the substantive citations of interest to #219 are reproduced below):
+
+| Source | Relevance to #219 |
+|---|---|
+| **HdrHistogram** (Gil Tene) | "Progression of nines" argument: high nines (p99.9, p99.99) cannot be recomputed from lower nines, must be emitted explicitly. #222's `p9999` honors this; #219's baseline comparator should treat each nine as an independent dimension, not just compare p99. |
+| **Google SRE Book Ch. 6** | "Multi-grade SLO" framing: body+tail percentile pairing is the SLO grammar. A meaningful "is API X degraded vs baseline?" comparison should track *both* a body percentile and a tail percentile, not collapse to one anchor. |
+| **USE/RED methods** (Brendan Gregg, Tom Wilkie) | USE adds *saturation* as a first-class signal. Goal-3 inflection detection cannot proceed without a load axis paired with the latency axis — RED dashboards always pair `rate` with `duration` at the same bucket. |
+| **OpenTelemetry exponential histograms** | The convergent design across OTel/Prometheus/DDSketch is **carry bins, derive quantiles** — bins are the truth, percentiles are a projection. ltl's existing bin-counter primitive (`%heatmap_data`, ~53 bpd default) is structurally aligned with this design. A future per-key × per-bucket emission could expose per-key bin counts at low cost. |
+| **DDSketch** (Datadog) | Relative-error guarantee in the tail (~2% typical). The right shape for "how much did this API's p99 move?" is a per-quantile relative-error bound, not an absolute-value bound. |
+| **Honeycomb BubbleUp** | The closest extant pattern for goal 3 baseline anomaly detection: compare in-selection distribution vs surrounding-baseline distribution, rank dimensions that explain the difference. The shape — selection vs reference, with a ranked output — is what #219 should aim for. |
+| **Sarle's bimodality coefficient** | `BC = (g² + 1) / (k + 3(n-1)²/((n-2)(n-3)))`. Cheapest multimodality screen available; flags shape changes (uni → bi) that no percentile movement can capture. #222 emits this per-row; #219's comparator can use *change in BC* as a signal independent of percentile drift. |
+| **Hartigan's dip test** | Expensive lookup-based test; Sarle BC captures ~80–90% of the screening signal at ~0% added cost. Recommendation for #219: do not adopt dip test unless BC false-positive rate is shown problematic in practice. |
+| **Bootstrap percentile sample-size literature** | For percentile p_q from n observations, 95% CI half-width on rank ≈ ±1.96 × √(n × q × (1−q)). p99.9 needs n ≥ ~10,000 for any meaning; p99.99 needs n ≥ ~100,000. #219 must suppress comparisons where one side has insufficient n. |
+
+---
+
+## Recommendations for a future #219 design pass
+
+These are **research findings**, not approved design decisions. They are written to seed the #219 planning conversation.
+
+### R1 — Add a third CSV shape: per-key × per-bucket
+
+The minimal data shape for goal 3 (inflection) and a strong baseline comparator (goal 4) is:
+
+```
+timestamp, category, message, occurrences,
+<load_metric>,
+min, mean, max, std_dev,
+p1, p25, p50, p75, iqr, p90, p95, p99, p999, p9999,
+cv, skewness, kurtosis, bimodality_coef
+```
+
+One row per `(time_bucket, key)` pair. The MESSAGES shape collapses time; the STATS shape collapses key; this third file (working name: **PERMSG-STATS**) collapses neither.
+
+The load metric column is the critical addition: `sessions` (concurrent count proxy) is the natural choice given ltl already auto-detects it; alternatives are `msg-rate` per bucket per key, or `count` per bucket per key. The choice affects which inflection curve is fittable.
+
+CLI shape suggestion: `-ops` / `--output-per-key-stats` to emit alongside existing MESSAGES + STATS.
+
+Risk: row explosion. A 24-hour log with 5-minute buckets and 1,000 unique keys produces 288,000 rows. Mitigation: only emit rows where `occurrences > 0` for the key in the bucket (which is the natural sparseness — most keys don't fire in most buckets).
+
+### R2 — Baseline comparator (the headline #219 idea)
+
+Given the post-#222 shape, the **per-row signal vector** for comparing baseline vs current is roughly:
+
+```
+{ p50, p95, p99, p999, p9999, skewness, kurtosis, bimodality_coef }
+```
+
+Eight dimensions per key. A row-level "deviance" score is then a weighted distance over those dimensions, with per-dimension tolerance bands derived from baseline sample size (n-aware certainty).
+
+Three modes per #219 issue body:
+- **Filter in** — show only keys whose vector-distance exceeds threshold
+- **Filter out** — hide keys whose vector-distance is within tolerance
+- **Highlight** — render all keys, visually flag deviant rows
+
+For **bimodality_coef specifically**, the signal isn't "BC moved by X" — it's "BC crossed the 0.555 threshold *in one direction*". A key that went from BC=0.4 (unimodal) to BC=0.7 (multimodal) is a regime change, not a continuous drift. The comparator should treat threshold crossings as distinct events.
+
+### R3 — Sample-size gating
+
+For each percentile column compared, suppress the comparison if `n < n_min(q)`:
+- p99 needs `n ≥ ~1,000`
+- p999 needs `n ≥ ~10,000`
+- p9999 needs `n ≥ ~100,000`
+- skewness/kurtosis/BC need `n ≥ 4` (already enforced by #222 — emitted blank otherwise) but for *meaningful* comparison `n ≥ ~100`
+
+A key with 50 occurrences in baseline and 50 occurrences in current cannot meaningfully report a p999 change. Surface as "n too low to compare" rather than treating absence as zero.
+
+### R4 — Threshold expression
+
+#219 issue body asks "absolute (ms), relative (%), or sigma-style?" The literature converges on **relative-error in the tail, absolute-or-sigma in the body**:
+- p1 / p25 / p50 / p75 → absolute or sigma (the body is typically tight; relative thresholds blow up near zero)
+- p90 / p95 / p99 / p999 / p9999 → relative-error (DDSketch grammar; tail movement is naturally multiplicative)
+- skewness / kurtosis → absolute delta with a min-magnitude floor
+- bimodality_coef → threshold-crossing, not delta
+
+A single threshold-shape switch (`--threshold-relative` / `--threshold-absolute`) would underserve the analysis. The default should be per-column-class.
+
+### R5 — New keys, disappeared keys
+
+#219 issue body asks how to handle messages present in one run but not the other. Recommendation:
+- **New key in current** — list separately as "newly observed in current", flag if occurrences > meaningful-N floor
+- **Disappeared key in baseline** — list separately as "absent from current", flag if baseline occurrences > meaningful-N floor (suggests dropped traffic, not natural decay)
+
+Not "synthesize zero values for missing keys" — that distorts the deviance computation.
+
+---
+
+## What this file is NOT
+
+- An implementation plan for #219. That belongs in a future planning doc when #219 is scheduled.
+- A binding commitment to any specific column set, threshold, or CSV shape. The recommendations above are research-grounded but not approved.
+- A statement that #178 (inflection detection) is the same as #219. They're related — both need a per-key × per-bucket data shape — but #178 is curve-fitting (USL-style), and #219 is distribution comparison. They share the same upstream substrate (R1).
+
+---
+
+## Cross-references
+
+- **#222** (delivered) — added the shape-moment + body/tail percentile columns referenced as R2's signal vector
+- **#219** (the home for the next iteration) — this file's R2/R3/R4/R5 inform that conversation
+- **#178** (planned) — per-API inflection-point detection; shares R1's per-key × per-bucket substrate
+- **#187** — unified percentile contract; the bin-counter primitive that R1's load-metric-aware extension could exploit
+- **#224** (planned) — percentile-value regression harness; once #224 + #219 both exist, they form a tiered observability gate (drift detection in 224, structural anomaly in 219)
+- Research source notes at `/tmp/222-research.md` (working copy; survives this session for cross-checking but is not committed)

--- a/ltl
+++ b/ltl
@@ -64,8 +64,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 my $version_number = "0.14.5";
 my $start_time = [gettimeofday];
 my $log_base = 2;
-my ( @rolling_window, @ORIGINAL_ARGV, @files_processed );
-my $rolling_window_size = 5;					# Adjust this value as needed - more time buckets included in the rolling window will give better sample for Z-score
+my ( @ORIGINAL_ARGV, @files_processed );
 my $impact_time_exponent = 7;		            # it was 5, and was weighting a few slow executions too heavily compared to frequent faster executions
 my ( $time_bucket_size, $bucket_size_seconds, $print_seconds, $print_milliseconds, $print_version, $omit_empty, $omit_summary, $omit_rate, $omit_stats, $omit_durations, $omit_bytes, $omit_count ) = 0;
 my ( $include_query_string, $include_session, $include_threadpool_summary, $include_count ) = ( 0, 0, 0, 0 );
@@ -6634,7 +6633,10 @@ sub calculate_all_statistics {
     
         # The duration based statistics won't catch the counts if there are no durations (see else condition below)
         if( $print_durations && !$omit_durations ) {
-            my ($min, $mean, $max, $p1, $p50, $p75, $p90, $p95, $p99, $p999, $std_dev, $cv) = calculate_statistics($aggregated_data);
+            my ($min, $mean, $max,
+                $p1, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999,
+                $std_dev, $cv,
+                $skewness, $kurtosis, $bimodality_coef) = calculate_statistics($aggregated_data);
 
             $log_stats{$bucket} = {
                 occurrences   => $aggregated_data->{occurrences},
@@ -6653,39 +6655,21 @@ sub calculate_all_statistics {
                 mean          => $mean,
                 max           => $max,
                 p1            => $p1,
+                p25           => $p25,
                 p50           => $p50,
                 p75           => $p75,
+                iqr           => $iqr,
                 p90           => $p90,
                 p95           => $p95,
                 p99           => $p99,
                 p999          => $p999,
+                p9999         => $p9999,
                 std_dev       => $std_dev,
                 cv            => $cv,
-                z_score       => undef
+                skewness      => $skewness,
+                kurtosis      => $kurtosis,
+                bimodality_coef => $bimodality_coef,
             };
-    
-            # Calculate rolling mean and std_dev (only if we have valid statistics)
-            if (defined $mean) {
-                my $rolling_mean = 0;
-                my $rolling_sum_of_squares = 0;
-                my $rolling_count = 0;
-                foreach my $prev_bucket (@rolling_window) {
-                    $rolling_mean += $prev_bucket->{mean};
-                    $rolling_sum_of_squares += $prev_bucket->{sum_of_squares};
-                    $rolling_count++;
-                }
-                if ($rolling_count > 0) {
-                    $rolling_mean /= $rolling_count;
-                    my $rolling_variance = ($rolling_sum_of_squares / $rolling_count) - ($rolling_mean ** 2);
-                    my $rolling_std_dev = sqrt($rolling_variance);
-                    my $z_score = calculate_z_score($mean, $rolling_mean, $rolling_std_dev);
-                   $log_stats{$bucket}{z_score} = $z_score;
-                }
-
-                # Update rolling window logic
-                push @rolling_window, { mean => $mean, sum_of_squares => $aggregated_data->{sum_of_squares} };
-                shift @rolling_window if @rolling_window > $rolling_window_size;
-            }
 
         } else {
             # This will catch the situation where there are no durations, printing them has been disabled, or they were not captured.
@@ -6783,20 +6767,29 @@ sub calculate_all_statistics {
                 }
 
                 if( defined $aggregated_data->{total_duration} && !$omit_durations ) {
-                    my ($min, $mean, $max, $p1, $p50, $p75, $p90, $p95, $p99, $p999, $std_dev, $cv) = calculate_statistics($aggregated_data);
+                    my ($min, $mean, $max,
+                        $p1, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999,
+                        $std_dev, $cv,
+                        $skewness, $kurtosis, $bimodality_coef) = calculate_statistics($aggregated_data);
 
                     $log_messages{$category}{$log_key}{min} = $min;
                     $log_messages{$category}{$log_key}{mean} = $mean;
                     $log_messages{$category}{$log_key}{max} = $max;
                     $log_messages{$category}{$log_key}{std_dev} = $std_dev;
                     $log_messages{$category}{$log_key}{p1} = $p1;
+                    $log_messages{$category}{$log_key}{p25} = $p25;
                     $log_messages{$category}{$log_key}{p50} = $p50;
                     $log_messages{$category}{$log_key}{p75} = $p75;
+                    $log_messages{$category}{$log_key}{iqr} = $iqr;
                     $log_messages{$category}{$log_key}{p90} = $p90;
                     $log_messages{$category}{$log_key}{p95} = $p95;
                     $log_messages{$category}{$log_key}{p99} = $p99;
                     $log_messages{$category}{$log_key}{p999} = $p999;
+                    $log_messages{$category}{$log_key}{p9999} = $p9999;
                     $log_messages{$category}{$log_key}{cv} = $cv;
+                    $log_messages{$category}{$log_key}{skewness} = $skewness;
+                    $log_messages{$category}{$log_key}{kurtosis} = $kurtosis;
+                    $log_messages{$category}{$log_key}{bimodality_coef} = $bimodality_coef;
                     $log_messages{$category}{$log_key}{total_duration_num} = $aggregated_data->{total_duration} if defined $aggregated_data->{total_duration};
                     $log_messages{$category}{$log_key}{total_duration} = format_time( $aggregated_data->{total_duration}, 'ms', 'medium', 'space' ) if defined $aggregated_data->{total_duration};
                 }
@@ -6896,13 +6889,6 @@ sub log_bucket {
     return $value > 0 ? floor(log($value) / log($base)) : 0;
 }
 
-# Function to calculate Z-score
-sub calculate_z_score {
-    my ($current_mean, $rolling_mean, $rolling_std_dev) = @_;
-    return undef if $rolling_std_dev == 0;
-    return sprintf("%.2f", ($current_mean - $rolling_mean) / $rolling_std_dev);
-}
-
 # Function to calculate statistical metrics
 sub calculate_statistics {
     my ($bucket_data) = @_;
@@ -6920,7 +6906,9 @@ sub calculate_statistics {
     my $mean = int($bucket_data->{total_duration} / $duration_count);
     my $max = max(@sorted);
     my $variance = ($bucket_data->{sum_of_squares} / $duration_count) - ($mean ** 2);
-    my $std_dev = sprintf("%.3f", sqrt($variance));
+    $variance = 0 if $variance < 0;  # guard floating-point underflow on near-constant data
+    my $std_num = sqrt($variance);
+    my $std_dev = sprintf("%.3f", $std_num);
     my $cv = undef;
     if ($mean != 0) {
         my $cv_raw = $std_dev / $mean;
@@ -6935,15 +6923,45 @@ sub calculate_statistics {
 
     # Percentile calculations must use duration_count, not occurrences
     # to correctly index into the sorted durations array
-    my $p1   = int($sorted[int($duration_count * 0.01)]);
-    my $p50  = int($sorted[int($duration_count * 0.5)]);
-    my $p75  = int($sorted[int($duration_count * 0.75)]);
-    my $p90  = int($sorted[int($duration_count * 0.9)]);
-    my $p95  = int($sorted[int($duration_count * 0.95)]);
-    my $p99  = int($sorted[int($duration_count * 0.99)]);
-    my $p999 = int($sorted[int($duration_count * 0.999)]);
+    my $p1    = int($sorted[int($duration_count * 0.01)]);
+    my $p25   = int($sorted[int($duration_count * 0.25)]);
+    my $p50   = int($sorted[int($duration_count * 0.5)]);
+    my $p75   = int($sorted[int($duration_count * 0.75)]);
+    my $p90   = int($sorted[int($duration_count * 0.9)]);
+    my $p95   = int($sorted[int($duration_count * 0.95)]);
+    my $p99   = int($sorted[int($duration_count * 0.99)]);
+    my $p999  = int($sorted[int($duration_count * 0.999)]);
+    my $p9999 = int($sorted[int($duration_count * 0.9999)] // $sorted[-1]);
+    my $iqr   = $p75 - $p25;
 
-    return ($min, $mean, $max, $p1, $p50, $p75, $p90, $p95, $p99, $p999, $std_dev, $cv);
+    # Distribution-shape moments — Sarle's bimodality coefficient screening (#222)
+    # Sarle BC > 5/9 (~0.555) flags suspect multimodal; threshold is the canonical
+    # cutoff from the bimodality-detection literature. Requires n >= 4 (denominator
+    # of BC has (n-2)(n-3) factor) and non-zero std_dev.
+    my ($skewness, $kurtosis, $bimodality_coef) = (undef, undef, undef);
+    if ($duration_count >= 4 && $std_num > 0) {
+        my ($m3_sum, $m4_sum) = (0, 0);
+        for my $x (@sorted) {
+            my $d = $x - $mean;
+            my $d2 = $d * $d;
+            $m3_sum += $d2 * $d;
+            $m4_sum += $d2 * $d2;
+        }
+        my $m3 = $m3_sum / $duration_count;
+        my $m4 = $m4_sum / $duration_count;
+        my $g  = $m3 / ($std_num ** 3);          # population skewness
+        my $k  = $m4 / ($std_num ** 4) - 3;      # excess kurtosis (normal = 0)
+        $skewness = sprintf("%.3f", $g);
+        $kurtosis = sprintf("%.3f", $k);
+        my $n = $duration_count;
+        my $bc_denom = $k + 3 * (($n - 1) ** 2) / (($n - 2) * ($n - 3));
+        $bimodality_coef = sprintf("%.3f", ($g * $g + 1) / $bc_denom) if $bc_denom > 0;
+    }
+
+    return ($min, $mean, $max,
+            $p1, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999,
+            $std_dev, $cv,
+            $skewness, $kurtosis, $bimodality_coef);
 }
 
 sub initialize_empty_time_windows {
@@ -7568,7 +7586,7 @@ sub normalize_data_for_output {
 
     # Add CSV output columns for latency stats
     if ($print_durations && !$omit_durations && !$omit_stats && !$heatmap_enabled) {
-        push @output_columns, qw( min mean max std_dev p1 p50 p75 p90 p95 p99 p999 cv z_score );
+        push @output_columns, qw( min mean max std_dev p1 p25 p50 p75 iqr p90 p95 p99 p999 p9999 cv skewness kurtosis bimodality_coef );
     }
 
     foreach my $bucket (keys %log_occurrences) {
@@ -8280,7 +8298,7 @@ sub print_bar_graph {
                         defined $log_stats{$bucket}{p999} ? printf( "$colors{'red'}P999:%-5s$colors{'NC'} ", ( length( $log_stats{$bucket}{p999} ) >= 4 ? format_time( $log_stats{$bucket}{p999}, 'ms' ) : $log_stats{$bucket}{p999} ) ) : printf( " " x 11 );
                         defined $log_stats{$bucket}{cv} ? printf( "$colors{$cv_color}CV:%4s$colors{'NC'}", $log_stats{$bucket}{cv} ) : printf ( " " x 7 );
 
-                        foreach my $stat ( qw( min mean max std_dev p1 p50 p75 p90 p95 p99 p999 cv z_score ) ) {
+                        foreach my $stat ( qw( min mean max std_dev p1 p25 p50 p75 iqr p90 p95 p99 p999 p9999 cv skewness kurtosis bimodality_coef ) ) {
                             push @csv_data, $log_stats{$bucket}{$stat};
                         }
                     }
@@ -9332,13 +9350,19 @@ sub print_message_summary {
                     my $std_dev = $log_messages{$grouping}{$key}{std_dev};
                     my $impact = $log_messages{$grouping}{$key}{impact};
                     my $p1 = $log_messages{$grouping}{$key}{p1};
+                    my $p25 = $log_messages{$grouping}{$key}{p25};
                     my $p50 = $log_messages{$grouping}{$key}{p50};
                     my $p75 = $log_messages{$grouping}{$key}{p75};
+                    my $iqr = $log_messages{$grouping}{$key}{iqr};
                     my $p90 = $log_messages{$grouping}{$key}{p90};
                     my $p95 = $log_messages{$grouping}{$key}{p95};
                     my $p99 = $log_messages{$grouping}{$key}{p99};
                     my $p999 = $log_messages{$grouping}{$key}{p999};
+                    my $p9999 = $log_messages{$grouping}{$key}{p9999};
                     my $cv = $log_messages{$grouping}{$key}{cv};
+                    my $skewness = $log_messages{$grouping}{$key}{skewness};
+                    my $kurtosis = $log_messages{$grouping}{$key}{kurtosis};
+                    my $bimodality_coef = $log_messages{$grouping}{$key}{bimodality_coef};
                     my $total_duration_num = $log_messages{$grouping}{$key}{total_duration_num};
                     my $total_duration = $log_messages{$grouping}{$key}{total_duration};
 
@@ -9374,7 +9398,7 @@ sub print_message_summary {
                                     $log_messages{$grouping}{$key}{"udm_${name}_sum"};
                             }
                         }
-                        $csv->print($csv_fh, [ $grouping, $key, $occurrences, $mean_bytes, $total_bytes_num, $total_bytes, $count_occurrences, $count_min, $count_mean, $count_max, $count_sum, $min, $mean, $max, $std_dev, $p1, $p50, $p75, $p90, $p95, $p99, $p999, $cv, $total_duration_num, $total_duration, $impact, @udm_csv_values ]);
+                        $csv->print($csv_fh, [ $grouping, $key, $occurrences, $mean_bytes, $total_bytes_num, $total_bytes, $count_occurrences, $count_min, $count_mean, $count_max, $count_sum, $min, $mean, $max, $std_dev, $p1, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $cv, $skewness, $kurtosis, $bimodality_coef, $total_duration_num, $total_duration, $impact, @udm_csv_values ]);
                     }
 
                     print "$row\n";
@@ -9783,7 +9807,7 @@ if( $write_messages_to_csv ) {                     # If write to CSV enabled, op
             push @udm_csv_headers, "${csv_prefix}_occurrences", "${csv_prefix}_min", "${csv_prefix}_mean", "${csv_prefix}_max", "${csv_prefix}_sum";
         }
     }
-    $csv->print($csv_fh, [qw(category message occurrences mean_bytes bytes bytes_nice count_occurrences count_min count_mean count_max count_sum min mean max std_dev p1 p50 p75 p90 p95 p99 p999 cv duration duration_nice impact), @udm_csv_headers]);
+    $csv->print($csv_fh, [qw(category message occurrences mean_bytes bytes bytes_nice count_occurrences count_min count_mean count_max count_sum min mean max std_dev p1 p25 p50 p75 iqr p90 p95 p99 p999 p9999 cv skewness kurtosis bimodality_coef duration duration_nice impact), @udm_csv_headers]);
 }
 
 print_message_summary();														                    # Print and write message summaries

--- a/releases/v0.14.6.md
+++ b/releases/v0.14.6.md
@@ -3,6 +3,7 @@
 ## Breaking Changes
 
 - CSV outputs (`-o`) now use consistent snake_case lowercase column names across MESSAGES and STATS, aligned with internal metric identifiers (`%log_stats` keys). MESSAGES headers `MinDuration`, `MeanDuration`, `MaxDuration`, `StdDev`, `P1`–`P99.9`, `CV`, `TotalDuration`, `TotalDurationNice`, `TotalBytes`, `TotalBytesNice`, `MeanBytes`, `Occurrences`, `Category`, `Message`, `Impact` become `min`, `mean`, `max`, `std_dev`, `p1`–`p999`, `cv`, `duration`, `duration_nice`, `bytes`, `bytes_nice`, `mean_bytes`, `occurrences`, `category`, `message`, `impact`. STATS headers `totalOccurrences`, `bytesNice`, `durationNice` become `occurrences`, `bytes_nice`, `duration_nice`. External CSV consumers must update column references. (#221)
+- SRE-grade distribution-analysis columns added to `-o` CSV outputs in both MESSAGES and STATS: body percentile `p25`, precomputed `iqr`, high-volume tail `p9999`, and three shape statistics — `skewness`, `kurtosis`, and `bimodality_coef` (Sarle's bimodality coefficient — multimodal when > 5/9 ≈ 0.555). Distribution shape can now be characterized from the CSV alone, enabling load-shape mode characterization, mode-evolution detection, and per-API certainty bounding without re-running ltl. The unused `z_score` column is removed from STATS (it was computed but never displayed, consumed, or documented). External CSV consumers must update column references. See `docs/usage.md` "Distribution shape" subsection for interpretation and sample-size notes. (#222)
 
 ## What's New
 


### PR DESCRIPTION
## Summary
- Add six distribution-analysis columns to `-o` CSV outputs in both MESSAGES (per-key) and STATS (per-bucket): `p25`, `iqr`, `p9999`, `skewness`, `kurtosis`, `bimodality_coef` (Sarle's BC; > 5/9 ≈ 0.555 flags suspect multimodal)
- Remove `z_score` from STATS — computed but never displayed, never consumed by internal logic, never user-documented. `@rolling_window`, `$rolling_window_size`, and `calculate_z_score` sub deleted alongside the column
- All new statistics computed O(n) on the existing sorted array in `calculate_statistics`; no new pass over data, no new memory regime
- New "Distribution shape" subsection in `docs/usage.md` documents the new columns, the Sarle BC threshold (5/9 ≈ 0.555), and sample-size guidance (n ≥ 4 floor for shape moments; n ≥ ~100k for p9999 stability)
- `releases/v0.14.6.md` Breaking Changes section extended with one bullet covering both the additions and the z_score removal
- New `features/219-baseline-anomaly-detection-research.md` captures the goal-3 (per-API inflection-point detection) research finding for the future #219 design pass — distribution analysis is structurally unsolvable from MESSAGES or STATS alone, needs a per-key × per-bucket CSV shape

## Scope split
- Column-structure validation harness — covered by **#223** (existing)
- Distribution-shape numerical validation harness (bimodality_coef / skewness / kurtosis against known synthetic inputs) — covered by **#254** (filed during scoping; depends on this PR)

## Test plan
- [x] Regression suite passes (`tests/validate-regression.sh`: 38/38) — display path unaffected
- [x] CSV eyeball against `ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log`: 32-col MESSAGES / 29-col STATS headers match spec; `iqr = p75 − p25` arithmetic verified on a real row
- [x] Synthetic bimodal log spot-check (two 1000-line clusters at 50ms ± 5 and 500ms ± 50) produces `bimodality_coef = 0.995` (well above 0.555 threshold); skewness ≈ 0; kurtosis strongly negative (platykurtic — characteristic two-peak signature)
- [x] Final grep sweep — no remaining `z_score` / `rolling_window` / `calculate_z_score` references anywhere in `ltl`
- [x] Perl compile-check (`perl -c ltl`) passes after every phase

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)