### PR TITLE
Issue #263: decouple STATS CSV latency stats from display visibility

### DIFF
--- a/ltl
+++ b/ltl
@@ -9652,7 +9652,10 @@ sub print_bar_graph {
                     }
 
                 } elsif ($col_id eq 'latency') {
-                    # Duration statistics
+                    # Duration statistics — terminal display only. CSV emission of
+                    # these stats happens after the column loop, independent of
+                    # whether this column is visible (so auto-hide on narrow
+                    # terminals does not silently drop the values from -o output).
                     if( defined $log_stats{$bucket}{bytes} || defined $log_stats{$bucket}{p50} || defined $log_stats{$bucket}{p95} || defined $log_stats{$bucket}{p99} || defined $log_stats{$bucket}{p999} || defined $log_stats{$bucket}{cv} ) {
                         my $cv_color = defined $log_stats{$bucket}{cv} && $log_stats{$bucket}{cv} >= 20 ? 'WARN-HL' : 'white-underline';
 
@@ -9661,10 +9664,6 @@ sub print_bar_graph {
                         defined $log_stats{$bucket}{p99} ? printf( "$colors{'bright-yellow'}P99:%-6s$colors{'NC'} ", ( length( $log_stats{$bucket}{p99} ) >= 4 ? format_time( $log_stats{$bucket}{p99}, 'ms' ) : $log_stats{$bucket}{p99} ) ) : printf( " " x 11 );
                         defined $log_stats{$bucket}{p999} ? printf( "$colors{'red'}P999:%-5s$colors{'NC'} ", ( length( $log_stats{$bucket}{p999} ) >= 4 ? format_time( $log_stats{$bucket}{p999}, 'ms' ) : $log_stats{$bucket}{p999} ) ) : printf( " " x 11 );
                         defined $log_stats{$bucket}{cv} ? printf( "$colors{$cv_color}CV:%4s$colors{'NC'}", $log_stats{$bucket}{cv} ) : printf ( " " x 7 );
-
-                        foreach my $stat ( qw( min mean max std_dev p1 p5 p10 p25 p50 p75 iqr p90 p95 p99 p999 p9999 p99999 cv skewness kurtosis bimodality_coef ) ) {
-                            push @csv_data, $log_stats{$bucket}{$stat};
-                        }
                     }
 
                 } elsif ($col_id eq 'heatmap') {
@@ -9673,6 +9672,18 @@ sub print_bar_graph {
 
                 # Print spacing after this column
                 print " " x ($col->{spacing_after} // 0);
+            }
+
+            # Append latency stats to CSV data. The header lists these columns
+            # when $print_durations && !$omit_durations && !$omit_stats &&
+            # !$heatmap_enabled (see normalize_data_for_output). The push must
+            # use the same gate so rows always match the header regardless of
+            # whether the latency *display column* was auto-hidden by terminal
+            # width. (Issue #263)
+            if( $print_durations && !$omit_durations && !$omit_stats && !$heatmap_enabled ) {
+                foreach my $stat ( qw( min mean max std_dev p1 p5 p10 p25 p50 p75 iqr p90 p95 p99 p999 p9999 p99999 cv skewness kurtosis bimodality_coef ) ) {
+                    push @csv_data, $log_stats{$bucket}{$stat};
+                }
             }
 
             # Print statistics for time-bucket statistics to the CSV file if activated


### PR DESCRIPTION
## Summary

- Decouples STATS CSV emission of latency statistics (`min`, `mean`, `max`, `std_dev`, `p1`–`p99999`, `cv`, `skewness`, `kurtosis`, `bimodality_coef`) from the terminal display column's visibility. Previously the `push @csv_data` for these 21 stats was nested inside the `latency` display column's branch and was skipped whenever `auto_hide_narrow_columns` hid that column (which has high `hide_order=70`, making it an early auto-hide candidate at narrow terminal widths). Statistics were computed correctly in `%log_stats`, but never reached CSV — so STATS CSV output silently depended on terminal width.
- After fix: CSV header inclusion and CSV row emission for these stats are now controlled by the same condition (`$print_durations && !$omit_durations && !$omit_stats && !$heatmap_enabled`), matching what `normalize_data_for_output` uses to decide header content.
- Unblocks `tests/validate-csv-output.sh` (#223) from FAILing on `access-bytes-duration` and `thingworx-script`.

## Test plan

- [x] `tests/validate-csv-output.sh`: 3 scenarios, 3 pass, 0 fail (was 1 pass / 2 fail before fix)
- [x] `tests/validate-regression.sh`: 38 passed, 0 failed (terminal display output unchanged)
- [x] Diagnostic confirmed before fix: forcing `--terminal-width 300` made stats appear in CSV; default narrow terminal made them blank. Same input, different CSV output — symptomatic of the visibility coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)