### PR TITLE
Issue #250: add --dark-background flag and heatmap-palette -V section

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,7 +127,7 @@ ltl -g 80 -iqs -is access.log
 
 ### Display & Output
 
-These options control what is shown and how. After the timeline bar graph, logtimeline prints a summary table ranking the top contributing messages — `-n` controls how many entries appear, and `-osum` suppresses it entirely. The hide options hide individual columns from the bar graph while still processing the underlying data — useful for freeing horizontal space on narrow terminals or focusing on the metrics that matter. The CSV output option (`-o`) writes the full analysis data to a file for external processing, archival, or baseline comparison. The light background mode (`-lbg`) switches color gradients for white or light terminal backgrounds. The pause option (`-p`) is useful when output exceeds the terminal height.
+These options control what is shown and how. After the timeline bar graph, logtimeline prints a summary table ranking the top contributing messages — `-n` controls how many entries appear, and `-osum` suppresses it entirely. The hide options hide individual columns from the bar graph while still processing the underlying data — useful for freeing horizontal space on narrow terminals or focusing on the metrics that matter. The CSV output option (`-o`) writes the full analysis data to a file for external processing, archival, or baseline comparison. The light background mode (`-lbg`) switches color gradients for white or light terminal backgrounds. The dark background mode (`-dbg`) forces the dark gradients and overrides `-lbg` if both are passed. The pause option (`-p`) is useful when output exceeds the terminal height.
 
 | Option | Description |
 |--------|-------------|
@@ -142,6 +142,7 @@ These options control what is shown and how. After the timeline bar graph, logti
 | `-hs, --hide-session` | Hide the Sessions column that automatically appears when session IDs are found in the log data |
 | `-hst, --hide-stats` | Hide the latency statistics or heatmap column |
 | `-lbg, --light-background` | Use pale-to-bright color gradients suited for light/white terminal backgrounds |
+| `-dbg, --dark-background` | Force dark-background color gradients; overrides `-lbg` and disables auto-detect |
 | `-nah, --no-auto-hide` | Disable automatic column hiding at narrow terminal widths (squeeze all columns instead) |
 | `-p, --pause` | Wait for a keypress between pages of output |
 | `-V, --verbose [<section>...]` | Emit diagnostic sections. Bare `-V` emits all; `-V <name>[,<name>...]` or repeated `-V` selects sections; `-V list` prints known sections. See "Verbose output (`-V`)" section below |
@@ -155,6 +156,8 @@ ltl -o access.log
 ltl -osum access.log
 # Use color gradients suited for light terminal backgrounds
 ltl -lbg access.log
+# Force dark-background gradients (overrides auto-detect and -lbg)
+ltl -dbg access.log
 ```
 
 ### Sorting
@@ -316,7 +319,7 @@ ltl -tpa "http-" -tpa "async-" app.log
 
 ### Verbose output (`-V`)
 
-The `-V` flag emits diagnostic sections describing internal state — effective configuration (CLI + environment), index pre-seed lookups, bin-counter feature state, message-grouping statistics, log-format detection, benchmark data. Each section is named and bracketed by `=== <name> ===` / `=== END <name> ===` markers so it can be extracted by `grep`, `sed`, or `awk`.
+The `-V` flag emits diagnostic sections describing internal state — effective configuration (CLI + environment), index pre-seed lookups, bin-counter feature state, message-grouping statistics, log-format detection, heatmap palette resolution, benchmark data. Each section is named and bracketed by `=== <name> ===` / `=== END <name> ===` markers so it can be extracted by `grep`, `sed`, or `awk`.
 
 | Form | Behavior |
 |------|----------|

--- a/ltl
+++ b/ltl
@@ -99,6 +99,9 @@ my %verbose_section_registry = (
     'format-detection' => {
         description => 'Per-file detected log-format slug, duration unit assumed vs applied, matched/unmatched line counts (Issue #228).',
     },
+    'heatmap-palette' => {
+        description => 'Heatmap color palette resolution: active metric, light/dark selection, source of selection, gradient arrays (Issue #250).',
+    },
     'benchmark-data' => {
         description => 'Machine-parseable TSV: version, files, line counts, timings, memory, structure counts.',
     },
@@ -110,6 +113,7 @@ my @verbose_section_order = qw(
     histogram-bin-counters
     message-grouping
     format-detection
+    heatmap-palette
     benchmark-data
 );
 my %verbose_sections_requested;   # Populated by adapt_to_command_line_options() from -V args
@@ -354,7 +358,9 @@ my $heatmap_udm_config;                     # Reference to @udm_configs entry fo
 my @histogram_udm_configs;                  # References to @udm_configs entries for histogram UDM metrics
 my $heatmap_width = 52;                     # Number of histogram buckets (default matches latency stats width)
 my $heatmap_light_bg = 0;                   # Flag: use light background color gradients (set by -lbg or auto-detect)
-my $heatmap_light_bg_auto = 1;              # Flag: auto-detect terminal background (disabled if -lbg explicitly set)
+my $heatmap_light_bg_auto = 1;              # Flag: auto-detect terminal background (disabled if -lbg or -dbg explicitly set)
+my $heatmap_dark_bg_explicit = 0;           # Flag: -dbg given on CLI; forces dark, wins over -lbg
+my $heatmap_light_bg_source = 'default';    # Provenance of $heatmap_light_bg: '-lbg' | '-dbg' | 'auto-detect' | 'default'
 my %heatmap_data;                           # {$bucket}{$range_index} = count
 my %heatmap_data_hl;                        # {$bucket}{$range_index} = highlighted count
 my %heatmap_raw;                            # {$bucket} = [raw values] - exact-path only
@@ -1373,7 +1379,7 @@ sub _classify_argv_provenance {
                 'consolidation-trigger', 'consolidation-ceiling',
                 'consolidation-max-patterns', 'final-threshold',
                 'group-ceiling|gc', 'heatmap|hm', 'heatmap-width|hmw',
-                'light-background|lbg', 'histogram|hg',
+                'light-background|lbg', 'dark-background|dbg', 'histogram|hg',
                 'histogram-width|hgw', 'histogram-height|hgh',
                 'hgbpd|histogram-buckets-per-decade',
                 'hgb|histogram-buckets',
@@ -1667,6 +1673,57 @@ sub emit_format_detection_verbose {
     }
 
     push @verbose_output, "=== END format-detection ===";
+}
+
+# Emit the heatmap-palette `-V` section. Reports the resolved palette state
+# at render time: which metric is active, light vs dark selection, the
+# provenance of that selection, and the dark/light gradient arrays that
+# print_heatmap_row() picks between. Always emitted when requested; reports
+# heatmap_active: no with n/a fields when -hm is not set.
+#
+# Contract (Issue #250): the section is consumed by
+# tests/validate-heatmap-palette.sh. Renames of the section header, any
+# field key, or the comma-separated gradient format are breaking changes
+# per tests/HARNESS-DESIGN.md and require updating every consumer in the
+# same commit.
+sub emit_heatmap_palette_verbose {
+    return unless section_requested('heatmap-palette');
+
+    push @verbose_output, "=== heatmap-palette ===";
+
+    if (!$heatmap_enabled || !defined $heatmap_metric) {
+        push @verbose_output, "heatmap_active: no";
+        push @verbose_output, "metric: n/a";
+        push @verbose_output, "light_bg: $heatmap_light_bg";
+        push @verbose_output, "light_bg_source: $heatmap_light_bg_source";
+        push @verbose_output, "color_name: n/a";
+        push @verbose_output, "gradient_dark: n/a";
+        push @verbose_output, "gradient_light: n/a";
+        push @verbose_output, "gradient_active: n/a";
+        push @verbose_output, "=== END heatmap-palette ===";
+        return;
+    }
+
+    # Resolve the same way print_heatmap_row() does at ltl read sites:
+    # color_key comes from heatmap_metric_map; entry from column_color_lookup
+    # (for column-bound colors like yellow/green/cyan) or from
+    # %heatmap_special_gradients (for non-column colors like white).
+    my $color_key = $heatmap_metric_map{$heatmap_metric}{color};
+    my $entry = $column_color_lookup{$color_key} // $heatmap_special_gradients{$color_key};
+
+    my $gradient_dark_str  = defined $entry && $entry->{gradient}       ? join(',', @{$entry->{gradient}})       : 'n/a';
+    my $gradient_light_str = defined $entry && $entry->{gradient_light} ? join(',', @{$entry->{gradient_light}}) : 'n/a';
+    my $gradient_active    = $heatmap_light_bg ? 'light' : 'dark';
+
+    push @verbose_output, "heatmap_active: yes";
+    push @verbose_output, "metric: $heatmap_metric";
+    push @verbose_output, "light_bg: $heatmap_light_bg";
+    push @verbose_output, "light_bg_source: $heatmap_light_bg_source";
+    push @verbose_output, "color_name: " . (defined $color_key ? $color_key : 'n/a');
+    push @verbose_output, "gradient_dark: $gradient_dark_str";
+    push @verbose_output, "gradient_light: $gradient_light_str";
+    push @verbose_output, "gradient_active: $gradient_active";
+    push @verbose_output, "=== END heatmap-palette ===";
 }
 
 # Section name, field names, consumer-name strings, and the three-value audit
@@ -2167,6 +2224,7 @@ sub print_help {
     $out .= $opt->("-hs,  --hide-session",          "Hide the Sessions column that automatically appears when session IDs are found in the log data");
     $out .= $opt->("-hst, --hide-stats",            "Hide the latency statistics or heatmap column");
     $out .= $opt->("-lbg, --light-background",      "Use pale-to-bright color gradients suited for light/white terminal backgrounds");
+    $out .= $opt->("-dbg, --dark-background",       "Force dark-background color gradients (disables auto-detect; wins over -lbg if both given)");
     $out .= $opt->("-nah, --no-auto-hide",          "Disable automatic column hiding at narrow terminal widths (squeeze all columns instead)");
     $out .= $opt->("-p,   --pause",                 "Wait for a keypress between pages of output");
     $out .= $opt->("-V,   --verbose [<section>...]", "Emit diagnostic sections. Bare -V emits all; -V <name>[,<name>...] or repeated -V selects sections; -V list prints known sections");
@@ -4570,7 +4628,8 @@ sub adapt_to_command_line_options {
         'group-ceiling|gc=i' => \$consolidation_final_ceiling,
         'heatmap|hm:s' => \$heatmap_metric,
         'heatmap-width|hmw=i' => \$heatmap_width,
-        'light-background|lbg' => sub { $heatmap_light_bg = 1; $heatmap_light_bg_auto = 0; },
+        'light-background|lbg' => sub { $heatmap_light_bg = 1; $heatmap_light_bg_auto = 0; $heatmap_light_bg_source = '-lbg'; },
+        'dark-background|dbg'  => sub { $heatmap_dark_bg_explicit = 1; $heatmap_light_bg_auto = 0; },
         'histogram|hg:s' => \&handle_histogram_option,
         'histogram-width|hgw=i' => sub { $histogram_width_percent = $_[1]; $histogram_width_explicit = 1; },
         'histogram-height|hgh=i' => sub { $histogram_height = $_[1]; $histogram_height_explicit = 1; },
@@ -4706,9 +4765,17 @@ sub adapt_to_command_line_options {
             $heatmap_metric = 'duration';  # time is allowed for consistency, but what is really meant is duration
         }
 
-        # Auto-detect light terminal background if -lbg wasn't explicitly set
+        # -dbg wins over -lbg regardless of CLI order: force dark and skip auto-detect
+        if ($heatmap_dark_bg_explicit) {
+            $heatmap_light_bg = 0;
+            $heatmap_light_bg_auto = 0;
+            $heatmap_light_bg_source = '-dbg';
+        }
+
+        # Auto-detect light terminal background if neither -lbg nor -dbg was set
         if ($heatmap_light_bg_auto) {
             $heatmap_light_bg = detect_light_terminal_background();
+            $heatmap_light_bg_source = 'auto-detect';
         }
     }
 
@@ -9771,6 +9838,8 @@ emit_index_readback_verbose();
 emit_bin_counter_mode_verbose();
 
 emit_format_detection_verbose();
+
+emit_heatmap_palette_verbose();
 
 print_verbose_output();
 

--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -75,6 +75,7 @@ This list prevents collisions across parallel work. Update it when adding a new 
 - `histogram-array` — exact-percentile (in-memory array) histogram dimensions; active under `--exact-percentiles`
 - `histogram-bin-counters` — HDR-style bin-counter histogram state and finalized histogram dimensions (Issue #187)
 - `message-grouping` — fuzzy message consolidation (Issue #96)
+- `heatmap-palette` — heatmap color palette resolution: active metric, light/dark selection, source of selection, gradient arrays (Issue #250)
 - `benchmark-data` — machine-parseable TSV: version, files, line counts, timings, memory, structure counts
 
 **Reserved by sub-issues, not yet implemented:**

--- a/tests/validate-heatmap-palette.sh
+++ b/tests/validate-heatmap-palette.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# validate-heatmap-palette.sh — Validate the heatmap-palette `-V` section
+# emits the resolved palette state under each light/dark selection path
+# and each heatmap metric (Issue #250).
+# Usage: ./tests/validate-heatmap-palette.sh
+#
+# Follows the self-documenting assertion design from tests/HARNESS-DESIGN.md.
+# Every assertion records:
+#   - asserts:     the application invariant being tested
+#   - produced_by: where in ltl the invariant is produced (function name)
+#   - contract:    the stability contract that makes it stable
+# All three are surfaced on failure so the reader can act without
+# opening external docs.
+#
+# Why this harness exists: the heatmap-palette section is the contract
+# point that lets a harness validate the light/dark selection branch
+# without grepping rendered ANSI from the bar graph (which HARNESS-DESIGN.md
+# explicitly forbids). The section reports the gradient array that
+# print_heatmap_row() will use, plus the provenance of the light_bg flag,
+# so this harness can guard the -lbg / -dbg / auto-detect / default
+# branches and the -dbg-wins-over-lbg precedence rule.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LTL="$REPO_DIR/ltl"
+SCRIPT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log"
+
+if [[ ! -x "$LTL" ]]; then
+    echo "ERROR: ltl not found or not executable at $LTL"
+    exit 1
+fi
+if [[ ! -f "$SCRIPT_LOG" ]]; then
+    echo "ERROR: SCRIPT_LOG not found: $SCRIPT_LOG"
+    exit 1
+fi
+
+# Expected gradient arrays — sourced from the canonical definitions in ltl:
+#   yellow (duration): @column_colors entry (ltl GLOBALS)
+#   green  (bytes):    @column_colors entry (ltl GLOBALS)
+#   cyan   (count):    @column_colors entry (ltl GLOBALS)
+# The harness asserts the section emits these literal arrays; a code-side
+# change to any gradient is a breaking change that requires updating both
+# the array and this expected-value table in the same commit.
+YELLOW_DARK='58,94,136,142,178,184,220,226'
+YELLOW_LIGHT='230,229,228,227,220,214,208,202'
+GREEN_DARK='22,28,34,40,46,82,118,154'
+GREEN_LIGHT='194,157,120,84,48,42,36,35'
+CYAN_DARK='23,30,37,44,51,80,86,123'
+CYAN_LIGHT='195,159,123,87,51,44,37,30'
+
+pass=0
+fail=0
+failures=()
+current_scenario=""
+
+# Run ltl with -V heatmap-palette and the standard suppression flag.
+# Captures combined output to a temp file, echoes the path.
+# Args after the function name are forwarded verbatim before the input file.
+run_section() {
+    local outfile
+    outfile=$(mktemp)
+    "$LTL" --disable-progress -V heatmap-palette "$@" "$SCRIPT_LOG" > "$outfile" 2>&1 || true
+    if [[ ! -s "$outfile" ]]; then
+        echo "FAIL: captured output is empty for: $LTL --disable-progress -V heatmap-palette $* $SCRIPT_LOG" >&2
+        exit 1
+    fi
+    echo "$outfile"
+}
+
+# Self-documenting assertion: a line matching `pattern` must be present.
+assert_line() {
+    local outfile="$1"
+    shift
+    local pattern asserts produced_by contract
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            pattern)     pattern="$2";     shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            *) echo "assert_line: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${pattern:?assert_line requires pattern}"
+    : "${asserts:?assert_line requires asserts}"
+    : "${produced_by:?assert_line requires produced_by}"
+    : "${contract:?assert_line requires contract}"
+
+    if grep -qE "$pattern" "$outfile"; then
+        echo "  PASS  $current_scenario :: $pattern"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $current_scenario"
+        echo "        pattern:     $pattern"
+        echo "        asserts:     $asserts"
+        echo "        produced_by: $produced_by"
+        echo "        contract:    $contract"
+        echo "        (not found in $outfile)"
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: $pattern")
+    fi
+}
+
+# Common: the section header must be present (HARNESS-DESIGN.md "must fail
+# on missing anchors" — guards against a silent rename).
+assert_header_present() {
+    local outfile="$1"
+    assert_line "$outfile" \
+        pattern     '^=== heatmap-palette ===$' \
+        asserts     'The heatmap-palette section is emitted whenever -V heatmap-palette is requested, regardless of whether heatmap mode is active' \
+        produced_by 'emit_heatmap_palette_verbose() in ltl' \
+        contract    'Issue #250 + tests/HARNESS-DESIGN.md § Reserved section names — section name is stability-contracted; renames are breaking'
+    assert_line "$outfile" \
+        pattern     '^=== END heatmap-palette ===$' \
+        asserts     'The heatmap-palette section closes with an explicit END marker so harnesses can use sed-range extraction unambiguously' \
+        produced_by 'emit_heatmap_palette_verbose() in ltl' \
+        contract    'tests/HARNESS-DESIGN.md § Delimiter contract — END markers are required'
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: no heatmap mode (sanity — section emits with n/a fields)
+# ---------------------------------------------------------------------------
+scenario_no_heatmap() {
+    current_scenario="no-heatmap"
+    echo "[$current_scenario]"
+    local out
+    out=$(run_section)
+
+    assert_header_present "$out"
+
+    assert_line "$out" \
+        pattern     '^heatmap_active: no$' \
+        asserts     'When -hm is not on the command line, heatmap_active reports `no` and the metric/color/gradient fields are placeholders' \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (inactive branch)' \
+        contract    'Issue #250 — section reports inactive state without crashing when heatmap is off'
+
+    assert_line "$out" \
+        pattern     '^metric: n/a$' \
+        asserts     'metric reports `n/a` when no heatmap metric is selected' \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (inactive branch)' \
+        contract    'Issue #250 — locked placeholder for absent metric'
+
+    assert_line "$out" \
+        pattern     '^gradient_active: n/a$' \
+        asserts     'gradient_active reports `n/a` when no heatmap is rendering — neither dark nor light branch is selected' \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (inactive branch)' \
+        contract    'Issue #250 — locked placeholder for absent gradient selection'
+}
+
+# ---------------------------------------------------------------------------
+# Per-palette scenarios — each forces dark or light and asserts metric,
+# color name, the matching gradient array literal, gradient_active, and
+# light_bg_source.
+# ---------------------------------------------------------------------------
+
+# Args: scenario_name, ltl_args, expected_metric, expected_color,
+#       expected_light_bg ("0"|"1"), expected_source, expected_active ("dark"|"light"),
+#       expected_gradient_dark, expected_gradient_light
+scenario_palette() {
+    local name="$1"; shift
+    local ltl_args="$1"; shift
+    local exp_metric="$1"; shift
+    local exp_color="$1"; shift
+    local exp_lbg="$1"; shift
+    local exp_source="$1"; shift
+    local exp_active="$1"; shift
+    local exp_dark="$1"; shift
+    local exp_light="$1"; shift
+
+    current_scenario="$name"
+    echo "[$current_scenario]"
+    local out
+    # shellcheck disable=SC2086
+    out=$(run_section $ltl_args)
+
+    assert_header_present "$out"
+
+    assert_line "$out" \
+        pattern     "^heatmap_active: yes\$" \
+        asserts     "When -hm is on the command line, heatmap_active reports \`yes\`" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (active branch)' \
+        contract    'Issue #250 — locked field value when heatmap mode is enabled'
+
+    assert_line "$out" \
+        pattern     "^metric: ${exp_metric}\$" \
+        asserts     "metric reports the heatmap metric selected via -hm (${exp_metric})" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (resolves $heatmap_metric)' \
+        contract    'Issue #250 — metric field tracks $heatmap_metric verbatim'
+
+    assert_line "$out" \
+        pattern     "^color_name: ${exp_color}\$" \
+        asserts     "color_name reports the column color (${exp_color}) bound to the heatmap metric via %heatmap_metric_map and resolved through %column_color_lookup" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (resolves $heatmap_metric_map{$heatmap_metric}{color})' \
+        contract    'Issue #250 — metric-to-color binding is the same resolution print_heatmap_row() performs at ltl:7830-7831'
+
+    assert_line "$out" \
+        pattern     "^light_bg: ${exp_lbg}\$" \
+        asserts     "light_bg reports the resolved value of \$heatmap_light_bg (${exp_lbg}) that print_heatmap_row() will branch on" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl' \
+        contract    'Issue #250 — light_bg field equals the runtime value read by print_heatmap_row()'
+
+    assert_line "$out" \
+        pattern     "^light_bg_source: ${exp_source}\$" \
+        asserts     "light_bg_source reports the provenance of the light_bg decision (${exp_source}); precedence: -dbg > -lbg > auto-detect > default" \
+        produced_by 'adapt_to_command_line_options() in ltl — set by -lbg callback, -dbg reconciliation block, and auto-detect block' \
+        contract    'Issue #250 — \$heatmap_light_bg_source is the canonical provenance signal; the four enumerated values are the only valid emissions'
+
+    assert_line "$out" \
+        pattern     "^gradient_dark: ${exp_dark}\$" \
+        asserts     "gradient_dark reports the dark-palette 256-color array for the active metric's color (${exp_color}); this is the literal array @column_colors carries in ltl GLOBALS" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (joins @{$entry->{gradient}} with commas)' \
+        contract    'Issue #250 — gradient arrays in @column_colors are part of the heatmap-palette contract surface; changes require updating this harness in the same commit'
+
+    assert_line "$out" \
+        pattern     "^gradient_light: ${exp_light}\$" \
+        asserts     "gradient_light reports the light-palette 256-color array for the active metric's color (${exp_color}); this is the literal array @column_colors carries in ltl GLOBALS" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (joins @{$entry->{gradient_light}} with commas)' \
+        contract    'Issue #250 — gradient arrays in @column_colors are part of the heatmap-palette contract surface; changes require updating this harness in the same commit'
+
+    assert_line "$out" \
+        pattern     "^gradient_active: ${exp_active}\$" \
+        asserts     "gradient_active reports which branch (${exp_active}) print_heatmap_row() will pick when rendering; load-bearing line for visual palette coverage" \
+        produced_by 'emit_heatmap_palette_verbose() in ltl (\$heatmap_light_bg ? "light" : "dark")' \
+        contract    'Issue #250 — gradient_active is the contract for which palette renders'
+}
+
+# ---------------------------------------------------------------------------
+# Run scenarios
+# ---------------------------------------------------------------------------
+
+echo "Validating heatmap-palette -V section (Issue #250)"
+echo ""
+
+scenario_no_heatmap
+echo ""
+
+# --- -dbg path: each of three metrics ---
+scenario_palette "dbg-duration" \
+    "-hm duration -dbg" \
+    "duration" "yellow" "0" "-dbg" "dark" \
+    "$YELLOW_DARK" "$YELLOW_LIGHT"
+echo ""
+
+scenario_palette "dbg-bytes" \
+    "-hm bytes -dbg" \
+    "bytes" "green" "0" "-dbg" "dark" \
+    "$GREEN_DARK" "$GREEN_LIGHT"
+echo ""
+
+scenario_palette "dbg-count" \
+    "-hm count -dbg" \
+    "count" "cyan" "0" "-dbg" "dark" \
+    "$CYAN_DARK" "$CYAN_LIGHT"
+echo ""
+
+# --- -lbg path: each of three metrics ---
+scenario_palette "lbg-duration" \
+    "-hm duration -lbg" \
+    "duration" "yellow" "1" "-lbg" "light" \
+    "$YELLOW_DARK" "$YELLOW_LIGHT"
+echo ""
+
+scenario_palette "lbg-bytes" \
+    "-hm bytes -lbg" \
+    "bytes" "green" "1" "-lbg" "light" \
+    "$GREEN_DARK" "$GREEN_LIGHT"
+echo ""
+
+scenario_palette "lbg-count" \
+    "-hm count -lbg" \
+    "count" "cyan" "1" "-lbg" "light" \
+    "$CYAN_DARK" "$CYAN_LIGHT"
+echo ""
+
+# --- Precedence: -dbg wins over -lbg regardless of CLI order ---
+scenario_palette "precedence-lbg-then-dbg" \
+    "-hm duration -lbg -dbg" \
+    "duration" "yellow" "0" "-dbg" "dark" \
+    "$YELLOW_DARK" "$YELLOW_LIGHT"
+echo ""
+
+scenario_palette "precedence-dbg-then-lbg" \
+    "-hm duration -dbg -lbg" \
+    "duration" "yellow" "0" "-dbg" "dark" \
+    "$YELLOW_DARK" "$YELLOW_LIGHT"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [[ "$fail" -gt 0 ]]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+echo "ALL HEATMAP-PALETTE TESTS PASSED"


### PR DESCRIPTION
## Summary

- Adds `--dark-background` / `-dbg` flag — the inverse of `-lbg`. Forces dark heatmap gradients and disables auto-detect. `-dbg` wins over `-lbg` regardless of CLI order via post-GetOptions reconciliation.
- Adds `heatmap-palette` `-V` section exposing the resolved palette state (active metric, light/dark selection, source of selection, gradient arrays) so harnesses can assert on the palette branch without scraping rendered ANSI from the bar graph.
- Adds `tests/validate-heatmap-palette.sh` — 85 assertions across 9 scenarios covering `-dbg`/`-lbg` × `duration`/`bytes`/`count` plus both precedence orderings. Modeled on `validate-histogram-bin-counters.sh` with self-documenting `asserts` / `produced_by` / `contract` fields per `tests/HARNESS-DESIGN.md`.
- Reserves `heatmap-palette` in `tests/HARNESS-DESIGN.md`; updates `print_help()` and `docs/usage.md`.

## Why the -V section

Closes #250 (just the flag) was the original ask. The harness rule in `HARNESS-DESIGN.md` forbids harnesses from grepping rendered analytical output — palette correctness must be observable via a `-V` section. The new section is the contract surface that lets the harness assert dark vs light selection, source of selection, and the gradient arrays themselves (literal 256-color array values from `@column_colors`).

## Test plan

- [x] `perl -c ltl` — syntax OK
- [x] `ltl --help` — shows both `-lbg` and `-dbg`
- [x] `ltl -V list` — registers `heatmap-palette`
- [x] `tests/validate-heatmap-palette.sh` — 85 passed, 0 failed
- [x] `tests/validate-regression.sh` — 38 passed, 0 failed (untouched)
- [x] `tests/validate-histogram-bin-counters.sh` — 24 passed, 0 failed (sibling unaffected)
- [x] Mutation test: rename `=== heatmap-palette ===` header → harness fails every scenario (missing-anchor guard works)
- [x] Mutation test: change one gradient value in `@column_colors` → harness fails 4 scenarios (real assertion power, not byte-diff theater)
- [x] Precedence verified: `-lbg -dbg`, `-dbg -lbg`, `-dbg -lbg -dbg` all resolve to dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)