### PR TITLE
Issue #266: explicit statistical data-model selectors

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,7 +201,7 @@ When this matters: at the default precision, percentile values like P50 / P99 ar
 |--------|-------------|
 | `-pp, --percentile-precision <N>` | Precision tier 1..9 (default: 5). Higher tiers give tighter percentile values at the cost of more memory per partition. |
 | `-pbpd, --percentile-buckets-per-decade <N>` | Buckets per decade directly (default: 53; valid 4..616). Overrides `--percentile-precision` when both supplied. |
-| `-ep, --exact-percentiles` | Revert to exact sort-based percentile computation. Deprecated; safety net retained from the bin-counter migration. |
+| `-ep, --exact-percentiles` | Revert to exact sort-based percentile computation. Deprecated; superseded by `-dm raw` / `--data-model raw` (see Data-model selectors below). |
 
 **Precision (`-pp` / `-pbpd`).** The default (tier 5 / 53 bpd) is appropriate for the vast majority of analyses — percentile values land very close to their true sort-based values. Raise it (tier 6–9, or `-pbpd` values up to 616) when you need tighter precision on tail percentiles (P99.9, P99.99) or when comparing two runs whose true percentiles differ by very small amounts; lower it (tier 1–4) to trade percentile precision for less memory on per-message percentile computation (summary table, CSV output), which fans out to one partition per unique message and so scales with message diversity. The histogram and heatmap consumers are unaffected — they use their own internal precision tuned for display rendering and ignore this knob.
 
@@ -222,6 +222,47 @@ ltl -V histogram-bin-counters access.log
 
 # Opt out to exact (sort-based) percentiles for byte-exact comparison
 ltl -ep access.log
+```
+
+### Data-model selectors
+
+ltl reduces duration samples into statistics through one of two internal data models:
+
+- **raw** — every observed duration retained, sorted at calculation time, statistics derived by direct array operations.
+- **bin** — HDR-style bin-counter; samples bucketed at capture time into bins-per-decade primitives, statistics derived from bin counts.
+
+The choice is independent per consumer surface. There are four surfaces:
+
+| # | Surface | Today's data model |
+|---|---|---|
+| 1 | Histogram statistics (consumed by `-hg`) | bin |
+| 2 | Heatmap statistics (consumed by `-hm`) | bin |
+| 3 | Per-message-key statistics | raw |
+| 4 | Per-time-bucket statistics | raw |
+
+The data-model selectors below let you **pin** which data model a surface uses when you need certainty (test harnesses, reproducibility, A/B comparison). They have no defaults — when unset, the surface's existing internal logic chooses, and ltl's user-observable behavior is unchanged from previous releases.
+
+| Option | Description |
+|--------|-------------|
+| `-dm, --data-model <raw\|bin>` | Pin the data model for every surface (overridden by any per-surface flag below). |
+| `-hgdm, --histogram-data-model <raw\|bin>` | Pin the histogram surface's data model. |
+| `-hmdm, --heatmap-data-model <raw\|bin>` | Pin the heatmap surface's data model. |
+| `-mdm, --message-stats-data-model <raw\|bin>` | Pin the per-message-key statistics data model. Selector is resolved but currently only the raw reduction is implemented for this surface; `bin` lands in a follow-up. |
+| `-bdm, --bucket-stats-data-model <raw\|bin>` | Pin the per-time-bucket statistics data model. Same status as `-mdm` — selector resolved, raw only today. |
+
+**Resolution.** Per-surface flag overrides `-dm`; `-dm` overrides the surface's internal default. Invalid values (anything other than `raw` or `bin`) cause ltl to exit at option-parse time with a clear error. Conflicting flags on the same axis follow standard last-one-wins ordering.
+
+**Relationship to `--exact-percentiles`.** `--exact-percentiles` is equivalent to `--data-model raw` on the histogram and heatmap surfaces (which is what it has always controlled). The new selectors supersede it; `--exact-percentiles` continues to work in this release but emits a deprecation notice and is scheduled for removal in a future release.
+
+```bash
+# Pin every surface to the raw reduction path
+ltl -dm raw access.log
+
+# Override just the histogram surface; leave the heatmap on its default
+ltl -hgdm raw -hm duration -hg access.log
+
+# Inspect which selectors are active for this run
+ltl -V runtime-config -dm raw -hgdm bin access.log
 ```
 
 ### Distribution shape (CSV columns)
@@ -374,7 +415,8 @@ Section content is governed by per-section stability contracts — additions are
 | `-g <non-numeric>` (e.g. `-g logfile.log`) | The non-numeric value is treated as a positional argument and the default similarity threshold (85) is applied. |
 | `-hm <unknown-metric>` without any `-udm` configured (e.g. `-hm bogus`) | The value is treated as a positional argument and the default heatmap metric (`duration`) is applied. |
 | Both `-pbpd` and `--percentile-precision` supplied | `-pbpd` wins; the warning surfaces the override so it is visible without `-V`. |
-| `--exact-percentiles` (or `-ep`) supplied | Deprecation notice. The flag reverts every migrated percentile consumer to pre-#187 sort-based computation and is scheduled for removal in a future release. |
+| `--exact-percentiles` (or `-ep`) supplied | Deprecation notice naming the new data-model selectors (`-dm raw`, `-hgdm raw`, `-hmdm raw`) as replacements. The flag continues to work; scheduled for removal in a future release. |
+| `--data-model`, `--histogram-data-model`, `--heatmap-data-model`, `--message-stats-data-model`, or `--bucket-stats-data-model` supplied with a value other than `raw` or `bin` | ltl exits with `<flag>: '<value>' is not a valid data model; valid values are 'raw' and 'bin'`. |
 
 To inspect the resolved configuration after warnings have fired, use `-V runtime-config` and read the `command-line` and `environment-variable` sub-sections.
 

--- a/features/266-data-model-selectors.md
+++ b/features/266-data-model-selectors.md
@@ -1,0 +1,219 @@
+# Issue #266 — Explicit statistical data-model selectors
+
+## Status
+
+Design phase. No code changes yet. Approval gate: this doc must be reviewed and signed off before any implementation begins.
+
+## Problem
+
+`ltl` reduces duration samples into statistics through one of two data models:
+
+- **raw** — every observed duration retained, sorted at calculation time, statistics computed by direct array operations.
+- **bin** — HDR-style bin-counter, samples bucketed at capture time into bins-per-decade primitives, statistics derived from bin counts.
+
+The choice is independent per consumer surface. There are four surfaces:
+
+| # | Surface (internal calculation path) | Today's data model | Today's selector |
+|---|---|---|---|
+| 1 | Histogram statistics (consumed by `-hg`) | bin (raw under `--exact-percentiles`) | `--exact-percentiles` (negative opt-out) |
+| 2 | Heatmap statistics (consumed by `-hm`) | bin (raw under `--exact-percentiles`) | `--exact-percentiles` (negative opt-out) |
+| 3 | Per-message-key statistics | raw (only path wired) | none |
+| 4 | Per-time-bucket statistics | raw (only path wired) | none |
+
+These four surfaces are *internal data-reduction paths*. Each takes captured duration samples and produces a statistics record. Downstream consumers (terminal columns, CSV writers, `-V` sections, histogram/heatmap renderers) read from whatever the surface produced — they are not the surface itself. The data-model selectors target the reduction path, not the renderer.
+
+Two problems block #224:
+
+1. `--exact-percentiles` is a global negative opt-out covering surfaces 1 and 2 only. A test matrix that wants to pin "this scenario measures the bin-counter reduction on the per-message-key statistics path" has no way to say so.
+2. Surfaces 3 and 4 have no bin-counter dispatch site at all. A test scenario asking for `bin` on those surfaces today has nowhere for the request to land.
+
+## Design
+
+### Five new CLI flags
+
+All accept `raw|bin`. Short-and-long pair per the project convention.
+
+| Flag (short / long) | Surface | Scope |
+|---|---|---|
+| `-dm` / `--data-model raw\|bin` | All surfaces (omnibus) | Sets default for every surface unless a per-surface flag overrides |
+| `-hgdm` / `--histogram-data-model raw\|bin` | Histogram | Per-surface override |
+| `-hmdm` / `--heatmap-data-model raw\|bin` | Heatmap | Per-surface override |
+| `-mdm` / `--message-stats-data-model raw\|bin` | Per-message-key statistics | Per-surface override |
+| `-bdm` / `--bucket-stats-data-model raw\|bin` | Per-time-bucket statistics | Per-surface override |
+
+### The flags have no defaults
+
+This is the core framing. The five new flags exist to **pin** the data model when the caller needs certainty (test harness, reproducibility, A/B comparison). They do not exist to *participate* in the surface's normal decision-making.
+
+When a flag is unset, it contributes nothing — the surface's existing internal logic chooses the data model exactly as today. The flags are a purely additive override layer.
+
+### Resolution at each call site
+
+For each of the four surfaces, at the point the surface decides which data model to use:
+
+1. If the surface's per-surface flag is set → use its value.
+2. Else if `-dm` is set → use its value.
+3. Else → the surface's existing internal logic decides, unchanged from today (this includes the existing `--exact-percentiles` consultation for surfaces 1 and 2).
+
+### Validation
+
+`raw` and `bin` are the only accepted values. Any other value (`--data-model dense`, `--message-stats-data-model 7`) causes `ltl` to die at option-parse time with a clear error.
+
+### Conflicting flags
+
+Last one on the command line wins, per Getopt::Long default behavior. No special-case logic. If a user writes `-dm raw -dm bin`, the result is `bin`. If a user writes `--exact-percentiles --data-model bin`, the result on surfaces 1 and 2 is `bin` because the new flag was set and takes the resolution-chain step 1 path; `--exact-percentiles` is only consulted in step 3.
+
+### Two-branch dispatch at every call site
+
+All four surfaces use the same call-site shape after this change:
+
+```
+my $dm = resolve_data_model(<surface>);   # 'raw' | 'bin' | undef
+if (defined $dm && $dm eq 'bin') {
+    # bin-counter path
+} else {
+    # raw path
+}
+```
+
+- **Surfaces 1 and 2** already have both paths wired (gated today by `--exact-percentiles`). This change swaps the gate from `$exact_percentiles_optout` to the resolved data-model selector. When the selector is `undef`, the surface's internal logic — including the existing `--exact-percentiles` consultation — runs unchanged, preserving today's behavior exactly.
+- **Surfaces 3 and 4** today have only the raw path. This change adds the two-branch dispatch structure as architectural foundation. The selector is resolved at the call site exactly as on surfaces 1 and 2, but the surface always executes the raw path regardless of what the selector resolves to. When the bin-counter reduction for these surfaces is built in a follow-up issue, the `bin` branch starts honoring the selector with no change to the call-site shape. #266 lays the foundation; it does not fill in the bin branch.
+
+### `--exact-percentiles` continues to work
+
+The flag continues to function identically to today on surfaces 1 and 2. It is not removed by this issue and its semantics do not change.
+
+What changes:
+
+- The deprecation warning at `ltl:5884` updates to name the new flags as replacements:
+
+  > `--exact-percentiles` is deprecated; use `--data-model raw` (omnibus) or `--histogram-data-model raw` / `--heatmap-data-model raw` (per-surface) instead. `--exact-percentiles` is equivalent to `--data-model raw` on the histogram and heatmap surfaces, which is what it has always controlled. This flag will be removed in a future release.
+
+- The flag continues to be consulted only inside the surface's internal logic — i.e. only at resolution-chain step 3, when no new flag is set for that surface. If the user passes both `--exact-percentiles` and `-dm bin` (or `-hgdm bin` / `-hmdm bin`), the new flag wins because the new flag is consulted at step 1; `--exact-percentiles` never gets a vote.
+
+This issue does not remove `--exact-percentiles`. Removal is a separate follow-up gated on user migration.
+
+### `-V runtime-config` surfacing
+
+The existing pattern at `ltl:1434–1566` is row-per-configured-flag inside `command-line` and `environment-variable` sub-sections. The sub-section header carries the source; rows carry only `value` or `value; overridden` or `value; clamped from <orig>`. There is no `(--flag-name)` source-trail suffix on individual rows.
+
+The five new flags are added to the `%resolved_values` hash. Per the existing partitioning rule, a flag is emitted **only** if it appears in the command-line or environment-variable provenance. An unset flag emits nothing. This is exactly what we want: the runtime-config section is a record of explicit configuration, not a reconstruction of the surface's decision tree.
+
+Examples:
+
+- User passes nothing → no data-model lines anywhere.
+- User passes `-dm raw` → command-line sub-section gains `data-model: raw`.
+- User passes `-hgdm bin --data-model raw` → command-line sub-section gains both `data-model: raw` and `histogram-data-model: bin`. No annotation between them — the user can read the precedence from the flag names.
+
+The `exact-percentiles` row already in `%resolved_values` at `ltl:1504` stays in place. When the user passes both `--exact-percentiles` and a new flag that affects the same surface, both rows appear in the command-line sub-section with their plain values. The "which one effectively won" question is answered by the resolution rule, not by an annotation — same as how the existing CLI vs env-var precedence is communicated by sub-section placement, not by row-level source trails.
+
+## Code touch points
+
+| File:line | What changes |
+|---|---|
+| `ltl:5800–5878` (`GetOptions`) | Add five entries. Use `=s` with a value-validation callback (see "Implementation notes" below). |
+| `ltl:5884–5886` (deprecation warning) | Update message to name the new flags. |
+| `ltl` (new globals, near other option globals) | Five new scalars holding the parsed `raw`/`bin`/`undef` values. |
+| `ltl` (new sub, near other small helpers) | `resolve_data_model($surface)` — returns `'raw'`, `'bin'`, or `undef` per the resolution rule. |
+| `ltl:7132, 7148, 7282, 7523` (histogram exact-path gates) | Replace `$exact_percentiles_optout` consultation with `resolve_data_model('histogram')` consultation, falling back to the existing logic when `undef`. |
+| `ltl:1856` (histogram consumer exact-path gate) | Same as above. |
+| Heatmap dispatch sites (located alongside histogram sites) | Same pattern with `resolve_data_model('heatmap')`. |
+| `ltl:8248` (`calculate_statistics`) | Add two-branch dispatch shell at the top. `resolve_data_model('message-stats')` is called and its value is available, but the surface always proceeds down the raw path today. The `bin` branch is a stub left for the follow-up issue. |
+| Per-time-bucket statistics sub (sibling of `calculate_statistics`) | Same as above with `resolve_data_model('bucket-stats')`. Locate by tracing the per-time-bucket reduction in `calculate_all_statistics`. |
+| `ltl:1456–1506` (`%resolved_values` in `emit_runtime_config_verbose`) | Add five rows. |
+| `print_help()` | Document the five new flags in the appropriate section. |
+| `docs/usage.md` | Document the five new flags. |
+| `README.md` | Mention in the options reference. |
+| `CLAUDE.md` | No change unless a release-process or helper-tools surface mentions `--exact-percentiles`; sweep to confirm. |
+| `releases/v0.14.6.md` | Add one bullet per the bullets-only rule. |
+
+## Implementation notes
+
+### Validating `raw|bin` at option-parse time
+
+Getopt::Long does not have native enum validation. Idiomatic pattern (used elsewhere in ltl for similar checks, e.g. `duration-unit`):
+
+```
+'data-model|dm=s'                    => sub { _validate_dm('data-model',                 $_[1]); $data_model_omnibus    = $_[1]; },
+'histogram-data-model|hgdm=s'        => sub { _validate_dm('histogram-data-model',      $_[1]); $data_model_histogram   = $_[1]; },
+'heatmap-data-model|hmdm=s'          => sub { _validate_dm('heatmap-data-model',        $_[1]); $data_model_heatmap     = $_[1]; },
+'message-stats-data-model|mdm=s'     => sub { _validate_dm('message-stats-data-model',  $_[1]); $data_model_message     = $_[1]; },
+'bucket-stats-data-model|bdm=s'      => sub { _validate_dm('bucket-stats-data-model',   $_[1]); $data_model_bucket      = $_[1]; },
+```
+
+`_validate_dm($flag_name, $value)` dies with: `--$flag_name: '$value' is not a valid data model; valid values are 'raw' and 'bin'`.
+
+### `resolve_data_model($surface)` shape
+
+```
+sub resolve_data_model {
+    my ($surface) = @_;
+    my $per_surface = {
+        histogram     => $data_model_histogram,
+        heatmap       => $data_model_heatmap,
+        'message-stats' => $data_model_message,
+        'bucket-stats'  => $data_model_bucket,
+    }->{$surface};
+    return $per_surface if defined $per_surface;
+    return $data_model_omnibus if defined $data_model_omnibus;
+    return undef;
+}
+```
+
+Returns `undef` deliberately so callers can distinguish "user pinned raw" from "user said nothing." The two cases need different code paths because the second one preserves the existing internal logic including `--exact-percentiles`.
+
+### Short forms
+
+All five flags have explicit short forms per the project convention (`feedback_short_forms_required`):
+- `-dm`, `-hgdm`, `-hmdm`, `-mdm`, `-bdm`.
+
+## Test plan
+
+1. **Regression** — `tests/validate-regression.sh` passes with no changes.
+2. **CSV structure** — `tests/validate-csv-output.sh` passes for every combination of the five flags.
+3. **Byte-identity at defaults** — Run `ltl -o` on a small Tomcat log and a ThingWorx log without any new flag; output (CSV files used as a convenient observable surface for the per-message-key and per-time-bucket statistics paths) is byte-identical to a baseline captured from `release/0.14.6` before this change.
+4. **Per-surface override** — Run with `-hgdm raw` against a known histogram-mode input; output matches an `--exact-percentiles -hg` invocation on the same input from before this change.
+5. **Omnibus override** — Run with `-dm raw -hg`; same expected result as test 4.
+6. **Surface 3 selector accepted but not honored** — Run with `-mdm bin -o`; ltl exits 0, and the per-message-key statistics (observed via CSV and terminal columns) are byte-identical to the no-flag baseline (raw path executed regardless of the selector).
+7. **Surface 4 selector accepted but not honored** — Same with `-bdm bin -o`, observed via the per-time-bucket statistics in CSV.
+8. **Invalid value** — Run with `--data-model dense`; ltl exits non-zero with the validation error message.
+9. **Conflicting last-wins** — Run with `-dm raw -dm bin -hg`; histogram output matches a `-hg` invocation without any new flag (because no new flag survives → step 3 → existing internal logic → bin per histogram's baked-in default).
+10. **`-V runtime-config` rows** — Run with `-V runtime-config -dm raw -hgdm bin`; output contains `data-model: raw` and `histogram-data-model: bin` in the command-line sub-section; no `(--…)` annotations on either row.
+11. **Deprecation warning text** — Run with `--exact-percentiles`; STDERR contains the updated warning naming the new flags.
+
+## Acceptance criteria mapping (issue body → this doc)
+
+| Issue criterion | Where addressed |
+|---|---|
+| All five flags accept `raw`/`bin`, reject other values | Validation section, Implementation notes / `_validate_dm` |
+| Per-surface flags override `-dm`; `-dm` overrides baked-in | Resolution section + `resolve_data_model` |
+| All five flags in `print_help()` and `docs/usage.md` | Code touch points |
+| Histogram/heatmap identical at `-hgdm bin` / `-hmdm bin` to today's non-`--exact-percentiles` | Two-branch dispatch section + tests 3, 4, 5 |
+| Histogram/heatmap identical at `-hgdm raw` / `-hmdm raw` to today's `--exact-percentiles` | Two-branch dispatch + tests 4, 5 |
+| Bin path implemented for per-message-key and per-time-bucket statistics | **Reframed**: #266 puts the dispatch foundation in place; surfaces 3 and 4 always run raw today regardless of selector. The bin reduction lands in a follow-up. |
+| Per-message-key / per-time-bucket statistics byte-identical at defaults | Test 3 |
+| `-V runtime-config` emits source-annotated lines per flag | `-V runtime-config` surfacing section + test 10 |
+| Deprecation notice on `--exact-percentiles` names new flags | Deprecation section + test 11 |
+| `tests/validate-regression.sh` passes | Test 1 |
+| `tests/validate-csv-output.sh` passes for every data-model combination | Test 2 |
+| Docs sweep references new flags | Code touch points |
+| Release notes bullet added | Code touch points |
+
+### Note on the surfaces 3/4 acceptance criterion
+
+The issue body's criterion "MESSAGES CSV and STATS CSV statistics emit when `-mdm bin` / `-bdm bin` is selected" is reframed here: #266 puts the dispatch foundation in place but does not implement the bin-counter reduction for these surfaces. The issue body should be amended to reflect this split, with a follow-up issue tracking the actual reduction implementation.
+
+## Out of scope
+
+- Removing `--exact-percentiles` (per issue body).
+- Changing default data-model selection on any surface (per issue body).
+- Changes to bin-counter precision `-pbpd` (per issue body).
+- Anything in #224 itself (per issue body).
+- Implementing the bin-counter reduction for surfaces 3 and 4 — foundation only; reduction lands in a follow-up.
+
+## Related
+
+- `features/187-histogram-bin-counter-percentiles.md`
+- `features/189-bin-counter-primitives-implementation-readiness-audit.md`
+- `features/224-statistics-drift-harness.md`
+- Issue #231 — current deprecation warning and `-V runtime-config` source-annotation pattern.

--- a/ltl
+++ b/ltl
@@ -422,6 +422,23 @@ my $percentile_precision_source    = 'default';  # 'default' | '-pbpd N' | '--pe
 my $exact_percentiles_optout       = 0;       # when set, migrated consumers revert to calculate_statistics
 my $percentile_seed_decades        = 5;       # partition seeds at 5 decades centered on first value
 
+# Issue #266: explicit per-surface statistical data-model selectors. The five
+# scalars below hold the user-supplied selector for each surface (or undef
+# when the user did not pass the flag). resolve_data_model()/choose_data_model()
+# read these to dispatch raw vs bin reductions at the caller. Defaults live in
+# the call sites, not here — the flags exist purely to override.
+my $data_model_omnibus             = undef;   # -dm   / --data-model
+my $data_model_histogram           = undef;   # -hgdm / --histogram-data-model
+my $data_model_heatmap             = undef;   # -hmdm / --heatmap-data-model
+my $data_model_message             = undef;   # -mdm  / --message-stats-data-model
+my $data_model_bucket              = undef;   # -bdm  / --bucket-stats-data-model
+
+# Issue #266: caller-side capture-mode cache for the parsing hot path. Set
+# once before the parsing loop begins (see choose_data_model() callers) so
+# the per-line branch in read_and_process_logs() does not re-resolve.
+my $histogram_capture_mode         = undef;   # 'raw' or 'bin' (set before parsing loop)
+my $heatmap_capture_mode           = undef;   # 'raw' or 'bin' (set before parsing loop)
+
 # Streaming-partition bpd for display-geometry-bound consumers (#201).
 # Higher than the F1 default (53) because F2/F3 partition counts are bounded
 # (~70 total across all heatmap time buckets + histogram metrics) and the
@@ -1323,6 +1340,47 @@ sub detect_index_drift {
     return;
 }
 
+# Issue #266: validate a --*data-model selector value. Dies at parse time
+# with a clear message on any value other than 'raw' or 'bin'.
+sub _validate_dm {
+    my ($flag_name, $value) = @_;
+    return if defined $value && ($value eq 'raw' || $value eq 'bin');
+    die "--$flag_name: '" . (defined $value ? $value : '') . "' is not a valid data model; valid values are 'raw' and 'bin'\n";
+}
+
+# Issue #266: resolve the user-supplied data-model selector for a surface.
+# Returns 'raw', 'bin', or undef. undef means the user supplied neither the
+# per-surface flag nor the omnibus -dm/--data-model; callers fall back to
+# their existing internal default. The surface name is one of: histogram,
+# heatmap, message-stats, bucket-stats.
+sub resolve_data_model {
+    my ($surface) = @_;
+    my %per_surface = (
+        histogram       => $data_model_histogram,
+        heatmap         => $data_model_heatmap,
+        'message-stats' => $data_model_message,
+        'bucket-stats'  => $data_model_bucket,
+    );
+    my $per = $per_surface{$surface};
+    return $per if defined $per;
+    return $data_model_omnibus if defined $data_model_omnibus;
+    return undef;
+}
+
+# Issue #266: caller-side dispatch helper. Resolves the user-supplied
+# selector via resolve_data_model(), then folds in the legacy
+# --exact-percentiles opt-out as a fallback (which means 'raw' on
+# the histogram and heatmap surfaces; surfaces 3 and 4 never honored it).
+# Returns 'raw', 'bin', or undef (undef = no user opinion at all; caller
+# applies its own internal default).
+sub choose_data_model {
+    my ($surface) = @_;
+    my $dm = resolve_data_model($surface);
+    return $dm if defined $dm;
+    return 'raw' if $exact_percentiles_optout;
+    return undef;
+}
+
 # Issue #231: classify each known long-flag-name as having been supplied
 # via the command line, the LTL_CONFIG env-var splice, both, or neither.
 # Returns a hash mapping flag-name => list of sources ('command-line',
@@ -1394,6 +1452,11 @@ sub _classify_argv_provenance {
                 'pbpd|percentile-buckets-per-decade',
                 'pp|percentile-precision',
                 'ep|exact-percentiles',
+                'dm|data-model',
+                'hgdm|histogram-data-model',
+                'hmdm|heatmap-data-model',
+                'mdm|message-stats-data-model',
+                'bdm|bucket-stats-data-model',
                 'terminal-width|tw', 'no-auto-hide|nah',
                 'debug-layout', 'validate-layout', 'help:s', 'explain|ex:s',
             );
@@ -1502,6 +1565,14 @@ sub emit_runtime_config_verbose {
         'percentile-buckets-per-decade'     => $percentile_buckets_per_decade,
         'percentile-precision'              => $percentile_precision_level,
         'exact-percentiles'                 => $exact_percentiles_optout,
+        # Issue #266: explicit data-model selectors. Emitted only when the
+        # user supplied them (per the existing provenance partitioning at
+        # the bottom of this sub) — unset flags emit nothing.
+        'data-model'                        => $data_model_omnibus,
+        'histogram-data-model'              => $data_model_histogram,
+        'heatmap-data-model'                => $data_model_heatmap,
+        'message-stats-data-model'          => $data_model_message,
+        'bucket-stats-data-model'           => $data_model_bucket,
         'no-auto-hide'                      => $no_auto_hide,
     );
 
@@ -3488,7 +3559,17 @@ sub print_help {
     $out .= help_subheading("Percentile mode");
     $out .= help_opt("-pp,   --percentile-precision <N>",            "Set percentile binning precision tier 1..9 (default: 5 = ~1.3%; 1=~10%, 9=~0.1%). Affects migrated consumers; see docs/usage.md");
     $out .= help_opt("-pbpd, --percentile-buckets-per-decade <N>",   "Set percentile buckets-per-decade directly (default: 53; valid 4..616). Overrides --percentile-precision when both supplied");
-    $out .= help_opt("-ep,   --exact-percentiles",                   "Disable unified percentile mode; revert to exact sort-based computation (deprecated; -V shows opt_out_active: yes)");
+    $out .= help_opt("-ep,   --exact-percentiles",                   "Disable unified percentile mode; revert to exact sort-based computation (deprecated; superseded by --data-model raw)");
+
+    # Data-model selectors (Issue #266). Pin which reduction path each
+    # surface uses. No defaults — when unset, the surface's existing
+    # internal logic chooses. Per-surface flag > -dm > internal default.
+    $out .= help_subheading("Data-model selectors");
+    $out .= help_opt("-dm,   --data-model <raw|bin>",                  "Pin the data model for every surface (overridden by any per-surface flag below)");
+    $out .= help_opt("-hgdm, --histogram-data-model <raw|bin>",        "Pin the histogram surface's data model");
+    $out .= help_opt("-hmdm, --heatmap-data-model <raw|bin>",          "Pin the heatmap surface's data model");
+    $out .= help_opt("-mdm,  --message-stats-data-model <raw|bin>",    "Pin the per-message-key statistics data model (selector resolved but currently always uses raw; bin lands in a follow-up)");
+    $out .= help_opt("-bdm,  --bucket-stats-data-model <raw|bin>",     "Pin the per-time-bucket statistics data model (selector resolved but currently always uses raw; bin lands in a follow-up)");
 
     # User-Defined Metrics
     $out .= help_subheading("User-Defined Metrics");
@@ -5869,6 +5950,14 @@ sub adapt_to_command_line_options {
         'pbpd|percentile-buckets-per-decade=i' => \$percentile_buckets_per_decade,
         'pp|percentile-precision=i' => \$percentile_precision_level,
         'ep|exact-percentiles' => \$exact_percentiles_optout,
+        # Issue #266: explicit data-model selectors. Each accepts 'raw' or 'bin';
+        # any other value dies at parse time via _validate_dm. The flags have no
+        # defaults — when unset, the surface's existing logic applies.
+        'dm|data-model=s'                  => sub { _validate_dm('data-model',                  $_[1]); $data_model_omnibus   = $_[1]; },
+        'hgdm|histogram-data-model=s'      => sub { _validate_dm('histogram-data-model',       $_[1]); $data_model_histogram = $_[1]; },
+        'hmdm|heatmap-data-model=s'        => sub { _validate_dm('heatmap-data-model',         $_[1]); $data_model_heatmap   = $_[1]; },
+        'mdm|message-stats-data-model=s'   => sub { _validate_dm('message-stats-data-model',   $_[1]); $data_model_message   = $_[1]; },
+        'bdm|bucket-stats-data-model=s'    => sub { _validate_dm('bucket-stats-data-model',    $_[1]); $data_model_bucket    = $_[1]; },
         'terminal-width|tw=i' => \$terminal_width,                                  # hidden
         'no-auto-hide|nah' => \$no_auto_hide,
         'debug-layout' => \$debug_layout,                                           # hidden
@@ -5877,12 +5966,14 @@ sub adapt_to_command_line_options {
         'explain|ex:s' => \$explain_arg,                                            # Issue #261: optional arg: '' = topic registry; <topic> = long-form explanation. Aliases shared with -so (avg, stddev, p1..p99999).
     ) or die print_usage( "required options not provided" );
 
-    # Issue #231: surface --exact-percentiles as deprecated. The flag
-    # reverts every migrated -V/percentile consumer to pre-#187 sort-based
-    # computation and is scheduled for removal in a future release per
-    # features/187-histogram-bin-counter-percentiles.md § Decision 8.
+    # Issue #266: --exact-percentiles is superseded by the explicit
+    # data-model selectors. Equivalent migration paths:
+    #   --exact-percentiles  -->  --data-model raw                (omnibus)
+    #                        -->  --histogram-data-model raw      (histogram only)
+    #                        -->  --heatmap-data-model raw        (heatmap only)
+    # The flag continues to work this release; removal is a follow-up.
     if ($exact_percentiles_optout) {
-        warn "--exact-percentiles is deprecated and will be removed in a future release. Migrated consumers will revert to pre-#187 sort-based percentile computation for this run.\n";
+        warn "--exact-percentiles is deprecated; use --data-model raw (omnibus) or --histogram-data-model raw / --heatmap-data-model raw (per-surface) instead. --exact-percentiles is equivalent to --data-model raw on the histogram and heatmap surfaces, which is what it has always controlled. This flag will be removed in a future release.\n";
     }
 
     # Issue #226: -V section selectivity. Resolve @verbose_args (raw from
@@ -6363,6 +6454,15 @@ sub pause_for_keypress {
 # Parse logs, bucket by time, and count log levels
 sub read_and_process_logs {
     %in_files_matched = map { $_ => 0 } @in_files;			# set hash key per file to match boolean = false
+
+    # Issue #266: resolve the heatmap and histogram capture modes once,
+    # before entering the per-line parsing loop. The hot-path branches at
+    # the heatmap and histogram raw-value-capture sites read these scalars
+    # so they do not re-resolve per line. Default to 'bin' when the user
+    # did not pin a selector and --exact-percentiles is not set (matches
+    # today's behavior).
+    $heatmap_capture_mode   = choose_data_model('heatmap')   // 'bin';
+    $histogram_capture_mode = choose_data_model('histogram') // 'bin';
 
     foreach my $in_file (@in_files) {
         open my $fh, '<', $in_file or die "Cannot open file: $in_file";
@@ -7129,7 +7229,9 @@ sub read_and_process_logs {
                             $heatmap_min = $heatmap_value if !defined $heatmap_min || $heatmap_value < $heatmap_min;
                             $heatmap_max = $heatmap_value if !defined $heatmap_max || $heatmap_value > $heatmap_max;
 
-                            if ($exact_percentiles_optout) {
+                            # Issue #266: dispatch via $heatmap_capture_mode resolved
+                            # once before this loop (set near the parsing-loop entry).
+                            if ($heatmap_capture_mode eq 'raw') {
                                 push @{$heatmap_raw{$bucket}}, $heatmap_value;
                                 push @{$heatmap_raw_hl{$bucket}}, $heatmap_value if $category_bucket =~ /-HL$/;
                             } else {
@@ -7145,7 +7247,9 @@ sub read_and_process_logs {
                     if ($histogram_enabled) {
                         my $is_highlighted = ($category_bucket =~ /-HL$/);
 
-                        if ($exact_percentiles_optout) {
+                        # Issue #266: dispatch via $histogram_capture_mode resolved
+                        # once before this loop (set near the parsing-loop entry).
+                        if ($histogram_capture_mode eq 'raw') {
                             if ((!%histogram_metrics || $histogram_metrics{duration}) && defined $duration && $duration > 0 && !$omit_durations) {
                                 push @{$histogram_values{duration}}, $duration;
                                 push @{$histogram_values_hl{duration}}, $duration if $is_highlighted;
@@ -7279,7 +7383,11 @@ sub find_heatmap_bucket {
 
 sub calculate_heatmap_buckets {
     return unless $heatmap_enabled;
-    return $exact_percentiles_optout
+    # Issue #266: caller-side data-model dispatch. Defaults to 'bin' (today's
+    # behavior) when the user did not pin a selector and --exact-percentiles
+    # is not set.
+    my $dm = choose_data_model('heatmap') // 'bin';
+    return $dm eq 'raw'
         ? calculate_heatmap_buckets_exact()
         : finalize_heatmap_unified();
 }
@@ -7520,7 +7628,11 @@ sub format_histogram_dimensions_line {
 # Calculate histogram buckets for all collected metrics - Issue #25
 sub calculate_histogram_buckets {
     return unless $histogram_enabled;
-    return $exact_percentiles_optout
+    # Issue #266: caller-side data-model dispatch. Defaults to 'bin' (today's
+    # behavior) when the user did not pin a selector and --exact-percentiles
+    # is not set.
+    my $dm = choose_data_model('histogram') // 'bin';
+    return $dm eq 'raw'
         ? calculate_histogram_buckets_exact()
         : finalize_histogram_unified();
 }
@@ -7982,6 +8094,12 @@ sub calculate_all_statistics {
     
         # The duration based statistics won't catch the counts if there are no durations (see else condition below)
         if( $print_durations && !$omit_durations ) {
+            # Issue #266: caller-side data-model dispatch shell. Surface 4
+            # (per-time-bucket statistics). The selector resolves to 'raw',
+            # 'bin', or undef but only the raw reduction is implemented
+            # today — calculate_statistics() is the raw primitive. When the
+            # bin reduction lands, branch on $dm before this call.
+            my $dm = choose_data_model('bucket-stats') // 'raw';
             my ($min, $mean, $max,
                 $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
                 $std_dev, $cv,
@@ -8119,6 +8237,12 @@ sub calculate_all_statistics {
                 }
 
                 if( defined $aggregated_data->{total_duration} && !$omit_durations ) {
+                    # Issue #266: caller-side data-model dispatch shell. Surface 3
+                    # (per-message-key statistics). The selector resolves to 'raw',
+                    # 'bin', or undef but only the raw reduction is implemented
+                    # today — calculate_statistics() is the raw primitive. When the
+                    # bin reduction lands, branch on $dm before this call.
+                    my $dm = choose_data_model('message-stats') // 'raw';
                     my ($min, $mean, $max,
                         $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
                         $std_dev, $cv,

--- a/releases/v0.14.6.md
+++ b/releases/v0.14.6.md
@@ -14,6 +14,7 @@
 - `-so` / `--sort-on` now accepts percentile latency (`p1, p5, p10, p25, p50, p75, p90, p95, p99, p999, p9999, p99999`), distribution-shape metrics from #222 (`iqr, skewness, kurtosis, bimodality_coef`), and the previously-missing `mean_bytes`. New percentiles `p5`, `p10`, and `p99999` are also added to MESSAGES + STATS CSV outputs and to `%histogram_stats` (#220)
 - New `--help statistics` shows a grouped index of every statistic ltl emits; new `--explain <topic>` shows long-form per-topic documentation with interpretation tables and worked examples. 12 topics ship: `min`, `max`, `mean`, `std_dev`, `cv`, `iqr`, `percentiles`, `skewness`, `kurtosis`, `bimodality_coef`, `heatmap`, and `histogram` (the last two include example charts) (#261)
 - New `tests/validate-csv-output.sh` harness validates structural integrity of `-o` CSV outputs (MESSAGES and STATS): column presence and ordering, row/header alignment, required-vs-conditional population, functional group consistency across metric families, data-type correctness (numeric vs human-readable), and per-column fixed-decimal rules; release-process step inserted before benchmarks (#223)
+- New explicit data-model selectors `-dm`/`--data-model`, `-hgdm`/`--histogram-data-model`, `-hmdm`/`--heatmap-data-model`, `-mdm`/`--message-stats-data-model`, `-bdm`/`--bucket-stats-data-model` pin the raw-array or bin-counter reduction path per surface; `--exact-percentiles` is now deprecated (equivalent to `--data-model raw` on histogram/heatmap) (#266)
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Summary

- Adds five CLI flags (`-dm`, `-hgdm`, `-hmdm`, `-mdm`, `-bdm`) for pinning the data-model reduction path per surface; all accept `raw|bin`, invalid values die at parse time.
- Dispatch is caller-side at all four surfaces. Surfaces 1 and 2 (histogram, heatmap) get full functional dispatch; surfaces 3 and 4 (per-message-key, per-time-bucket statistics) get the resolution shell and always execute raw today, with the bin reduction reserved for a follow-up issue.
- `--exact-percentiles` is now deprecated (warning names the new flags as replacements); it continues to work and is equivalent to `--data-model raw` on histogram/heatmap.
- `-V runtime-config` emits one row per supplied selector via the existing provenance machinery; unset flags emit nothing.
- Docs sweep: `print_help()`, `docs/usage.md`, and release notes updated in the same commit.
- Design doc lives at `features/266-data-model-selectors.md`.

## Test plan

- [x] `perl -c ./ltl` clean
- [x] `tests/validate-regression.sh` — 38/38 pass
- [x] `tests/validate-csv-output.sh` — 3/3 pass
- [x] `-hgdm raw` / `-hmdm raw` output matches prior `--exact-percentiles` baseline (modulo flag echo + timer noise)
- [x] `-hgdm bin` / `-hmdm bin` output matches prior default baseline
- [x] `-mdm bin` / `-bdm bin` accepted with no STDERR warning; STATS CSV byte-identical to no-flag baseline
- [x] `-V runtime-config` emits rows only for supplied selectors
- [x] `--exact-percentiles` emits the new deprecation message naming the new flags
- [x] Last-one-wins on conflicting flags (`-dm raw -dm bin` → `bin`)
- [x] Invalid value rejection (`--data-model dense` → exit 1, clear error message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)