### PR TITLE
Issue #275: self-documenting failure output for three harnesses

### DIFF
--- a/tests/validate-help-layout.sh
+++ b/tests/validate-help-layout.sh
@@ -80,20 +80,76 @@ fail=0
 failures=()
 
 note_pass() { pass=$((pass + 1)); echo "  PASS  $1"; }
-note_fail() { fail=$((fail + 1)); failures+=("$1"); echo "  FAIL  $1"; }
+
+# Self-documenting failure emitter per tests/HARNESS-DESIGN.md
+# § Self-documenting assertions. Required named fields: label, asserts,
+# produced_by, contract. An optional `detail` field appends an extra line
+# (used when the inspector produced a more specific diagnostic, e.g.
+# the exact mismatched column number).
+emit_fail() {
+    local label asserts produced_by contract detail
+    detail=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            label)       label="$2";       shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            detail)      detail="$2";      shift 2 ;;
+            *) echo "emit_fail: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${label:?emit_fail requires label}"
+    : "${asserts:?emit_fail requires asserts}"
+    : "${produced_by:?emit_fail requires produced_by}"
+    : "${contract:?emit_fail requires contract}"
+    echo "  FAIL  $label"
+    echo "        asserts:     $asserts"
+    echo "        produced_by: $produced_by"
+    echo "        contract:    $contract"
+    if [[ -n "$detail" ]]; then
+        echo "        detail:      $detail"
+    fi
+    fail=$((fail + 1))
+    failures+=("$label")
+}
 
 # ---------------------------------------------------------------------------
 # Sanity: $desc_col found and looks reasonable
 # ---------------------------------------------------------------------------
 echo "[sanity]"
+SANITY_ASSERTS='The three help-layout column constants ($help_opt_col, $help_short_col, $help_desc_col) extracted from ltl fall within plausible bounds, and $help_desc_col exceeds the long-form column so descriptions cannot overlap the long-form option text'
+SANITY_PRODUCED_BY='print_help() in ltl — module-scope my-declarations of $help_opt_col, $help_short_col, $help_desc_col'
+SANITY_CONTRACT='Issue #261 hoisted these constants to module scope so --help, --help statistics, and --explain share one source of truth; bounds here exist to catch typo-class regressions where one is reset to an obviously-wrong value'
+
 if [[ "$DESC_COL" -lt 30 || "$DESC_COL" -gt 80 ]]; then
-    note_fail "sanity :: \$help_desc_col=$DESC_COL is out of plausible range (30..80)"
+    emit_fail \
+        label       "sanity" \
+        asserts     "$SANITY_ASSERTS" \
+        produced_by "$SANITY_PRODUCED_BY" \
+        contract    "$SANITY_CONTRACT" \
+        detail      "\$help_desc_col=$DESC_COL is out of plausible range (30..80)"
 elif [[ "$SHORT_COL" -lt 5 || "$SHORT_COL" -gt 12 ]]; then
-    note_fail "sanity :: \$help_short_col=$SHORT_COL is out of plausible range (5..12)"
+    emit_fail \
+        label       "sanity" \
+        asserts     "$SANITY_ASSERTS" \
+        produced_by "$SANITY_PRODUCED_BY" \
+        contract    "$SANITY_CONTRACT" \
+        detail      "\$help_short_col=$SHORT_COL is out of plausible range (5..12)"
 elif [[ "$OPT_COL" -lt 2 || "$OPT_COL" -gt 8 ]]; then
-    note_fail "sanity :: \$help_opt_col=$OPT_COL is out of plausible range (2..8)"
+    emit_fail \
+        label       "sanity" \
+        asserts     "$SANITY_ASSERTS" \
+        produced_by "$SANITY_PRODUCED_BY" \
+        contract    "$SANITY_CONTRACT" \
+        detail      "\$help_opt_col=$OPT_COL is out of plausible range (2..8)"
 elif [[ "$DESC_COL" -le "$EXPECTED_LONG_COL" ]]; then
-    note_fail "sanity :: \$help_desc_col=$DESC_COL must exceed long-form column ($EXPECTED_LONG_COL = \$help_opt_col + \$help_short_col)"
+    emit_fail \
+        label       "sanity" \
+        asserts     "$SANITY_ASSERTS" \
+        produced_by "$SANITY_PRODUCED_BY" \
+        contract    "$SANITY_CONTRACT" \
+        detail      "\$help_desc_col=$DESC_COL must exceed long-form column ($EXPECTED_LONG_COL = \$help_opt_col + \$help_short_col)"
 else
     note_pass "sanity :: \$help_opt_col=$OPT_COL  \$help_short_col=$SHORT_COL  \$help_desc_col=$DESC_COL  long-form col=$EXPECTED_LONG_COL  desc col=$EXPECTED_DESC_COL"
 fi
@@ -231,11 +287,26 @@ if [[ $rc -eq 0 ]]; then
     note_pass "every option row description starts at col $EXPECTED_DESC_COL"
     note_pass "every wrapped-description continuation row starts at col $EXPECTED_DESC_COL"
 elif [[ $rc -eq 2 ]]; then
-    note_fail "one or more option rows have misaligned description column (see output above)"
+    emit_fail \
+        label       "option-row alignment" \
+        asserts     "Every option-row description begins at column \$help_desc_col+1 ($EXPECTED_DESC_COL); a row whose description starts to the right means its option text exceeded the column budget and overflowed silently" \
+        produced_by 'print_help() in ltl — the option-text rendering uses $help_desc_col as the padding target for the description column' \
+        contract    'Issue #189-3 root cause: long-form options exceeding the option-text column budget shipped silently because there was no test asserting the column was honored. This assertion is what makes the failure visible.' \
+        detail      "Perl inspector exit code 2 — one or more option rows misaligned (per-row diagnostics printed above)"
 elif [[ $rc -eq 3 ]]; then
-    note_fail "one or more continuation rows have misaligned column (see output above)"
+    emit_fail \
+        label       "continuation-row alignment" \
+        asserts     'Every wrapped-description continuation line begins at the same column as the description start ($help_desc_col+1)' \
+        produced_by 'print_help() in ltl — wrap continuations are emitted with the same leading indent as the description column' \
+        contract    'Issue #189-3 — the same column-budget bug that misaligns option rows also misaligns their wrap continuations; both must be guarded together' \
+        detail      "Perl inspector exit code 3 — one or more continuation rows misaligned (per-row diagnostics printed above)"
 else
-    note_fail "Perl inspector exited with unexpected code $rc"
+    emit_fail \
+        label       "option-row alignment (inspector)" \
+        asserts     'The Perl inspector must exit 0, 2, or 3; any other exit code means the inspector itself broke and the test is no longer asserting anything' \
+        produced_by 'inline Perl inspector at the top of validate-help-layout.sh' \
+        contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — an inspector that cannot run is an unasserted test' \
+        detail      "Perl inspector exited with unexpected code $rc"
 fi
 
 # ---------------------------------------------------------------------------
@@ -287,9 +358,19 @@ rc=$?
 if [[ $rc -eq 0 ]]; then
     note_pass "every short+long row places its long form at col $EXPECTED_LONG_COL"
 elif [[ $rc -eq 2 ]]; then
-    note_fail "one or more short+long rows misalign the long-form column (see output above)"
+    emit_fail \
+        label       "long-form column alignment" \
+        asserts     "Every short+long option row places its long form starting at column \$help_opt_col + \$help_short_col + 1 ($EXPECTED_LONG_COL); a short form whose length pushes the long form rightward produces a ragged left margin even though the description column itself can still be honored" \
+        produced_by 'print_help() in ltl — the short-form rendering pads to $help_short_col before emitting the long form' \
+        contract    "Issue #261 — \$help_short_col was sized to accommodate the longest short form; a regression on either side (short form too long, or \$help_short_col bumped down) breaks left-margin alignment" \
+        detail      "Perl inspector exit code 2 — one or more short+long rows misaligned (per-row diagnostics printed above)"
 else
-    note_fail "long-form-column Perl inspector exited with unexpected code $rc"
+    emit_fail \
+        label       "long-form column alignment (inspector)" \
+        asserts     'The long-form-column Perl inspector must exit 0 or 2; any other exit code means the inspector itself broke' \
+        produced_by 'inline Perl inspector in the [long-form column alignment] block of validate-help-layout.sh' \
+        contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — an inspector that cannot run is an unasserted test' \
+        detail      "long-form-column Perl inspector exited with unexpected code $rc"
 fi
 
 # ---------------------------------------------------------------------------
@@ -305,7 +386,12 @@ assert_pair() {
     if grep -qE "^[[:space:]]+${short}, +${long}([[:space:]]|<|\[|$)" "$STRIPPED"; then
         note_pass "$short, $long"
     else
-        note_fail "$short, $long  (expected both short and long form on same line)"
+        emit_fail \
+            label       "$short, $long" \
+            asserts     "Both the short form ($short) and long form ($long) appear on the same row of --help output, in the canonical 'short, long' order; missing-pair regressions cost the user a discoverable surface (memory: 'short forms required for every CLI option')" \
+            produced_by 'print_help() in ltl — the option-table row that registers this flag emits short+long together' \
+            contract    "MEMORY.md feedback_short_forms_required: every CLI flag in ltl must have both short and long form; 'no short form' decisions are errors that need amending before wiring" \
+            detail      "no row matched '^[[:space:]]+${short}, +${long}' in stripped --help output"
     fi
 }
 assert_pair "-pp"    "--percentile-precision"

--- a/tests/validate-histogram-ticks.sh
+++ b/tests/validate-histogram-ticks.sh
@@ -39,7 +39,38 @@ fail=0
 failures=()
 
 note_pass() { pass=$((pass + 1)); echo "  PASS: $1"; }
-note_fail() { fail=$((fail + 1)); failures+=("$1"); echo "  FAIL: $1"; }
+
+# Self-documenting failure emitter per tests/HARNESS-DESIGN.md
+# § Self-documenting assertions. Required named fields: label, asserts,
+# produced_by, contract. Optional `detail` carries the run-specific
+# diagnostic (counts, widths, etc.).
+emit_fail() {
+    local label asserts produced_by contract detail
+    detail=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            label)       label="$2";       shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            detail)      detail="$2";      shift 2 ;;
+            *) echo "emit_fail: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${label:?emit_fail requires label}"
+    : "${asserts:?emit_fail requires asserts}"
+    : "${produced_by:?emit_fail requires produced_by}"
+    : "${contract:?emit_fail requires contract}"
+    echo "  FAIL  $label"
+    echo "        asserts:     $asserts"
+    echo "        produced_by: $produced_by"
+    echo "        contract:    $contract"
+    if [[ -n "$detail" ]]; then
+        echo "        detail:      $detail"
+    fi
+    fail=$((fail + 1))
+    failures+=("$label")
+}
 
 # ---------------------------------------------------------------------------
 # Inspector: parse one ltl run's output, extract per-histogram axis-tick and
@@ -179,7 +210,12 @@ test_single_width() {
     if [[ "$oo" == "0" ]]; then
         note_pass "no ┴/┻/┼/╋ outside axis lines (-hgw $hgw)"
     else
-        note_fail "found $oo lines containing ticks outside axis (-hgw $hgw)"
+        emit_fail \
+            label       "out-of-axis ticks (-hgw $hgw)" \
+            asserts     'Percentile tick characters (┴ ┻ ┼ ╋) appear only on the histogram x-axis frame row; appearance elsewhere means the tick emission code is firing on a non-axis row, which is a layout regression' \
+            produced_by 'print_histogram() in ltl — the tick characters are inserted into the same row that emits ┗ ━ ┳ ┛ for the histogram frame' \
+            contract    'Issue #185 § percentile tick marks on histogram x-axis — tick emission is confined to the axis row by construction; tick characters in other rows are not part of the contract' \
+            detail      "found $oo lines containing ticks outside axis (-hgw $hgw)"
     fi
 
     # Colour assertion.
@@ -188,7 +224,12 @@ test_single_width() {
     if [[ "$bad_colour" == "0" ]]; then
         note_pass "tick chars match axis frame colour (no ANSI wrapping) (-hgw $hgw)"
     else
-        note_fail "$bad_colour tick chars carry ANSI colour wrapping (-hgw $hgw)"
+        emit_fail \
+            label       "tick colour parity (-hgw $hgw)" \
+            asserts     'Percentile tick characters are emitted with no ANSI wrapping, matching the rest of the frame which is also unwrapped; an ANSI escape sequence immediately preceding a tick means the tick will render in a different colour than ┗ ━ ┳ ┛' \
+            produced_by 'print_histogram() in ltl — tick characters are appended to the frame string with no additional colour wrapping' \
+            contract    'Issue #185 — visual unity of the axis frame requires tick chars to inherit the frame colour by being emitted in the same uncoloured stream' \
+            detail      "$bad_colour tick chars carry ANSI colour wrapping (-hgw $hgw)"
     fi
 
     # Tick-vs-legend invariant: 1 <= ticks <= entries.
@@ -196,11 +237,21 @@ test_single_width() {
     tick_total=$(echo "$report" | awk -F: '/^AXIS:1:1:/ {for (i=1;i<=NF;i++) if ($i ~ /^total=/) {split($i,a,"="); print a[2]}}')
     legend_entries=$(echo "$report" | awk -F: '/^LEGEND:1:1:/ {for (i=1;i<=NF;i++) if ($i ~ /^entries=/) {split($i,a,"="); print a[2]}}')
     if [[ -z "$tick_total" || -z "$legend_entries" ]]; then
-        note_fail "could not extract axis/legend counts (-hgw $hgw): tick='$tick_total' legend='$legend_entries'"
+        emit_fail \
+            label       "tick/legend extraction (-hgw $hgw)" \
+            asserts     'The inspector must successfully extract both an AXIS tick total and a LEGEND entry count from the single-histogram output; a missing anchor here means the histogram or its legend was not emitted, OR the inspector regexes drifted from the rendered output' \
+            produced_by 'print_histogram() + legend rendering in ltl; inspector regexes in inspect_output() of this harness' \
+            contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — a grep that matches nothing is a failure, not a pass' \
+            detail      "could not extract axis/legend counts (-hgw $hgw): tick='$tick_total' legend='$legend_entries'"
     elif [[ "$tick_total" -ge 1 && "$tick_total" -le "$legend_entries" ]]; then
         note_pass "axis ticks ($tick_total) within [1, $legend_entries] legend entries (-hgw $hgw)"
     else
-        note_fail "axis ticks ($tick_total) outside [1, $legend_entries] legend entries (-hgw $hgw)"
+        emit_fail \
+            label       "tick/legend cardinality (-hgw $hgw)" \
+            asserts     'The number of axis ticks is at least 1 and at most the number of legend entries; tick_count > legend_count means orphan ticks with no matching legend entry (the legend is the contract); tick_count < 1 means the percentile marker layer was not rendered at all' \
+            produced_by 'print_histogram() in ltl — tick column derivation maps each legend percentile to a column; duplicate columns collapse to one tick' \
+            contract    'Issue #185 — set-semantics: percentiles with identical (or column-quantised-identical) values collapse to one tick; orphan ticks have no place in the rendering' \
+            detail      "axis ticks ($tick_total) outside [1, $legend_entries] legend entries (-hgw $hgw)"
     fi
 
     rm -f "$out"
@@ -225,7 +276,12 @@ test_multi_histogram() {
     if [[ "$oo" == "0" ]]; then
         note_pass "no ticks outside axis (multi)"
     else
-        note_fail "found $oo lines with ticks outside axis (multi)"
+        emit_fail \
+            label       "out-of-axis ticks (multi)" \
+            asserts     'In a multi-histogram run, percentile tick characters still appear only on histogram x-axis frame rows; tick leakage into other rows is a layout regression that the single-width tests can miss because multi-histogram layout takes a different code path' \
+            produced_by 'print_histogram() in ltl — invoked once per metric for -hg duration,bytes; each invocation must restrict tick emission to its own axis row' \
+            contract    'Issue #185 — multi-histogram is the panel-stacking variant; the same axis-row containment invariant applies independently to each panel' \
+            detail      "found $oo lines with ticks outside axis (multi)"
     fi
 
     # Per-histogram tick-vs-legend invariant: 1 <= ticks <= entries.
@@ -234,11 +290,21 @@ test_multi_histogram() {
         tick=$(echo "$report" | awk -F: -v h="$hidx" '/^AXIS:1:/ && $3==h {for (i=1;i<=NF;i++) if ($i ~ /^total=/) {split($i,a,"="); print a[2]}}')
         legend=$(echo "$report" | awk -F: -v h="$hidx" '/^LEGEND:1:/ && $3==h {for (i=1;i<=NF;i++) if ($i ~ /^entries=/) {split($i,a,"="); print a[2]}}')
         if [[ -z "$tick" || -z "$legend" ]]; then
-            note_fail "could not extract counts for hist#$hidx (multi): tick='$tick' legend='$legend'"
+            emit_fail \
+                label       "tick/legend extraction (multi hist#$hidx)" \
+                asserts     "The inspector must successfully extract both an AXIS tick total and a LEGEND entry count for histogram panel #$hidx; missing data here means the panel was not rendered, or its legend was emitted on a row the inspector cannot identify" \
+                produced_by 'print_histogram() (per-panel invocation) + inspect_output() per-segment splitting in this harness' \
+                contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — multi-histogram extraction failures must not silently degrade to a passing test' \
+                detail      "could not extract counts for hist#$hidx (multi): tick='$tick' legend='$legend'"
         elif [[ "$tick" -ge 1 && "$tick" -le "$legend" ]]; then
             note_pass "hist#$hidx ticks ($tick) within [1, $legend] legend entries"
         else
-            note_fail "hist#$hidx ticks ($tick) outside [1, $legend] legend entries"
+            emit_fail \
+                label       "tick/legend cardinality (multi hist#$hidx)" \
+                asserts     "Histogram panel #$hidx has at least 1 axis tick and no more axis ticks than legend entries; each panel carries its own independent tick set matching its own legend" \
+                produced_by 'print_histogram() in ltl — tick column derivation runs independently per panel' \
+                contract    'Issue #185 — multi-histogram panels carry independent tick sets; cross-panel sharing would create the orphan-tick failure mode this assertion exists to prevent' \
+                detail      "hist#$hidx ticks ($tick) outside [1, $legend] legend entries"
         fi
     done
 

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -46,6 +46,38 @@ fi
 pass=0
 fail=0
 skip=0
+failures=()
+
+# Self-documenting fields shared across every run_test assertion. The
+# assertion shape is uniform across this harness: a byte-stable rendering
+# of `ltl` output (after stripping nondeterministic content) must match
+# the captured reference file. The test-name dimension is what varies;
+# the invariant, producer, and contract are the same for every case.
+# Per tests/HARNESS-DESIGN.md § Self-documenting assertions, these three
+# fields are surfaced alongside every failure.
+REGRESSION_ASSERTS='ltl output (after stripping ANSI, timing, memory, and other nondeterministic content) is byte-identical to the captured reference file for this scenario'
+REGRESSION_PRODUCED_BY='print_bar_graph(), print_summary_table(), print_heatmap_row(), and the layout engine in ltl — composite rendered output'
+REGRESSION_CONTRACT='tests/HARNESS-DESIGN.md § Self-documenting assertions + this harness re-runs the commands from capture-regression.sh against tests/reference-output/; rebaselining is a per-release activity, not an automatic remediation'
+
+# Emit a regression-suite failure in the self-documenting multi-line form
+# required by tests/HARNESS-DESIGN.md § Self-documenting assertions.
+# Args: $1 scenario name, $2 short cause line, $3 (optional) path to a
+# file whose contents should be appended as an indented diagnostic body.
+emit_regression_fail() {
+    local name="$1"
+    local cause="$2"
+    local body_file="${3:-}"
+    echo "  FAIL  $name"
+    echo "        cause:       $cause"
+    echo "        asserts:     $REGRESSION_ASSERTS"
+    echo "        produced_by: $REGRESSION_PRODUCED_BY"
+    echo "        contract:    $REGRESSION_CONTRACT"
+    if [[ -n "$body_file" && -s "$body_file" ]]; then
+        sed 's/^/        /' "$body_file"
+    fi
+    fail=$((fail + 1))
+    failures+=("$name :: $cause")
+}
 
 run_test() {
     local name="$1"
@@ -53,6 +85,7 @@ run_test() {
     local reffile="$REF_DIR/$name.txt"
     local tmpfile="$TMP_DIR/$name.txt"
     local stderrfile="$TMP_DIR/$name.stderr"
+    local difffile="$TMP_DIR/$name.diff"
 
     if [[ ! -f "$reffile" ]]; then
         echo "  SKIP  $name (no reference file)"
@@ -70,15 +103,11 @@ run_test() {
     set -e
 
     if [[ "${pipe_status[0]}" -ne 0 ]]; then
-        echo "  FAIL  $name :: ltl exited ${pipe_status[0]}; stderr:" >&2
-        sed 's/^/        /' "$stderrfile" >&2
-        fail=$((fail + 1))
+        emit_regression_fail "$name" "ltl exited ${pipe_status[0]} (stderr below)" "$stderrfile"
         return
     fi
     if [[ ! -s "$tmpfile" ]]; then
-        echo "  FAIL  $name :: captured output is empty (regression target produced nothing); stderr:" >&2
-        sed 's/^/        /' "$stderrfile" >&2
-        fail=$((fail + 1))
+        emit_regression_fail "$name" "captured output is empty (regression target produced nothing; stderr below)" "$stderrfile"
         return
     fi
 
@@ -86,14 +115,13 @@ run_test() {
         echo "  PASS  $name"
         pass=$((pass + 1))
     else
-        echo "  FAIL  $name"
         # diff returns 1 on differences (intentional); pipefail would propagate
         # that and abort the harness before printing the Results summary.
         # Per tests/HARNESS-DESIGN.md, intentional non-zero exits in a
         # diagnostic pipeline must be neutralized so the harness can complete.
-        { diff --unified=3 "$reffile" "$tmpfile" || true; } | head -30
-        echo "  ..."
-        fail=$((fail + 1))
+        { diff --unified=3 "$reffile" "$tmpfile" || true; } | head -30 > "$difffile"
+        echo "  ..."  >> "$difffile"
+        emit_regression_fail "$name" "rendered output differs from reference (unified diff below, truncated to 30 lines)" "$difffile"
     fi
 }
 
@@ -195,6 +223,10 @@ echo "Results: $pass passed, $fail failed, $skip skipped"
 # TMP_DIR cleanup handled by EXIT trap at top of script
 
 if [[ $fail -gt 0 ]]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  - $f"
+    done
     echo "REGRESSION DETECTED"
     exit 1
 else

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -275,10 +275,10 @@ scenario_warning_exact_percentiles_deprecated() {
     run_ltl "warn-ep" --exact-percentiles "$TEST_LOG"
 
     assert_line "$RUN_STDERR" \
-        pattern     '^--exact-percentiles is deprecated and will be removed in a future release\.' \
-        asserts     'ltl emits a deprecation warning on every run that uses --exact-percentiles. The flag reverts every migrated -V/percentile consumer to pre-#187 sort-based computation and is scheduled for removal — users should see the warning before the removal lands.' \
+        pattern     '^--exact-percentiles is deprecated' \
+        asserts     'ltl emits a deprecation warning on every run that uses --exact-percentiles. The flag is superseded by --data-model raw (and the per-surface --histogram-data-model / --heatmap-data-model overrides) introduced in #266; users must see the warning before the removal lands so they can migrate.' \
         produced_by 'adapt_to_command_line_options() in ltl (post-GetOptions deprecation gate)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — --exact-percentiles is documented-deprecated; warning is the user-visible signal of the deprecation status'
+        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + Issue #266 — --exact-percentiles is documented-deprecated and supersession is locked; warning is the user-visible signal of the deprecation status. Anchored at the opening clause because the body advises on replacement flags and may evolve as --data-model evolves.'
 }
 
 scenario_error_unknown_so() {


### PR DESCRIPTION
## Summary

- Retrofit `tests/validate-regression.sh`, `tests/validate-help-layout.sh`, and `tests/validate-histogram-ticks.sh` to emit failures in the multi-line indented form with `asserts` / `produced_by` / `contract` fields per `tests/HARNESS-DESIGN.md` § Self-documenting assertions.
- `validate-regression.sh` uses one shared contract across all ~38 diff assertions (uniform invariant: rendered output must match the captured reference byte-for-byte after stripping nondeterministic content). The unified diff body is preserved as an indented diagnostic under the three fields.
- `validate-help-layout.sh` and `validate-histogram-ticks.sh` supply per-call-site fields because each assertion guards a different invariant (sanity bounds, description-column alignment, long-form column alignment, short+long pair presence; out-of-axis ticks, tick colour parity, tick/legend cardinality, extraction-anchor presence, multi-histogram variants).
- Also fix `validate-runtime-config.sh`'s `warning-exact-percentiles-deprecated` assertion — it was asserting the pre-#266 deprecation text. #266 rewrote the warning to lead with replacement-flag advice; the anchor is now `^--exact-percentiles is deprecated` (the opening clause is contractual; the body may evolve as `--data-model` evolves). Surfaced while running the full harness suite for AC5 ("no regression in any other harness"); no separate issue tracked this drift.

## Acceptance criteria (from #275)

- [x] `validate-regression.sh` emits failures using the multi-line indented form with `asserts` / `produced_by` / `contract` fields. The diff body remains, but the three fields appear above it.
- [x] `validate-help-layout.sh` replaces `note_fail` calls with `emit_fail`; each call site supplies the three fields.
- [x] `validate-histogram-ticks.sh` same as above.
- [x] The three updated harnesses pass on the current branch and produce the multi-line format when artificially forced to fail (each verified once via reversible tampering; tampering reverted).
- [x] No regression in any other harness. (`validate-runtime-config.sh` surfaced a pre-#266 deprecation-text drift; fixed in the same PR per user direction.)

## Test plan

- [ ] `./tests/validate-regression.sh` — must report `ALL TESTS PASSED` (38 passed)
- [ ] `./tests/validate-help-layout.sh` — must report `ALL HELP-LAYOUT TESTS PASSED` (9 passed)
- [ ] `./tests/validate-histogram-ticks.sh` — must report `Total: 15 | Passed: 15 | Failed: 0`
- [ ] `./tests/validate-runtime-config.sh` — must report `ALL RUNTIME-CONFIG TESTS PASSED` (23 passed)
- [ ] All other harnesses still pass (csv-output, doc-examples, explain, format-detection, heatmap-palette, help-content, histogram-bin-counters, index-read-back)
- [ ] Sanity check the multi-line failure shape by temporarily tampering with one assertion (e.g. flip an expected count in `validate-histogram-ticks.sh`) and confirm the three fields render before reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)