### PR TITLE
Issue #284: stabilize consolidation across runs

### DIFF
--- a/ltl
+++ b/ltl
@@ -4460,7 +4460,7 @@ sub group_similar_messages {
             my @sorted_keys = sort {
                 my ($msg_a) = $a =~ /^\[[^\]]+\]\s*(.*)/s;
                 my ($msg_b) = $b =~ /^\[[^\]]+\]\s*(.*)/s;
-                ($msg_a // $a) cmp ($msg_b // $b)
+                (($msg_a // $a) cmp ($msg_b // $b)) || ($a cmp $b)
             } keys %{$log_messages{$category}};
 
             my @window;
@@ -5073,7 +5073,7 @@ sub consolidation_process_key {
 
     # Check trigger per category — fire checkpoints for all groups in this category
     if (($consolidation_category_unmatched_count{$category} // 0) >= $consolidation_trigger) {
-        for my $ck (keys %consolidation_unmatched) {
+        for my $ck (sort keys %consolidation_unmatched) {
             next unless $ck =~ /^\Q$category\E\|/;
             next if scalar(keys %{$consolidation_unmatched{$ck}}) < 2;
             my ($cc, $gk) = split(/\|/, $ck, 2);


### PR DESCRIPTION
## Summary
- Add `($a cmp $b)` tiebreaker to the final-pass `@sorted_keys` sort in `group_similar_messages` — ties on the prefix-stripped message body were falling back to hash-random key order, producing run-to-run variance in cluster identity (the symptom in #284).
- Defensively sort the streaming checkpoint-trigger iteration over `%consolidation_unmatched` (no observed output impact, same pattern).

## Verification
- Reproduced #284 on `localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt` with `-bs 240 -g 90 -n 25 -mdm raw -bdm raw -o`: 5 runs produced 4 distinct MESSAGES CSV MD5s before the fix.
- `PERL_HASH_SEED=0` runs produced identical output, confirming hash-iteration order was the root cause.
- `--no-final-pass` (without the fix) produced identical runs, narrowing the bug to final-pass code.
- After the fix: 5 consecutive runs produce identical MESSAGES CSVs, matching the `PERL_HASH_SEED=0` canonical output.

## Test plan
- [x] Reproduce #284 symptom before fix (5 runs, 4 distinct MD5s)
- [x] Confirm `--no-final-pass` is deterministic without the fix
- [x] Confirm `PERL_HASH_SEED=0` is deterministic without the fix
- [x] 5 consecutive runs after fix produce identical MD5s