### PR TITLE
Issue #272: percentile algorithm research + docs reframing

### DIFF
--- a/docs/explain/statistics.md
+++ b/docs/explain/statistics.md
@@ -159,7 +159,7 @@ ltl -so cv -n 20 access.log           # surface most variable APIs
 ltl -so iqr -n 20 access.log          # find APIs with the noisiest middle range
 ```
 
-**How ltl computes this.** Derived from already-computed percentiles: `iqr = p75 − p25`. Inherits the same precision as the underlying percentile computation — around 1.3% by default, tunable via `-pbpd` (buckets per decade) for tighter or looser bin spacing.
+**How ltl computes this.** Derived from already-computed percentiles: `iqr = p75 − p25`. Inherits the data model and algorithm of the underlying percentiles — exact relative to observed samples in the raw values data model, or subject to bin-width interpolation in the bin counter data model (default ~1.3% relative bin width).
 
 **See also.** `p25`, `p50`, `p75`, `std_dev`, `cv`.
 
@@ -200,12 +200,27 @@ Percentiles answer the question "what value is faster than (or equal to) N% of a
 ltl -so p999 -n 20 access.log         # find APIs with the worst p999 tail latency
 ltl -so p9999 -n 20 access.log        # tail-of-tail analysis; needs many samples
 ltl -pp 7 access.log                  # tighten percentile precision (slower; more memory)
-ltl -ep access.log                    # opt out of bin counters; exact sort-based percentiles
 ```
 
-**How ltl computes this.** ltl computes percentiles using log-spaced bin counters with HDR-histogram-style precision. The default 53 buckets per decade gives ~1.3% precision, matching the resolution of common observability tools. The number of buckets per decade is tunable via `-pbpd`; `--percentile-precision` exposes named tiers (1..9). For byte-exact verification against sort-based percentiles, `-ep` opts out of the binned computation.
+**How ltl computes this.** ltl computes percentiles from one of two data models, each using its own algorithm. The two models answer slightly different questions about the same data and produce different values, especially at the tail percentiles. Neither is "the truth" relative to the other — both are valid; the right one depends on what you're trying to learn.
 
-**See also.** `min`, `max`, `iqr`, `skewness`, `kurtosis`, `bimodality_coef`. Flags: `-pbpd`, `-pp`, `-ep`.
+**Raw values data model** — every observation is held in memory; the percentile is selected by **nearest-rank**, i.e. an actually-observed sample at the computed rank in the sorted array. The returned `p99` is a real request that happened. No interpolation, no synthesised values.
+
+**Bin counter data model** — observations are accumulated into log-spaced bins (HDR-histogram-style); the percentile is computed by **linear interpolation between bucket boundaries**, the same approach Prometheus `histogram_quantile()` uses. The returned value is generally not an observed sample; it's a value on the interpolated cumulative-count line. Bin resolution determines how tight the interpolation is — the default 53 buckets per decade gives roughly 1.3% relative bin width.
+
+**Why the values differ.** Nearest-rank returns a real sample; bucket-boundary interpolation returns a synthesised value between bin edges. On the same input the two algorithms will report different `p99` (and other percentile) values, particularly in the tail. This is the data model, not a precision deviation. If you switch a surface between models, expect the percentile column to move.
+
+**Selecting the data model.** The choice comes down to memory budget, returned-value semantics, and what you're going to do with the result.
+
+**Choose the raw values data model when:** sample counts are bounded (a single message's per-bucket samples, a filtered analysis, a small log) and the per-observation memory cost is acceptable; you need the reported `p99` to map back to a specific log line you can go read; you're reproducing or comparing against another tool that returns observed samples.
+
+**Choose the bin counter data model when:** sample counts are large, unbounded, or unknown in advance (high-volume access logs, multi-gigabyte captures, long real-time runs) and a fixed per-partition memory cost is more predictable than a per-sample one; you're comparing against histogram-based tools that use the same bucket-interpolation algorithm; you only need the percentile *value*, not a mapping back to an individual observation.
+
+**Resource cost comparison.** The raw values data model scales with observation count: every sample occupies its own slot until the run completes. The bin counter data model scales with bin count: one partition per logical series, with a fixed bin footprint per partition regardless of how many observations stream through it. On small inputs the two are comparable; as sample counts grow the raw cost climbs linearly while the bin cost stays flat per partition. The crossover depends on how many distinct partitions you have — many low-volume series favour the raw values data model; few high-volume series favour the bin counter data model.
+
+**Flags.** Surfaces use sensible internal defaults (see the data-model selectors in `--help`); `--data-model raw` and `--data-model bin` pin every surface to one model. Per-surface selectors (`--histogram-data-model`, `--heatmap-data-model`, `--message-stats-data-model`, `--bucket-stats-data-model`) override the global setting. Bin resolution is tuned with `--percentile-buckets-per-decade` (default 53) or `--percentile-precision` (named tiers 1..9).
+
+**See also.** `min`, `max`, `iqr`, `skewness`, `kurtosis`, `bimodality_coef`. Flags: `--percentile-buckets-per-decade`, `--percentile-precision`, `--data-model`.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -192,56 +192,24 @@ ltl -so occurrences -sa access.log
 
 Percentile and shape metrics require a sufficient sample size to be statistically meaningful: `p999` ≥ ~1k, `p9999` ≥ ~100k, `p99999` ≥ ~1M. `bimodality_coef` is a *screening* statistic — at n < 100 small-sample noise can produce false positives. Skewness/kurtosis/bimodality_coef are undefined (blank in CSV, treated as 0 for sort ordering) when n < 4.
 
-### Percentile mode
+### Percentile data model and algorithm
 
-ltl computes latency percentiles for the summary table, CSV output, per-time-bucket statistics, heatmap markers, and histogram indicators. Under the unified percentile contract (issue [#187](https://github.com/gregeva/logtimeline/issues/187)), these consumers share a single bin-counter substrate with log-spaced bin geometry and HdrHistogram-style auto-resize. Bin precision is tunable; the locked default (53 buckets per decade, ~1.3% precision) matches OpenTelemetry's Scale-4 analog and is appropriate for the vast majority of analyses.
+ltl computes percentiles from one of two data models, each with its own algorithm. The two models produce different values for the same input, particularly in the tail; this is the data model, not a precision deviation. See `ltl --explain percentiles` for the deeper explanation, when to use which, and the trade-offs.
 
-When this matters: at the default precision, percentile values like P50 / P99 are within ~1.3% of their true sort-based values. Increasing precision reduces binning error proportionally at the cost of memory per partition (~2.1 KB per partition at default precision; scales linearly with bpd).
+**Raw values data model.** Every observation is held in memory and the percentile is selected by **nearest-rank** — an actually-observed sample at the computed rank in the sorted array. The returned value is a real request that happened. Scales with observation count.
 
-| Option | Description |
-|--------|-------------|
-| `-pp, --percentile-precision <N>` | Precision tier 1..9 (default: 5). Higher tiers give tighter percentile values at the cost of more memory per partition. |
-| `-pbpd, --percentile-buckets-per-decade <N>` | Buckets per decade directly (default: 53; valid 4..616). Overrides `--percentile-precision` when both supplied. |
-| `-ep, --exact-percentiles` | Revert to exact sort-based percentile computation. Deprecated; superseded by `-dm raw` / `--data-model raw` (see Data-model selectors below). |
+**Bin counter data model.** Observations are accumulated into log-spaced bins (HDR-histogram-style) and the percentile is computed by **linear interpolation between bucket boundaries**, the same approach Prometheus `histogram_quantile()` uses. The returned value is generally a synthesised value between bin edges, not an observed sample. Bin resolution sets the interpolation tightness — the default 53 buckets per decade gives roughly 1.3% relative bin width, matching OpenTelemetry's Scale-4 exponential histogram resolution. Scales with partition count rather than observation count.
 
-**Precision (`-pp` / `-pbpd`).** The default (tier 5 / 53 bpd) is appropriate for the vast majority of analyses — percentile values land very close to their true sort-based values. Raise it (tier 6–9, or `-pbpd` values up to 616) when you need tighter precision on tail percentiles (P99.9, P99.99) or when comparing two runs whose true percentiles differ by very small amounts; lower it (tier 1–4) to trade percentile precision for less memory on per-message percentile computation (summary table, CSV output), which fans out to one partition per unique message and so scales with message diversity. The histogram and heatmap consumers are unaffected — they use their own internal precision tuned for display rendering and ignore this knob.
+**Per-surface defaults.** Four consumer surfaces use percentile output; each has a default data model today:
 
-Use `-V` to inspect the active settings. The `=== BIN-COUNTER MODE ===` section reports the resolved precision, the source annotation (default, flag, or override), per-consumer state, and per-quantile audit codes (`out_of_range_bounded: pN=none|low|high`).
-
-```bash
-# Default precision (5 / 53 bpd)
-ltl access.log
-
-# Higher precision tier for tight outlier analysis
-ltl -pp 7 access.log
-
-# Direct buckets-per-decade override
-ltl -pbpd 100 access.log
-
-# Inspect the resolved settings
-ltl -V histogram-bin-counters access.log
-
-# Opt out to exact (sort-based) percentiles for byte-exact comparison
-ltl -ep access.log
-```
-
-### Data-model selectors
-
-ltl reduces duration samples into statistics through one of two internal data models:
-
-- **raw** — every observed duration retained, sorted at calculation time, statistics derived by direct array operations.
-- **bin** — HDR-style bin-counter; samples bucketed at capture time into bins-per-decade primitives, statistics derived from bin counts.
-
-The choice is independent per consumer surface. There are four surfaces:
-
-| # | Surface | Today's data model |
+| # | Surface | Default Data Model |
 |---|---|---|
-| 1 | Histogram statistics (consumed by `-hg`) | bin |
-| 2 | Heatmap statistics (consumed by `-hm`) | bin |
-| 3 | Per-message-key statistics | raw |
-| 4 | Per-time-bucket statistics | raw |
+| 1 | Histogram statistics (consumed by `-hg`) | bin counter |
+| 2 | Heatmap statistics (consumed by `-hm`) | bin counter |
+| 3 | Per-message-key statistics | raw values |
+| 4 | Per-time-bucket statistics | raw values |
 
-The data-model selectors below let you **pin** which data model a surface uses when you need certainty (test harnesses, reproducibility, A/B comparison). They have no defaults — when unset, the surface's existing internal logic chooses, and ltl's user-observable behavior is unchanged from previous releases.
+**Pinning the data model.** The selectors below override the per-surface default when you need certainty (test harnesses, reproducibility, A/B comparison). The omnibus `-dm` flag pins every surface; per-surface flags override `-dm` for their surface.
 
 | Option | Description |
 |--------|-------------|
@@ -251,9 +219,38 @@ The data-model selectors below let you **pin** which data model a surface uses w
 | `-mdm, --message-stats-data-model <raw\|bin>` | Pin the per-message-key statistics data model. Selector is resolved but currently only the raw reduction is implemented for this surface; `bin` lands in a follow-up. |
 | `-bdm, --bucket-stats-data-model <raw\|bin>` | Pin the per-time-bucket statistics data model. Same status as `-mdm` — selector resolved, raw only today. |
 
-**Resolution.** Per-surface flag overrides `-dm`; `-dm` overrides the surface's internal default. Invalid values (anything other than `raw` or `bin`) cause ltl to exit at option-parse time with a clear error. Conflicting flags on the same axis follow standard last-one-wins ordering.
+Per-surface flag overrides `-dm`; `-dm` overrides the per-surface default. Invalid values (anything other than `raw` or `bin`) cause ltl to exit at option-parse time with a clear error. Conflicting flags on the same axis follow standard last-one-wins ordering.
 
-**Relationship to `--exact-percentiles`.** `--exact-percentiles` is equivalent to `--data-model raw` on the histogram and heatmap surfaces (which is what it has always controlled). The new selectors supersede it; `--exact-percentiles` continues to work in this release but emits a deprecation notice and is scheduled for removal in a future release.
+**Tuning the bin counter algorithm.** When a surface uses the bin counter data model, bin resolution determines how tight the linear interpolation is. Raise resolution for tighter values in the tail percentiles (`p999`, `p9999`); lower it to reduce per-partition memory cost. The default (tier 5 / 53 bpd) suits most analyses.
+
+| Option | Description |
+|--------|-------------|
+| `-pp, --percentile-precision <N>` | Precision tier 1..9 (default: 5). Higher tiers give tighter percentile values at the cost of more memory per partition. |
+| `-pbpd, --percentile-buckets-per-decade <N>` | Buckets per decade directly (default: 53; valid 4..616). Overrides `--percentile-precision` when both supplied. |
+
+Per-message-key percentiles are the highest-cost consumer because they fan out to one partition per unique message; tier 1–4 trades resolution for less memory there. The histogram and heatmap surfaces are unaffected — they use their own internal resolution tuned for display rendering and ignore these knobs.
+
+Use `-V histogram-bin-counters` to inspect the resolved precision, the source (default, flag, or override), and per-consumer state.
+
+```bash
+# Default behavior (per-surface defaults above)
+ltl access.log
+
+# Higher precision tier for tight tail-percentile analysis
+ltl -pp 7 access.log
+
+# Direct buckets-per-decade override
+ltl -pbpd 100 access.log
+
+# Pin every surface to the raw values data model
+ltl -dm raw access.log
+
+# Override just the histogram surface; leave the heatmap on its default
+ltl -hgdm raw -hm duration -hg access.log
+
+# Inspect resolved settings
+ltl -V histogram-bin-counters access.log
+```
 
 ```bash
 # Pin every surface to the raw reduction path

--- a/features/272-percentile-algorithm-industry-grounding.md
+++ b/features/272-percentile-algorithm-industry-grounding.md
@@ -1,0 +1,180 @@
+# Industry-practice grounding for issue #272 (raw-array percentile algorithm)
+
+## Purpose
+
+This document records what industry-standard references do when computing percentiles from a **raw sample array** — i.e. when the full set of observations is materialised in memory and no histogram or sketch is used. It is the sibling of `features/187-histogram-industry-grounding.md`, which covers the bin-counter (histogram) data-model case. Together the two files cover the two data models on which `ltl` computes percentiles.
+
+This is a *facts-from-the-literature* document. It does not propose recommendations for `ltl`, does not pick winners, and does not invent options. Where a source is silent on the algorithm, the silence is recorded. Where a fetch failed and the content could not be quoted from a primary source, the failure is recorded rather than papered over.
+
+All quotations below were obtained by direct fetches of the source URLs listed in the "Sources consulted" section.
+
+## Sources consulted
+
+Fetched successfully (text reachable, key passages quoted):
+
+- **numpy.percentile documentation** — `method` parameter default, full list of 13 supported methods, Hyndman & Fan citation. URL: https://numpy.org/doc/stable/reference/generated/numpy.percentile.html
+- **pandas.DataFrame.quantile documentation** — `interpolation` parameter default and method list. URL: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.quantile.html
+- **R `quantile()` documentation** (stat.ethz.ch) — `type` parameter default, Hyndman & Fan citation, Type 7 formula, H&F authors' Type 8 recommendation. URL: https://stat.ethz.ch/R-manual/R-devel/library/stats/html/quantile.html
+- **Prometheus `histogram_quantile()` documentation** — bucket interpolation rule for classic and native histograms. URL: https://prometheus.io/docs/prometheus/latest/querying/functions/
+- **OTEP 149** (OpenTelemetry exponential histogram **proposal**, preserved-as-reference, **not adopted into OTEL spec**) — "percentile calculation usually returns log scale mid point of a bucket". URL: https://github.com/open-telemetry/oteps/blob/main/text/0149-exponential-histogram.md
+- **Datadog DDSketch engineering blog** — confirms DDSketch is the algorithm behind Datadog distributions; relative-error guarantee. URL: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/
+- **New Relic NRQL percentile improvements doc** — proprietary log-scale equal-width histogram algorithm, relative-error contract, `relativeError` field. URL: https://docs.newrelic.com/docs/nrql/using-nrql/improvements-nrql-percentile/
+- **Elastic percentile aggregation documentation** — T-Digest default, HDR Histogram opt-in, accuracy properties, non-determinism caveat. URL: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
+- **AWS CloudWatch statistics definitions** — semantic definition of `p95`, requirement for raw data points, algorithm not documented. URL: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html
+- **Google SRE Book — Monitoring Distributed Systems chapter** — explicit recommendation for histogram-bucketed collection over raw latencies; silent on percentile algorithm. URL: https://sre.google/sre-book/monitoring-distributed-systems/
+- **Google SRE Book — Service Level Objectives chapter** — discusses high-order percentiles; silent on percentile algorithm. URL: https://sre.google/sre-book/service-level-objectives/
+
+Fetches that failed or returned no usable content (recorded as gaps, not paraphrased from memory):
+
+- **Splunk percentile documentation** (`https://docs.splunk.com/Documentation/Splunk/latest/SearchReference/CommonStatsFunctions`) and **Splunk community thread** (`https://community.splunk.com/t5/Splunk-Search/Percentile-Implementation/m-p/106641`) — both returned HTTP 403. Splunk's algorithm (nearest-rank for small distinct-value counts, digest above a threshold, opt-in interpolated mode) is widely cited in secondary sources but could not be verified by direct fetch in this pass. Recorded as a gap.
+- **Hyndman & Fan 1996** ("Sample Quantiles in Statistical Packages", *The American Statistician* 50(4):361-365, doi 10.1080/00031305.1996.10473566) — publisher page (`https://www.tandfonline.com/doi/abs/10.1080/00031305.1996.10473566`) returned HTTP 403. The paper is cited verbatim by **both** the numpy documentation and the R `quantile()` documentation (see quotations below), which establishes the citation as authentic without requiring a direct fetch of the paper itself. The paper's nine-type taxonomy of sample quantile definitions is the canonical reference for this material.
+
+## What the algorithms are
+
+Before the per-tool findings, the two algorithms that bear on `ltl`'s raw-array path are named precisely.
+
+### Nearest-rank
+
+For a sorted sample array of length `n` and a percentile `p` in `[0, 1]`, nearest-rank picks an actually observed sample at a computed index. The exact index formula varies by definition (Hyndman & Fan's Types 1–3 are the discontinuous variants), but the property in common is: **the returned value is one of the observations** — never a synthesised value between observations. `ltl`'s `calculate_statistics` raw-array path uses `$sorted[int($duration_count * $p)]`, an index-into-sorted-array selection.
+
+### Linear interpolation (Hyndman & Fan Type 7)
+
+For a sorted sample array of length `n` and a percentile `p` in `[0, 1]`, Type 7 places `p` at index `1 + (n - 1) * p` (1-based) and linearly interpolates between the two adjacent observations when the index is non-integer. R's `quantile()` documentation states the formula verbatim:
+
+> "Type 7: `m = 1-p`. `p_k = (k - 1) / (n - 1)`. In this case, `p_k = mode[F(x_k)]`. This is used by S."
+
+pandas' documentation states the operational form:
+
+> "i + (j - i) * fraction, where fraction is the fractional part of the index surrounded by i and j."
+
+The returned value is generally **not** an observed sample. It is a synthesised value on the line segment between two adjacent observations.
+
+## Per-tool findings — raw-sample path
+
+### numpy.percentile
+
+- Default `method` parameter: `'linear'`.
+- The documentation lists 13 methods total: nine "standard methods sorted by R type per H&F paper" (`inverted_cdf`, `averaged_inverted_cdf`, `closest_observation`, `interpolated_inverted_cdf`, `hazen`, `weibull`, `linear` (default), `median_unbiased`, `normal_unbiased`) and four "discontinuous variations of `linear`" (`lower`, `higher`, `midpoint`, `nearest`).
+- Verbatim citation in the numpy docs: "R. J. Hyndman and Y. Fan, *Sample quantiles in statistical packages*, The American Statistician, 50(4), pp. 361-365, 1996" (cited as the source summarising R types for the first nine methods).
+- Note: numpy's own documentation classifies `'nearest'` as a "discontinuous variation of `linear`". `ltl`'s existing raw-array index selection (`int(n * p)`) is closest in spirit to `method='nearest'` (with off-by-one details that fall inside the H&F taxonomy as Type 1 / Type 3 variants).
+
+### pandas.DataFrame.quantile
+
+- Default `interpolation` parameter: `'linear'`.
+- Supported interpolation methods: `linear`, `lower`, `higher`, `nearest`, `midpoint`.
+- `'linear'` operational definition (verbatim): "i + (j - i) * fraction, where fraction is the fractional part of the index surrounded by i and j."
+
+### R `quantile()`
+
+- Default `type` parameter: `type = 7`.
+- Hyndman & Fan citation (verbatim): "Hyndman R. J., Fan Y. (1996). *Sample Quantiles in Statistical Packages*. The American Statistician, 50(4), 361–365."
+- Verbatim from the R docs: "Further details are provided in Hyndman and Fan (1996) who recommended type 8."
+- The R default is Type 7 — kept for compatibility with S — even though the H&F authors themselves recommended Type 8.
+
+### Splunk percentile functions (`perc99`, etc.)
+
+- Primary sources (Splunk docs, Splunk community thread) **returned HTTP 403** on direct fetch and could not be quoted.
+- Recorded as a gap. Secondary sources widely cite Splunk's behaviour as: nearest-rank for distinct-value counts below ~1000, digest above that threshold, with an opt-in `perc_method=interpolated` mode in `limits.conf`. Not verified by direct primary-source fetch in this pass.
+
+### AWS CloudWatch `p99` / `p95`
+
+- The CloudWatch statistics definitions page documents the **semantics** of a percentile statistic — "**p95** is the 95th percentile and means that 95 percent of the data within the period is lower than this value and 5 percent of the data is higher than this value" — but **does not specify the algorithm** (nearest-rank, interpolation, sketch type, or anything else).
+- The page does confirm that percentile statistics require raw data points: "CloudWatch needs raw data points to calculate the following statistics: Percentiles, Trimmed mean, Interquartile mean, Winsorized mean, Trimmed sum, Trimmed count, Percentile rank."
+- Algorithm not documented; recorded as unspecified.
+
+### Honeycomb P99 / P95
+
+- No fetched primary source on the algorithm Honeycomb uses for P99/P95. Recorded as a gap; not paraphrased from memory.
+
+## Per-tool findings — histogram and sketch paths (for context)
+
+The observability industry has largely moved off the raw-sample question entirely, in favour of histogram or sketch data models. These tools do not answer the raw-array question this issue is about — they are quoted here for completeness, so a reader understands why the "what does the industry do" question doesn't reduce cleanly to one answer.
+
+### Prometheus `histogram_quantile()`
+
+Histogram-based, not raw-sample. Verbatim from the Prometheus docs:
+
+> "For classic histograms and certain native histogram scenarios, the function 'assumes a uniform distribution of observations within the bucket (also called *linear interpolation*).' For non-zero buckets of native histograms with standard exponential schemas, a different method applies: 'the interpolation is done under the assumption that the samples within the bucket are distributed in a way that they would uniformly populate the buckets in a hypothetical histogram with higher resolution. (This is also called *exponential interpolation*.)'"
+
+Linear interpolation here is between **bucket boundaries**, not between samples.
+
+### OpenTelemetry exponential histograms
+
+The OpenTelemetry specification itself is silent on quantile-from-bucket estimation (see `features/187-histogram-industry-grounding.md` for the second-pass verification of that silence). OTEP 149 — a **proposal document, not adopted into the spec** — states:
+
+> "percentiles/quantiles can be computed from exponential buckets with constant relative error across the full range"
+
+> "To minimize relative error, percentile calculation usually returns log scale mid point of a bucket. So returned percentile values won't be on 10, 100, 1000, etc., even if the histogram is base10."
+
+The "log scale mid point of a bucket" rule is the OTEP-149 informational recommendation, not a specification mandate.
+
+### Datadog distributions
+
+Sketch-based, not raw-sample. Verbatim from the Datadog engineering blog:
+
+> "As we developed distribution metrics at Datadog to compute percentiles, we started using a sketch algorithm"
+
+> "We now use DDSketch at scale at Datadog."
+
+> "A relative-error guarantee of 2 percent means that if the actual 95th percentile is 1 second, the value returned by the sketch will be between 0.98 and 1.02 seconds."
+
+### New Relic NRQL `percentile()`
+
+Histogram-based, proprietary. Verbatim from the New Relic docs:
+
+> "uses a proprietary algorithm in what is known as the logarithmic scale equal-width histogram family"
+
+> "The typical relative error of the new method for most datasets is about 3%"
+
+> "the reported value is guaranteed to be within 3% of the actual value"
+
+A `relativeError` field is returned in JSON results so callers can see the precision margin per query.
+
+### Elastic / Kibana percentile aggregation
+
+Sketch-based by default. Verbatim from the Elastic docs:
+
+> "The algorithm used by the `percentile` metric is called TDigest (introduced by Ted Dunning..."
+
+> "Accuracy is proportional to `q(1-q)`. This means that extreme percentiles (e.g. 99%) are more accurate than less extreme percentiles..."
+
+> "Percentile aggregations are also non-deterministic. This means you can get slightly different results using the same data."
+
+HDR Histogram is available as an opt-in via the `hdr` parameter.
+
+## Authoritative SRE specifications
+
+### Google SRE Book — Monitoring Distributed Systems chapter
+
+The chapter explicitly recommends histogram-bucketed collection over raw latencies. Verbatim:
+
+> "The simplest way to differentiate between a slow average and a very slow 'tail' of requests is to collect request counts bucketed by latencies (suitable for rendering a histogram), rather than actual latencies"
+
+The chapter is **silent on the percentile-from-bucket or percentile-from-array algorithm**. The recommendation is about the *collection format* (histogram buckets), not the *quantile-estimation algorithm* applied to them.
+
+### Google SRE Book — Service Level Objectives chapter
+
+The chapter discusses "a high-order percentile, such as the 99th or 99.9th" and emphasises that "using percentiles for indicators allows you to consider the shape of the distribution and its differing attributes" — but is **silent on the computation algorithm** (nearest-rank, linear interpolation, Type 7, sketch, etc.). The chapter focuses on *why* percentiles matter, not *how* they are computed.
+
+### RED / USE / other SRE-discipline writeups
+
+No authoritative SRE source located in this pass specifies a sample-quantile algorithm. Recorded as a gap, not paraphrased from secondary commentary.
+
+## Hyndman & Fan 1996 — canonical reference
+
+The paper Hyndman, R. J. and Fan, Y. (1996), "Sample Quantiles in Statistical Packages", *The American Statistician* 50(4):361-365, doi 10.1080/00031305.1996.10473566, defines a taxonomy of nine sample-quantile definitions (Types 1–9). The publisher page returned HTTP 403 on direct fetch in this pass, so the paper text itself was not quoted. However the paper is cited verbatim by both the numpy documentation and the R `quantile()` documentation (quoted in the per-tool findings above), which establishes that:
+
+- Both stats-package defaults (`numpy.percentile` `method='linear'` and R `quantile()` `type=7`) trace to this taxonomy.
+- The paper's authors recommended Type 8 — a fact R's docs surface verbatim and numpy's docs surface implicitly by listing it (`median_unbiased`).
+- Type 7 is the inherited default in both packages for compatibility, not because H&F endorsed it.
+
+## Cross-file relationship
+
+This file documents the raw-array (full-observation) data model. Its sibling, `features/187-histogram-industry-grounding.md`, documents the histogram-bin-counter data model. The two files together cover the two data models on which `ltl` computes percentiles. They are paired: the same statistic, two algorithms, two data models, two evidence bases.
+
+`ltl`'s algorithm choices, recorded in issue #272:
+
+- Raw-array data model → nearest-rank (status quo).
+- Bin-counter data model → linear interpolation between bucket boundaries (status quo; implemented in #187).
+
+Both choices are defensible against the evidence in these two files. Neither is "the SRE-standard algorithm" — no such standard exists in the references surveyed. The choice in each case is driven by what the data model can faithfully express.

--- a/ltl
+++ b/ltl
@@ -3634,9 +3634,9 @@ sub print_help {
 
     # Percentile mode (Issue #189)
     $out .= help_subheading("Percentile mode");
-    $out .= help_opt("-pp,   --percentile-precision <N>",            "Set percentile binning precision tier 1..9 (default: 5 = ~1.3%; 1=~10%, 9=~0.1%). Affects migrated consumers; see docs/usage.md");
+    $out .= help_opt("-pp,   --percentile-precision <N>",            "Set percentile binning precision tier 1..9 (default: 5 = ~1.3%; 1=~10%, 9=~0.1%). Applies to surfaces using the bin counter data model; see docs/usage.md");
     $out .= help_opt("-pbpd, --percentile-buckets-per-decade <N>",   "Set percentile buckets-per-decade directly (default: 53; valid 4..616). Overrides --percentile-precision when both supplied");
-    $out .= help_opt("-ep,   --exact-percentiles",                   "Disable unified percentile mode; revert to exact sort-based computation (deprecated; superseded by --data-model raw)");
+    $out .= help_opt("-ep,   --exact-percentiles",                   "Pin the histogram and heatmap surfaces to the raw values data model (deprecated; superseded by --data-model raw)");
 
     # Data-model selectors (Issue #266). Pin which reduction path each
     # surface uses. No defaults — when unset, the surface's existing


### PR DESCRIPTION
## Summary

- Adds `features/272-percentile-algorithm-industry-grounding.md` — industry research file (sibling to `features/187-histogram-industry-grounding.md`) capturing what numpy, pandas, R, Prometheus, OTEP 149, Datadog, New Relic, Elastic, AWS CloudWatch, and the Google SRE Book do for raw-array percentile computation. Verbatim quotes from direct fetches; failed fetches recorded honestly as gaps.
- Reframes user-facing percentile docs (`docs/explain/statistics.md`, `docs/usage.md`, `ltl --help`) around the corrected understanding: two data models (raw values, bin counter), each with its own algorithm (nearest-rank, linear interpolation between bucket boundaries), producing different values by design. No functional changes.

## Test plan

- [ ] `./tests/validate-regression.sh` passes (no functional change, but sanity-check)
- [ ] `ltl --help` renders the two updated help rows cleanly
- [ ] `ltl --explain percentiles` renders the rewritten topic cleanly
- [ ] Spot-read the rewritten Percentile data model and algorithm section in `docs/usage.md`