### PR TITLE
Issue #291: restrict emitted output to ASCII

### DIFF
--- a/ltl
+++ b/ltl
@@ -12353,12 +12353,12 @@ unless( $group_similar_sensitivity eq "none" ) {
                 my $fp_absorbed = ($s->{fp_p1_s3} // 0) + ($s->{fp_p1_s4_pairwise} // 0) + ($s->{fp_p1_s4_rescan} // 0) + ($s->{fp_p2_s3} // 0);
                 my $combined_patterns = exists $consolidation_patterns{$cat_gk} ? scalar @{$consolidation_patterns{$cat_gk}} : 0;
                 $final_remaining = $fp_keys - $fp_absorbed - ($s->{fp_p1_s2_ceiling} // 0) + $combined_patterns;
-                push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
+                push @verbose_output, sprintf("    Reduction: %d -> %d (%.1f%%)",
                     $keys_seen, $final_remaining,
                     (1 - $final_remaining / ($keys_seen || 1)) * 100);
             } else {
                 $final_remaining = $genuinely_unmatched + $evicted + $ceiling_filtered + $patterns;
-                push @verbose_output, sprintf("    Reduction: %d → %d (%.1f%%)",
+                push @verbose_output, sprintf("    Reduction: %d -> %d (%.1f%%)",
                     $keys_seen, $final_remaining,
                     (1 - $final_remaining / ($keys_seen || 1)) * 100);
             }

--- a/tests/validate-csv-output.sh
+++ b/tests/validate-csv-output.sh
@@ -140,7 +140,7 @@ while IFS=$'\t' read -r scenario logfile options families; do
         echo "        -V csv-output / precision sub-section was empty or absent in ltl stdout" >&2
         echo "        asserts: every -o run must emit -V csv-output / precision when -V csv-output is requested" >&2
         echo "        produced_by: emit_csv_output_verbose() in ltl" >&2
-        echo "        contract: Issue #268 § locked observability surface" >&2
+        echo "        contract: Issue #268 section locked observability surface" >&2
         total_fail=$((total_fail + 1))
         scenarios_run=$((scenarios_run + 1))
         continue

--- a/tests/validate-doc-examples.sh
+++ b/tests/validate-doc-examples.sh
@@ -207,7 +207,7 @@ run_doc_example() {
             label       "doc example exited $ec" \
             asserts     "Every non-skipped ltl example in user-facing documentation parses its options and runs to completion (exit 0) against a known fixture. A non-zero exit means an option was renamed, removed, or the example was wrong from the start." \
             produced_by 'docs/usage.md (example) + ltl option parser' \
-            contract    'features/225-test-harness-coverage-gaps.md § #234 — docs/usage.md is the canonical wiki source per CLAUDE.md release-process step 15; broken examples ship to the wiki' \
+            contract    'features/225-test-harness-coverage-gaps.md section #234 - docs/usage.md is the canonical wiki source per CLAUDE.md release-process step 15; broken examples ship to the wiki' \
             detail      "command: $LTL $LTL_INJECT $ltl_args ; stderr: $(head -3 "$stderr_file" 2>/dev/null | tr '\n' ' ')"
         return
     fi
@@ -215,9 +215,9 @@ run_doc_example() {
     if [[ ! -s "$stdout_file" ]]; then
         emit_failure \
             label       "doc example produced empty stdout" \
-            asserts     'Successful example runs produce non-empty output. An empty stdout with exit 0 indicates the example silently no-ops (matched 0 lines, filtered everything out) — the example is misleading even if technically functional.' \
+            asserts     'Successful example runs produce non-empty output. An empty stdout with exit 0 indicates the example silently no-ops (matched 0 lines, filtered everything out) - the example is misleading even if technically functional.' \
             produced_by 'docs/usage.md (example) + ltl output writer' \
-            contract    'features/225-test-harness-coverage-gaps.md § #234 — examples must demonstrate something, not just exit cleanly' \
+            contract    'features/225-test-harness-coverage-gaps.md section #234 - examples must demonstrate something, not just exit cleanly' \
             detail      "command: $LTL $LTL_INJECT $ltl_args"
         return
     fi

--- a/tests/validate-duration-display.sh
+++ b/tests/validate-duration-display.sh
@@ -159,22 +159,22 @@ run_scenario() {
         command     "$PERL '$CHECKER' --render '$render' --resolved-unit '$unit' --check unit" \
         label       "every duration cell carries a unit ($unit source) on both surfaces" \
         asserts     'Every populated duration cell in the summary table (Min/P50/P99.9) and the timeline (P50/P95/P99/P999) renders as <number><unit>; no value prints bare. This is the invariant Bug 2 violated, where small magnitudes (e.g. 58, 166, 1) printed with no unit.' \
-        produced_by 'format_duration() in ltl — the single helper both surfaces route through; always passes through format_time so a unit is always present (no length>=4 bare-number bypass).' \
-        contract    'Issue #292 + tests/HARNESS-DESIGN.md § Render-invariant harnesses. format_duration() is the locked rendering entry point for duration cells.'
+        produced_by 'format_duration() in ltl - the single helper both surfaces route through; always passes through format_time so a unit is always present (no length>=4 bare-number bypass).' \
+        contract    'Issue #292 + tests/HARNESS-DESIGN.md section Render-invariant harnesses. format_duration() is the locked rendering entry point for duration cells.'
 
     assert_command \
         command     "$PERL '$CHECKER' --render '$render' --resolved-unit '$unit' --check zero" \
         label       "zero renders as 0$unit (resolved unit), never bare or auto-scaled" \
         asserts     'A zero duration renders in the resolved source unit (0ms for a ms source), never bare 0 and never auto-scaled down to 0us. format_time would scale 0 to the smallest unit; format_duration special-cases zero to the resolved unit.' \
-        produced_by 'format_duration() in ltl — the `return "0$unit" if $value == 0` zero special-case.' \
-        contract    'Issue #292 + tests/HARNESS-DESIGN.md § Render-invariant harnesses.'
+        produced_by 'format_duration() in ltl - the `return "0$unit" if $value == 0` zero special-case.' \
+        contract    'Issue #292 + tests/HARNESS-DESIGN.md section Render-invariant harnesses.'
 
     assert_command \
         command     "$PERL '$CHECKER' --render '$render' --resolved-unit '$unit' --check precision" \
         label       "<=1 decimal everywhere; 0 decimals when displayed in the source unit ($unit)" \
-        asserts     'Duration cells follow the display precision rule: (a) at most one fractional digit on any cell (ltls one-decimal display convention); (b) zero fractional digits when a cell is displayed in the source resolution unit, since one decimal there fabricates sub-unit precision the input never had (a ms source shows 58ms not 58.2ms — Bug 1). A value that auto-scales to a coarser unit (ms source -> 1.2s; us source -> 47.2ms) legitimately keeps its single decimal. Applies to duration cells only; CV and other columns have their own formatting regime and are not extracted.' \
-        produced_by 'format_duration() in ltl — rounds the ms-valued statistic to %duration_display_decimals{resolved-unit} before format_time auto-scales and applies its single-decimal render.' \
-        contract    'Issue #292 + tests/HARNESS-DESIGN.md § Render-invariant harnesses. The precision rule is a function of displayed-unit vs resolved-unit (read from -V duration_unit_resolved).'
+        asserts     'Duration cells follow the display precision rule: (a) at most one fractional digit on any cell (ltls one-decimal display convention); (b) zero fractional digits when a cell is displayed in the source resolution unit, since one decimal there fabricates sub-unit precision the input never had (a ms source shows 58ms not 58.2ms - Bug 1). A value that auto-scales to a coarser unit (ms source -> 1.2s; us source -> 47.2ms) legitimately keeps its single decimal. Applies to duration cells only; CV and other columns have their own formatting regime and are not extracted.' \
+        produced_by 'format_duration() in ltl - rounds the ms-valued statistic to %duration_display_decimals{resolved-unit} before format_time auto-scales and applies its single-decimal render.' \
+        contract    'Issue #292 + tests/HARNESS-DESIGN.md section Render-invariant harnesses. The precision rule is a function of displayed-unit vs resolved-unit (read from -V duration_unit_resolved).'
 }
 
 echo "Validating duration-statistic display invariants (Issue #292)"

--- a/tests/validate-explain.sh
+++ b/tests/validate-explain.sh
@@ -764,7 +764,7 @@ scenario_table_border_alignment() {
         else
             echo "  FAIL  $current_scenario"
             echo "$probe_result" | tail -n +2
-            echo "        asserts:     Top border (┌┬┐) and bottom border (└┴┘) column positions must match the column positions of verticals (│) on body rows"
+            echo "        asserts:     Top border and bottom border column positions must match the vertical-divider positions on body rows"
             echo "        produced_by: render_table() in ltl + visible_length() correctly stripping non-printing decorations"
             echo "        contract:    Issue #261 phase 2: visible_length must strip ANSI codes AND backspace overstrike so cell padding aligns with border glyphs"
             fail=$((fail + 1))
@@ -1026,7 +1026,7 @@ scenario_data_model_aware_prose() {
         pattern     'bin counter path maintains a running min sidecar' \
         asserts     "--explain min compute section describes the bin-path sidecar source post-#287; previously said 'first element of the sorted duration array' which is raw-only language" \
         produced_by '$explain_min_compute in ltl' \
-        contract    'features/287-message-stats-bin-counter-data-model.md § R3.2 — derivation table names the sidecar source for min under -mdm bin'
+        contract    'features/287-message-stats-bin-counter-data-model.md section R3.2 - derivation table names the sidecar source for min under -mdm bin'
 
     current_scenario="prose:max-mentions-bin-sidecar"
     echo "[$current_scenario]"
@@ -1036,7 +1036,7 @@ scenario_data_model_aware_prose() {
         pattern     'bin counter path maintains a running max sidecar' \
         asserts     "--explain max compute section describes the bin-path sidecar source post-#287" \
         produced_by '$explain_max_compute in ltl' \
-        contract    'features/287-message-stats-bin-counter-data-model.md § R3.2'
+        contract    'features/287-message-stats-bin-counter-data-model.md section R3.2'
 
     # --- iqr: data-model dependency must be stated ---
     current_scenario="prose:iqr-mentions-both-models"
@@ -1047,7 +1047,7 @@ scenario_data_model_aware_prose() {
         pattern     'bin-width interpolation' \
         asserts     "--explain iqr describes the data-model dependency of its precision; bin-width interpolation language identifies the bin-counter path" \
         produced_by '$explain_iqr_compute in ltl' \
-        contract    'features/272-percentile-algorithm-industry-grounding.md — both algorithms must be discoverable from --explain.'
+        contract    'features/272-percentile-algorithm-industry-grounding.md - both algorithms must be discoverable from --explain.'
 
     # --- percentiles: both algorithms named + surface defaults stated + -ep absent ---
     current_scenario="prose:percentiles-names-both-algorithms"
@@ -1058,19 +1058,19 @@ scenario_data_model_aware_prose() {
         pattern     'exponential interpolation within the bucket' \
         asserts     "--explain percentiles names the bin-counter algorithm by its locked term per #272 + #187 Decision 1" \
         produced_by '$explain_percentiles_compute in ltl' \
-        contract    'features/272-percentile-algorithm-industry-grounding.md § Locked decisions — algorithm-name text is the user-facing identifier the harness oracle dispatches on (#280); pinning here prevents drift.'
+        contract    'features/272-percentile-algorithm-industry-grounding.md section Locked decisions - algorithm-name text is the user-facing identifier the harness oracle dispatches on (#280); pinning here prevents drift.'
 
     assert_line "$out" \
         pattern     'nearest-rank' \
         asserts     "--explain percentiles names the raw-data-model algorithm by its locked term (#272)" \
         produced_by '$explain_percentiles_compute in ltl' \
-        contract    'features/272-percentile-algorithm-industry-grounding.md § Locked decisions.'
+        contract    'features/272-percentile-algorithm-industry-grounding.md section Locked decisions.'
 
     assert_line "$out" \
         pattern     'message-stats|per-message-key' \
         asserts     "--explain percentiles names the per-message-key surface to disambiguate which surface uses which default" \
         produced_by '$explain_percentiles_compute in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R12 — surface naming locked at Decision 8 consumer strings'
+        contract    'features/187-histogram-bin-counter-percentiles.md section R12 - surface naming locked at Decision 8 consumer strings'
 
     # Patterns leading with '-' would be parsed as grep flags; wrap in a
     # character class so the first char is data, not an option prefix.
@@ -1078,13 +1078,13 @@ scenario_data_model_aware_prose() {
         pattern     'ltl [-]ep ' \
         asserts     "--explain percentiles examples block does not reference -ep; user-facing examples guide users to the data-model selectors (-dm/-hgdm/-hmdm/-mdm)" \
         produced_by '%explain_topics{percentiles} example block in ltl' \
-        contract    'Issue #266 — the data-model selectors are the locked opt-out surface for the histogram and heatmap percentile algorithms.'
+        contract    'Issue #266 - the data-model selectors are the locked opt-out surface for the histogram and heatmap percentile algorithms.'
 
     assert_line "$out" \
         pattern     '[-]mdm bin' \
         asserts     "--explain percentiles examples block includes -mdm bin to demonstrate the per-message-key bin-counter opt-in path shipped by #287" \
         produced_by '%explain_topics{percentiles} example block in ltl' \
-        contract    'features/287-message-stats-bin-counter-data-model.md — opt-in flag must be discoverable from --explain examples.'
+        contract    'features/287-message-stats-bin-counter-data-model.md - opt-in flag must be discoverable from --explain examples.'
 
     # --- skewness and kurtosis: Welford-Pébay must be named under the bin path ---
     current_scenario="prose:skewness-mentions-welford-pebay"
@@ -1095,7 +1095,7 @@ scenario_data_model_aware_prose() {
         pattern     'Welford-Pébay' \
         asserts     "--explain skewness names the online central-moment accumulator family used under the bin path post-#287" \
         produced_by '$explain_skewness_compute in ltl' \
-        contract    'features/287-message-stats-bin-counter-data-model.md § Algorithm appendix — Welford-Pébay (Pébay 2008) is the locked accumulator family.'
+        contract    'features/287-message-stats-bin-counter-data-model.md section Algorithm appendix - Welford-Pébay (Pébay 2008) is the locked accumulator family.'
 
     current_scenario="prose:kurtosis-mentions-welford-pebay"
     echo "[$current_scenario]"
@@ -1105,7 +1105,7 @@ scenario_data_model_aware_prose() {
         pattern     'Welford-Pébay' \
         asserts     "--explain kurtosis names the online central-moment accumulator family used under the bin path post-#287" \
         produced_by '$explain_kurtosis_compute in ltl' \
-        contract    'features/287-message-stats-bin-counter-data-model.md § Algorithm appendix.'
+        contract    'features/287-message-stats-bin-counter-data-model.md section Algorithm appendix.'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -122,13 +122,13 @@ scenario_tomcat9_ms() {
         pattern     '^  format: tomcat_access_with_duration$' \
         asserts     'Tomcat 9 access log with %D millisecond duration binds to slug `tomcat_access_with_duration`. Detection regex: ltl:4907 (match_type 3).' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    '%match_type_to_slug in ltl GLOBALS — slug names are locked; renames are breaking under HARNESS-DESIGN.md § Stability contract'
+        contract    '%match_type_to_slug in ltl GLOBALS - slug names are locked; renames are breaking under HARNESS-DESIGN.md section Stability contract'
 
     assert_line "$out" \
         pattern     '^  match_type: 3$' \
         asserts     'Tomcat 9 access log binds to internal match_type 3' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 — match_type integers are an implementation detail surfaced for diagnostic value; the slug is the user-facing contract'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - match_type integers are an implementation detail surfaced for diagnostic value; the slug is the user-facing contract'
 
     assert_line "$out" \
         pattern     '^  matched_lines: 5000$' \
@@ -149,15 +149,15 @@ scenario_apache_httpd_us() {
 
     assert_line "$out" \
         pattern     '^  format: tomcat_access_with_duration$' \
-        asserts     'Apache HTTP Server 2.x access log binds to slug `tomcat_access_with_duration` — same regex as Tomcat 9, currently misclassified pending format-registry rewrite (#23)' \
+        asserts     'Apache HTTP Server 2.x access log binds to slug `tomcat_access_with_duration` - same regex as Tomcat 9, currently misclassified pending format-registry rewrite (#23)' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 + ltl GLOBALS comment on Apache misclassification — when #23 splits the formats, this scenario must be updated to expect the new Apache-specific slug'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 + ltl GLOBALS comment on Apache misclassification - when #23 splits the formats, this scenario must be updated to expect the new Apache-specific slug'
 
     assert_line "$out" \
         pattern     '^duration_unit_override: us$' \
         asserts     'When `-du us` is given, the format-detection section reports the override value' \
         produced_by 'emit_format_detection_verbose() in ltl (run-level duration_unit_override field)' \
-        contract    '%match_type_to_slug and emit_format_detection_verbose() in ltl — duration_unit_override is locked field reporting the user-supplied -du value'
+        contract    '%match_type_to_slug and emit_format_detection_verbose() in ltl - duration_unit_override is locked field reporting the user-supplied -du value'
 }
 
 scenario_codebeamer() {
@@ -172,17 +172,17 @@ scenario_codebeamer() {
         pattern     '^  format: tomcat_codebeamer$' \
         asserts     'Codebeamer access log with `[Nms] [Ns]` duration fields binds to slug `tomcat_codebeamer`. Detection regex: ltl:4892 (match_type 12).' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    '%match_type_to_slug in ltl GLOBALS — slug names are locked; renames are breaking under HARNESS-DESIGN.md § Stability contract'
+        contract    '%match_type_to_slug in ltl GLOBALS - slug names are locked; renames are breaking under HARNESS-DESIGN.md section Stability contract'
 
     assert_line "$out" \
         pattern     '^  match_type: 12$' \
         asserts     'Codebeamer log binds to internal match_type 12, must precede match_type 3 in cascade order' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 — codebeamer regex must remain before tomcat 9 regex in the cascade so it wins for codebeamer-formatted lines'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - codebeamer regex must remain before tomcat 9 regex in the cascade so it wins for codebeamer-formatted lines'
 
     assert_line "$out" \
         pattern     '^  matched_lines: 741$' \
-        asserts     'Codebeamer fixture (741 lines) parses every line via match_type 12 — no fallthrough to match_type 3' \
+        asserts     'Codebeamer fixture (741 lines) parses every line via match_type 12 - no fallthrough to match_type 3' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file matched_lines field)' \
         contract    'A regression in the codebeamer regex would silently fall back to match_type 3; this exact count guards against that'
 }
@@ -199,13 +199,13 @@ scenario_thingworx_standard() {
         pattern     '^  format: thingworx_standard$' \
         asserts     'ThingWorx ApplicationLog binds to slug `thingworx_standard`. Detection regex: ltl:4792 (match_type 1).' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    '%match_type_to_slug in ltl GLOBALS — slug names are locked'
+        contract    '%match_type_to_slug in ltl GLOBALS - slug names are locked'
 
     assert_line "$out" \
         pattern     '^  match_type: 1$' \
         asserts     'ThingWorx standard log binds to internal match_type 1' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 — match_type 1 covers both full ThingWorx and the Logback-style fallback at ltl:4655'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - match_type 1 covers both full ThingWorx and the Logback-style fallback at ltl:4655'
 }
 
 scenario_thingworx_with_metrics() {
@@ -218,15 +218,15 @@ scenario_thingworx_with_metrics() {
 
     assert_line "$out" \
         pattern     '^  format: thingworx_standard$' \
-        asserts     'ThingWorx ScriptLog with durationMS=/bytes= fields also binds to `thingworx_standard` — the duration/bytes capture happens within match_type 1, not as a separate slug' \
+        asserts     'ThingWorx ScriptLog with durationMS=/bytes= fields also binds to `thingworx_standard` - the duration/bytes capture happens within match_type 1, not as a separate slug' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    '%match_type_to_slug in ltl GLOBALS — ThingWorx logs with or without metrics share the same slug; metric presence is signaled via is_access_log=yes'
+        contract    '%match_type_to_slug in ltl GLOBALS - ThingWorx logs with or without metrics share the same slug; metric presence is signaled via is_access_log=yes'
 
     assert_line "$out" \
         pattern     '^  is_access_log: yes$' \
         asserts     'A ThingWorx log with durationMS= or bytes= flips is_access_log to yes per ltl:4799-4802' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file is_access_log field)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 — is_access_log distinguishes ThingWorx logs that have parseable latency/bytes from ones that do not'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - is_access_log distinguishes ThingWorx logs that have parseable latency/bytes from ones that do not'
 }
 
 scenario_tw_edge_c_sdk() {
@@ -241,13 +241,13 @@ scenario_tw_edge_c_sdk() {
         pattern     '^  format: tw_edge_c_sdk$' \
         asserts     'ThingWorx Edge C SDK log binds to slug `tw_edge_c_sdk`. Detection regex: ltl:4884 (match_type 11). Format: `LEVEL ts file.cpp:NN message`.' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    '%match_type_to_slug in ltl GLOBALS — slug names are locked'
+        contract    '%match_type_to_slug in ltl GLOBALS - slug names are locked'
 
     assert_line "$out" \
         pattern     '^  match_type: 11$' \
         asserts     'Edge C SDK log binds to internal match_type 11' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 — match_type 11'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - match_type 11'
 }
 
 scenario_csv_with_udm() {
@@ -264,13 +264,13 @@ scenario_csv_with_udm() {
         pattern     '^  format: csv$' \
         asserts     'CSV file binds to slug `csv` when -udm is supplied. Detection: detect_and_parse_csv_header() invoked at ltl:4744+4935 (match_type 13).' \
         produced_by 'emit_format_detection_verbose() in ltl' \
-        contract    '%match_type_to_slug in ltl GLOBALS — CSV detection requires explicit -udm config; bare ltl on a CSV file gives no matches and is intentional'
+        contract    '%match_type_to_slug in ltl GLOBALS - CSV detection requires explicit -udm config; bare ltl on a CSV file gives no matches and is intentional'
 
     assert_line "$out" \
         pattern     '^  match_type: 13$' \
         asserts     'CSV path uses internal match_type 13' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #228 — match_type 13 is reserved for the CSV path'
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - match_type 13 is reserved for the CSV path'
 }
 
 # ---------- Run -----------------------------------------------------------

--- a/tests/validate-heatmap-palette.sh
+++ b/tests/validate-heatmap-palette.sh
@@ -111,12 +111,12 @@ assert_header_present() {
         pattern     '^=== heatmap-palette ===$' \
         asserts     'The heatmap-palette section is emitted whenever -V heatmap-palette is requested, regardless of whether heatmap mode is active' \
         produced_by 'emit_heatmap_palette_verbose() in ltl' \
-        contract    'Issue #250 + tests/HARNESS-DESIGN.md § Reserved section names — section name is stability-contracted; renames are breaking'
+        contract    'Issue #250 + tests/HARNESS-DESIGN.md section Reserved section names - section name is stability-contracted; renames are breaking'
     assert_line "$outfile" \
         pattern     '^=== END heatmap-palette ===$' \
         asserts     'The heatmap-palette section closes with an explicit END marker so harnesses can use sed-range extraction unambiguously' \
         produced_by 'emit_heatmap_palette_verbose() in ltl' \
-        contract    'tests/HARNESS-DESIGN.md § Delimiter contract — END markers are required'
+        contract    'tests/HARNESS-DESIGN.md section Delimiter contract - END markers are required'
 }
 
 # ---------------------------------------------------------------------------
@@ -134,19 +134,19 @@ scenario_no_heatmap() {
         pattern     '^heatmap_active: no$' \
         asserts     'When -hm is not on the command line, heatmap_active reports `no` and the metric/color/gradient fields are placeholders' \
         produced_by 'emit_heatmap_palette_verbose() in ltl (inactive branch)' \
-        contract    'Issue #250 — section reports inactive state without crashing when heatmap is off'
+        contract    'Issue #250 - section reports inactive state without crashing when heatmap is off'
 
     assert_line "$out" \
         pattern     '^metric: n/a$' \
         asserts     'metric reports `n/a` when no heatmap metric is selected' \
         produced_by 'emit_heatmap_palette_verbose() in ltl (inactive branch)' \
-        contract    'Issue #250 — locked placeholder for absent metric'
+        contract    'Issue #250 - locked placeholder for absent metric'
 
     assert_line "$out" \
         pattern     '^gradient_active: n/a$' \
-        asserts     'gradient_active reports `n/a` when no heatmap is rendering — neither dark nor light branch is selected' \
+        asserts     'gradient_active reports `n/a` when no heatmap is rendering - neither dark nor light branch is selected' \
         produced_by 'emit_heatmap_palette_verbose() in ltl (inactive branch)' \
-        contract    'Issue #250 — locked placeholder for absent gradient selection'
+        contract    'Issue #250 - locked placeholder for absent gradient selection'
 }
 
 # ---------------------------------------------------------------------------
@@ -181,49 +181,49 @@ scenario_palette() {
         pattern     "^heatmap_active: yes\$" \
         asserts     "When -hm is on the command line, heatmap_active reports \`yes\`" \
         produced_by 'emit_heatmap_palette_verbose() in ltl (active branch)' \
-        contract    'Issue #250 — locked field value when heatmap mode is enabled'
+        contract    'Issue #250 - locked field value when heatmap mode is enabled'
 
     assert_line "$out" \
         pattern     "^metric: ${exp_metric}\$" \
         asserts     "metric reports the heatmap metric selected via -hm (${exp_metric})" \
         produced_by 'emit_heatmap_palette_verbose() in ltl (resolves $heatmap_metric)' \
-        contract    'Issue #250 — metric field tracks $heatmap_metric verbatim'
+        contract    'Issue #250 - metric field tracks $heatmap_metric verbatim'
 
     assert_line "$out" \
         pattern     "^color_name: ${exp_color}\$" \
         asserts     "color_name reports the column color (${exp_color}) bound to the heatmap metric via %heatmap_metric_map and resolved through %column_color_lookup" \
         produced_by 'emit_heatmap_palette_verbose() in ltl (resolves $heatmap_metric_map{$heatmap_metric}{color})' \
-        contract    'Issue #250 — metric-to-color binding is the same resolution print_heatmap_row() performs at ltl:7830-7831'
+        contract    'Issue #250 - metric-to-color binding is the same resolution print_heatmap_row() performs at ltl:7830-7831'
 
     assert_line "$out" \
         pattern     "^light_bg: ${exp_lbg}\$" \
         asserts     "light_bg reports the resolved value of \$heatmap_light_bg (${exp_lbg}) that print_heatmap_row() will branch on" \
         produced_by 'emit_heatmap_palette_verbose() in ltl' \
-        contract    'Issue #250 — light_bg field equals the runtime value read by print_heatmap_row()'
+        contract    'Issue #250 - light_bg field equals the runtime value read by print_heatmap_row()'
 
     assert_line "$out" \
         pattern     "^light_bg_source: ${exp_source}\$" \
         asserts     "light_bg_source reports the provenance of the light_bg decision (${exp_source}); precedence: -dbg > -lbg > auto-detect > default" \
-        produced_by 'adapt_to_command_line_options() in ltl — set by -lbg callback, -dbg reconciliation block, and auto-detect block' \
-        contract    'Issue #250 — \$heatmap_light_bg_source is the canonical provenance signal; the four enumerated values are the only valid emissions'
+        produced_by 'adapt_to_command_line_options() in ltl - set by -lbg callback, -dbg reconciliation block, and auto-detect block' \
+        contract    'Issue #250 - \$heatmap_light_bg_source is the canonical provenance signal; the four enumerated values are the only valid emissions'
 
     assert_line "$out" \
         pattern     "^gradient_dark: ${exp_dark}\$" \
         asserts     "gradient_dark reports the dark-palette 256-color array for the active metric's color (${exp_color}); this is the literal array @column_colors carries in ltl GLOBALS" \
         produced_by 'emit_heatmap_palette_verbose() in ltl (joins @{$entry->{gradient}} with commas)' \
-        contract    'Issue #250 — gradient arrays in @column_colors are part of the heatmap-palette contract surface; changes require updating this harness in the same commit'
+        contract    'Issue #250 - gradient arrays in @column_colors are part of the heatmap-palette contract surface; changes require updating this harness in the same commit'
 
     assert_line "$out" \
         pattern     "^gradient_light: ${exp_light}\$" \
         asserts     "gradient_light reports the light-palette 256-color array for the active metric's color (${exp_color}); this is the literal array @column_colors carries in ltl GLOBALS" \
         produced_by 'emit_heatmap_palette_verbose() in ltl (joins @{$entry->{gradient_light}} with commas)' \
-        contract    'Issue #250 — gradient arrays in @column_colors are part of the heatmap-palette contract surface; changes require updating this harness in the same commit'
+        contract    'Issue #250 - gradient arrays in @column_colors are part of the heatmap-palette contract surface; changes require updating this harness in the same commit'
 
     assert_line "$out" \
         pattern     "^gradient_active: ${exp_active}\$" \
         asserts     "gradient_active reports which branch (${exp_active}) print_heatmap_row() will pick when rendering; load-bearing line for visual palette coverage" \
         produced_by 'emit_heatmap_palette_verbose() in ltl (\$heatmap_light_bg ? "light" : "dark")' \
-        contract    'Issue #250 — gradient_active is the contract for which palette renders'
+        contract    'Issue #250 - gradient_active is the contract for which palette renders'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/validate-help-content.sh
+++ b/tests/validate-help-content.sh
@@ -232,7 +232,7 @@ perl -ne '
 
 GETOPTS_COUNT=$(wc -l < "$GETOPTS_TSV" | tr -d ' ')
 if [[ "$GETOPTS_COUNT" -lt 50 ]]; then
-    echo "ERROR: parsed only $GETOPTS_COUNT GetOptions entries — parser likely broken"
+    echo "ERROR: parsed only $GETOPTS_COUNT GetOptions entries - parser likely broken"
     head "$GETOPTS_TSV"
     exit 1
 fi
@@ -292,8 +292,8 @@ scenario_A_help_contains_all_visible_longs() {
     assert_all_present "$VISIBLE_LONGS_FILE" "$HELP_LONGS_FILE" \
         label       'every non-hidden GetOptions long-form appears in --help output' \
         asserts     'For every option declared in GetOptions that is NOT annotated `# hidden`, print_help() must document the option by its long name. Drift here means a user-visible flag is documented in code but missing from --help.' \
-        produced_by 'print_help() in ltl — must add a $opt->("-short, --long ...", "description") line for every non-hidden GetOptions entry' \
-        contract    'features/232-help-coverage.md § 3 + § 8 — hidden flags are annotated `# hidden` in GetOptions; everything else must appear in --help'
+        produced_by 'print_help() in ltl - must add a $opt->("-short, --long ...", "description") line for every non-hidden GetOptions entry' \
+        contract    'features/232-help-coverage.md section 3 + section 8 - hidden flags are annotated `# hidden` in GetOptions; everything else must appear in --help'
 }
 
 scenario_B_usage_contains_all_visible_longs() {
@@ -303,8 +303,8 @@ scenario_B_usage_contains_all_visible_longs() {
     assert_all_present "$VISIBLE_LONGS_FILE" "$USAGE_LONGS_FILE" \
         label       'every non-hidden GetOptions long-form appears in docs/usage.md' \
         asserts     'docs/usage.md is the canonical wiki source per CLAUDE.md (overwritten on each release); every non-hidden flag must appear there. The -hgb doc bug found during research (declared, in print_help, missing from usage.md) is exactly this class.' \
-        produced_by 'docs/usage.md option tables — manually maintained, must be updated alongside any non-hidden flag addition' \
-        contract    'CLAUDE.md release-process step 15 (Sync Wiki) + features/232-help-coverage.md § 3 — usage.md is part of the user-facing contract'
+        produced_by 'docs/usage.md option tables - manually maintained, must be updated alongside any non-hidden flag addition' \
+        contract    'CLAUDE.md release-process step 15 (Sync Wiki) + features/232-help-coverage.md section 3 - usage.md is part of the user-facing contract'
 }
 
 scenario_C_help_short_forms_match_getopts() {
@@ -314,8 +314,8 @@ scenario_C_help_short_forms_match_getopts() {
     assert_all_present "$VISIBLE_SHORTS_FILE" "$HELP_SHORTS_FILE" \
         label       'every short form declared in GetOptions appears in --help output' \
         asserts     'When a flag has both -short and --long forms in GetOptions, print_help() must document both. A long form documented without its short form (or vice versa) is content drift.' \
-        produced_by 'print_help() $opt->() call site — first arg should be "-short, --long" not just "--long"' \
-        contract    'features/232-help-coverage.md § 8 — every GetOptions entry with a short form must surface that short form in help'
+        produced_by 'print_help() $opt->() call site - first arg should be "-short, --long" not just "--long"' \
+        contract    'features/232-help-coverage.md section 8 - every GetOptions entry with a short form must surface that short form in help'
 }
 
 scenario_D_dash_v_matches_version_number() {
@@ -332,7 +332,7 @@ scenario_D_dash_v_matches_version_number() {
         echo "        label:       ltl -v exited non-zero ($ec)"
         echo "        asserts:     ltl -v exits 0 and emits the version string"
         echo "        produced_by: print_version() in ltl"
-        echo "        contract:    features/232-help-coverage.md § 4 — -v is one of three in-binary version-emission sites that must agree with \$version_number"
+        echo "        contract:    features/232-help-coverage.md section 4 - -v is one of three in-binary version-emission sites that must agree with \$version_number"
         echo "        (captured in $vout)"
         fail=$((fail + 1))
         failures+=("$current_scenario :: ltl -v non-zero exit")
@@ -343,7 +343,7 @@ scenario_D_dash_v_matches_version_number() {
         pattern     "^Version: ${VERSION_NUMBER}$" \
         asserts     "The -v flag emits 'Version: ${VERSION_NUMBER}' matching the \$version_number literal in ltl source. This is one of three in-binary emission sites; all must agree." \
         produced_by 'print_version() in ltl' \
-        contract    'features/232-help-coverage.md § 4 — version string emission sites are stability-contracted to agree with $version_number'
+        contract    'features/232-help-coverage.md section 4 - version string emission sites are stability-contracted to agree with $version_number'
 }
 
 scenario_E_benchmark_data_section_matches_version_number() {
@@ -360,7 +360,7 @@ scenario_E_benchmark_data_section_matches_version_number() {
         echo "        label:       ltl -V benchmark-data exited non-zero ($ec)"
         echo "        asserts:     ltl -V benchmark-data <log> exits 0 and emits the benchmark-data section"
         echo "        produced_by: print_verbose_output() in ltl (benchmark-data section dispatch)"
-        echo "        contract:    Issue #226 framework + tests/HARNESS-DESIGN.md § Reserved section names — benchmark-data is a reserved section"
+        echo "        contract:    Issue #226 framework + tests/HARNESS-DESIGN.md section Reserved section names - benchmark-data is a reserved section"
         echo "        (captured in $bout)"
         fail=$((fail + 1))
         failures+=("$current_scenario :: ltl -V benchmark-data non-zero exit")
@@ -372,14 +372,14 @@ scenario_E_benchmark_data_section_matches_version_number() {
         pattern     '^=== benchmark-data ===$' \
         asserts     'The benchmark-data section header is emitted when requested via -V benchmark-data' \
         produced_by 'print_verbose_output() in ltl (benchmark-data emitter)' \
-        contract    'tests/HARNESS-DESIGN.md § Delimiter contract + Reserved section names — section header is stability-contracted'
+        contract    'tests/HARNESS-DESIGN.md section Delimiter contract + Reserved section names - section header is stability-contracted'
 
     # End-marker presence check before extracting body (HARNESS-DESIGN.md Trap 3).
     assert_line "$bout" \
         pattern     '^=== END benchmark-data ===$' \
         asserts     'The benchmark-data section is closed with the required end marker per the delimiter contract' \
         produced_by 'print_verbose_output() in ltl (benchmark-data emitter)' \
-        contract    'tests/HARNESS-DESIGN.md § Delimiter contract — end markers are required'
+        contract    'tests/HARNESS-DESIGN.md section Delimiter contract - end markers are required'
 
     # Extract the section body and assert the version row matches.
     local body
@@ -389,7 +389,7 @@ scenario_E_benchmark_data_section_matches_version_number() {
         echo "        label:       benchmark-data body extraction returned empty"
         echo "        asserts:     The body between '=== benchmark-data ===' and '=== END benchmark-data ===' must contain the version TSV row"
         echo "        produced_by: print_verbose_output() in ltl (benchmark-data TSV row writer)"
-        echo "        contract:    features/232-help-coverage.md § 4 + tests/HARNESS-DESIGN.md § Stability contract — version row format is locked"
+        echo "        contract:    features/232-help-coverage.md section 4 + tests/HARNESS-DESIGN.md section Stability contract - version row format is locked"
         echo "        (captured in $bout)"
         fail=$((fail + 1))
         failures+=("$current_scenario :: benchmark-data body empty")
@@ -402,7 +402,7 @@ scenario_E_benchmark_data_section_matches_version_number() {
         pattern     "^version	${VERSION_NUMBER}$" \
         asserts     "The benchmark-data section's 'version' TSV row matches the \$version_number literal. This is the second of three in-binary emission sites; all must agree." \
         produced_by 'print_verbose_output() in ltl (benchmark-data TSV row writer)' \
-        contract    'features/232-help-coverage.md § 4 + tests/HARNESS-DESIGN.md § Stability contract — version row format is locked'
+        contract    'features/232-help-coverage.md section 4 + tests/HARNESS-DESIGN.md section Stability contract - version row format is locked'
 }
 
 scenario_F_description_quality_warnings() {
@@ -449,7 +449,7 @@ scenario_F_description_quality_warnings() {
                     label       "placeholder token in help description: $flags" \
                     asserts     'Help descriptions must not contain placeholder tokens (TODO/FIXME/XXX/undocumented/TBD/tk/???); these indicate unfinished documentation.' \
                     produced_by 'print_help() $opt->() call site for this flag' \
-                    contract    'features/232-help-coverage.md § 5 heuristic 1 — placeholder-token check is locked as a hard signal of unfinished work' \
+                    contract    'features/232-help-coverage.md section 5 heuristic 1 - placeholder-token check is locked as a hard signal of unfinished work' \
                     detail      "flags='$flags' desc='$desc'"
                 ;;
             H2)
@@ -457,7 +457,7 @@ scenario_F_description_quality_warnings() {
                     label       "single-word description: $flags" \
                     asserts     'Help descriptions should be at least two words; single-word descriptions are usually tautological or truncated.' \
                     produced_by 'print_help() $opt->() call site for this flag' \
-                    contract    'features/232-help-coverage.md § 5 heuristic 2 — single-word descriptions are soft signal of drift' \
+                    contract    'features/232-help-coverage.md section 5 heuristic 2 - single-word descriptions are soft signal of drift' \
                     detail      "flags='$flags' desc='$desc'"
                 ;;
         esac

--- a/tests/validate-help-layout.sh
+++ b/tests/validate-help-layout.sh
@@ -119,7 +119,7 @@ emit_fail() {
 # ---------------------------------------------------------------------------
 echo "[sanity]"
 SANITY_ASSERTS='The three help-layout column constants ($help_opt_col, $help_short_col, $help_desc_col) extracted from ltl fall within plausible bounds, and $help_desc_col exceeds the long-form column so descriptions cannot overlap the long-form option text'
-SANITY_PRODUCED_BY='print_help() in ltl — module-scope my-declarations of $help_opt_col, $help_short_col, $help_desc_col'
+SANITY_PRODUCED_BY='print_help() in ltl - module-scope my-declarations of $help_opt_col, $help_short_col, $help_desc_col'
 SANITY_CONTRACT='Issue #261 hoisted these constants to module scope so --help, --help statistics, and --explain share one source of truth; bounds here exist to catch typo-class regressions where one is reset to an obviously-wrong value'
 
 if [[ "$DESC_COL" -lt 30 || "$DESC_COL" -gt 80 ]]; then
@@ -290,22 +290,22 @@ elif [[ $rc -eq 2 ]]; then
     emit_fail \
         label       "option-row alignment" \
         asserts     "Every option-row description begins at column \$help_desc_col+1 ($EXPECTED_DESC_COL); a row whose description starts to the right means its option text exceeded the column budget and overflowed silently" \
-        produced_by 'print_help() in ltl — the option-text rendering uses $help_desc_col as the padding target for the description column' \
+        produced_by 'print_help() in ltl - the option-text rendering uses $help_desc_col as the padding target for the description column' \
         contract    'Issue #189-3 root cause: long-form options exceeding the option-text column budget shipped silently because there was no test asserting the column was honored. This assertion is what makes the failure visible.' \
-        detail      "Perl inspector exit code 2 — one or more option rows misaligned (per-row diagnostics printed above)"
+        detail      "Perl inspector exit code 2 - one or more option rows misaligned (per-row diagnostics printed above)"
 elif [[ $rc -eq 3 ]]; then
     emit_fail \
         label       "continuation-row alignment" \
         asserts     'Every wrapped-description continuation line begins at the same column as the description start ($help_desc_col+1)' \
-        produced_by 'print_help() in ltl — wrap continuations are emitted with the same leading indent as the description column' \
-        contract    'Issue #189-3 — the same column-budget bug that misaligns option rows also misaligns their wrap continuations; both must be guarded together' \
-        detail      "Perl inspector exit code 3 — one or more continuation rows misaligned (per-row diagnostics printed above)"
+        produced_by 'print_help() in ltl - wrap continuations are emitted with the same leading indent as the description column' \
+        contract    'Issue #189-3 - the same column-budget bug that misaligns option rows also misaligns their wrap continuations; both must be guarded together' \
+        detail      "Perl inspector exit code 3 - one or more continuation rows misaligned (per-row diagnostics printed above)"
 else
     emit_fail \
         label       "option-row alignment (inspector)" \
         asserts     'The Perl inspector must exit 0, 2, or 3; any other exit code means the inspector itself broke and the test is no longer asserting anything' \
         produced_by 'inline Perl inspector at the top of validate-help-layout.sh' \
-        contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — an inspector that cannot run is an unasserted test' \
+        contract    'tests/HARNESS-DESIGN.md section Harnesses must fail on missing anchors - an inspector that cannot run is an unasserted test' \
         detail      "Perl inspector exited with unexpected code $rc"
 fi
 
@@ -361,15 +361,15 @@ elif [[ $rc -eq 2 ]]; then
     emit_fail \
         label       "long-form column alignment" \
         asserts     "Every short+long option row places its long form starting at column \$help_opt_col + \$help_short_col + 1 ($EXPECTED_LONG_COL); a short form whose length pushes the long form rightward produces a ragged left margin even though the description column itself can still be honored" \
-        produced_by 'print_help() in ltl — the short-form rendering pads to $help_short_col before emitting the long form' \
-        contract    "Issue #261 — \$help_short_col was sized to accommodate the longest short form; a regression on either side (short form too long, or \$help_short_col bumped down) breaks left-margin alignment" \
-        detail      "Perl inspector exit code 2 — one or more short+long rows misaligned (per-row diagnostics printed above)"
+        produced_by 'print_help() in ltl - the short-form rendering pads to $help_short_col before emitting the long form' \
+        contract    "Issue #261 - \$help_short_col was sized to accommodate the longest short form; a regression on either side (short form too long, or \$help_short_col bumped down) breaks left-margin alignment" \
+        detail      "Perl inspector exit code 2 - one or more short+long rows misaligned (per-row diagnostics printed above)"
 else
     emit_fail \
         label       "long-form column alignment (inspector)" \
         asserts     'The long-form-column Perl inspector must exit 0 or 2; any other exit code means the inspector itself broke' \
         produced_by 'inline Perl inspector in the [long-form column alignment] block of validate-help-layout.sh' \
-        contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — an inspector that cannot run is an unasserted test' \
+        contract    'tests/HARNESS-DESIGN.md section Harnesses must fail on missing anchors - an inspector that cannot run is an unasserted test' \
         detail      "long-form-column Perl inspector exited with unexpected code $rc"
 fi
 
@@ -389,7 +389,7 @@ assert_pair() {
         emit_fail \
             label       "$short, $long" \
             asserts     "Both the short form ($short) and long form ($long) appear on the same row of --help output, in the canonical 'short, long' order; missing-pair regressions cost the user a discoverable surface (memory: 'short forms required for every CLI option')" \
-            produced_by 'print_help() in ltl — the option-table row that registers this flag emits short+long together' \
+            produced_by 'print_help() in ltl - the option-table row that registers this flag emits short+long together' \
             contract    "MEMORY.md feedback_short_forms_required: every CLI flag in ltl must have both short and long form; 'no short form' decisions are errors that need amending before wiring" \
             detail      "no row matched '^[[:space:]]+${short}, +${long}' in stripped --help output"
     fi

--- a/tests/validate-histogram-bin-counters.sh
+++ b/tests/validate-histogram-bin-counters.sh
@@ -122,7 +122,7 @@ assert_header_present() {
         pattern     '^=== histogram-bin-counters ===$' \
         asserts     'The histogram-bin-counters section is emitted whenever -V histogram-bin-counters is requested, regardless of which downstream features are active' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl' \
-        contract    'Issue #226 framework + features/187-histogram-bin-counter-percentiles.md § Decision 8 — section name is stability-contracted; renames are breaking'
+        contract    'Issue #226 framework + features/187-histogram-bin-counter-percentiles.md section Decision 8 - section name is stability-contracted; renames are breaking'
 }
 
 # ---------------------------------------------------------------------------
@@ -140,13 +140,13 @@ scenario_default() {
         pattern     '^percentile_precision: 5 \(default\)$' \
         asserts     'With no precision flags, percentile_precision reports tier 5 (the default level in the locked tier table) with source annotation `(default)`' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + § Decision 2 — tier 5 is the default level; source annotation form is locked'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 2 - tier 5 is the default level; source annotation form is locked'
 
     assert_line "$out" \
         pattern     '^buckets_per_decade: 53 \(default\)$' \
         asserts     'With no precision flags, buckets_per_decade reports the default 53 (the bpd corresponding to tier 5) with source annotation `(default)`' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + § Decision 2 — tier 5 → bpd 53 is locked'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 2 - tier 5 -> bpd 53 is locked'
 
     rm -f "$out"
 }
@@ -166,13 +166,13 @@ scenario_precision_tier() {
         pattern     '^percentile_precision: 7 \(--percentile-precision 7\)$' \
         asserts     'When --percentile-precision N is given without -pbpd, percentile_precision reports N with source annotation `(--percentile-precision N)`' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; --percentile-precision branch of source annotation)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — source annotation form is locked per branch'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - source annotation form is locked per branch'
 
     assert_line "$out" \
         pattern     '^buckets_per_decade: 115 \(--percentile-precision 7\)$' \
         asserts     'When --percentile-precision 7 resolves through the tier table, buckets_per_decade reports 115 (the bpd for tier 7) with matching source annotation' \
         produced_by 'adapt_to_command_line_options() in ltl (tier table %level_to_bpd) + emit_bin_counter_mode_verbose() (source annotation)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 2 — tier 7 → bpd 115 is locked'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - tier 7 -> bpd 115 is locked'
 
     rm -f "$out"
 }
@@ -192,13 +192,13 @@ scenario_pbpd_non_tier() {
         pattern     '^percentile_precision: n/a \(-pbpd 100\)$' \
         asserts     'When -pbpd resolves to a value with no tier-table match, percentile_precision reports the literal string `n/a` (not an integer) with source annotation reflecting the -pbpd source' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; bpd-without-tier-match branch)' \
-        contract    'features/189-percentile-mode-audit.md § Bucket A § A5 — literal `n/a` rendering for non-tier bpd values is locked'
+        contract    'features/189-percentile-mode-audit.md section Bucket A section A5 - literal `n/a` rendering for non-tier bpd values is locked'
 
     assert_line "$out" \
         pattern     '^buckets_per_decade: 100 \(-pbpd 100\)$' \
         asserts     'When -pbpd N is given, buckets_per_decade reports N with source annotation `(-pbpd N)`' \
         produced_by 'adapt_to_command_line_options() in ltl (-pbpd branch) + emit_bin_counter_mode_verbose() (source annotation)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — source annotation form is locked'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - source annotation form is locked'
 
     rm -f "$out"
 }
@@ -218,13 +218,13 @@ scenario_flag_conflict() {
         pattern     '^percentile_precision: 4 \(--percentile-precision 4; overridden\)$' \
         asserts     'When both -pbpd and --percentile-precision are given, percentile_precision reports the *requested* level from --percentile-precision with `; overridden` suffix indicating -pbpd won' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; conflict branch of $level_source)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — conflict annotation form is locked'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - conflict annotation form is locked'
 
     assert_line "$out" \
         pattern     '^buckets_per_decade: 100 \(-pbpd 100; --percentile-precision 4 overridden\)$' \
         asserts     'When both flags conflict, buckets_per_decade reports the *active* bpd from -pbpd with full conflict annotation showing both flags and which one was overridden' \
         produced_by 'adapt_to_command_line_options() in ltl ($percentile_precision_source assembly)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — full conflict annotation is locked'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - full conflict annotation is locked'
 
     rm -f "$out"
 }
@@ -244,19 +244,19 @@ scenario_pbpd_out_of_range() {
         pattern     'Invalid -pbpd: 9999' \
         asserts     'When -pbpd is outside the locked 4..616 range, ltl emits a warning to stderr naming the invalid value' \
         produced_by 'adapt_to_command_line_options() in ltl (-pbpd range-check branch)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 2 — valid range is locked at 4..616'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - valid range is locked at 4..616'
 
     assert_line "$out" \
         pattern     '^percentile_precision: 5 \(default\)$' \
         asserts     'When -pbpd is out of range, percentile_precision falls back to the default tier 5 (not the invalid value)' \
         produced_by 'adapt_to_command_line_options() in ltl (range-check fallback) + emit_bin_counter_mode_verbose() (source annotation)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 2 — fallback to default is locked behavior'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - fallback to default is locked behavior'
 
     assert_line "$out" \
         pattern     '^buckets_per_decade: 53 \(default\)$' \
         asserts     'When -pbpd is out of range, buckets_per_decade falls back to 53 with source annotation reset to `(default)`' \
         produced_by 'adapt_to_command_line_options() in ltl (range-check fallback resets $percentile_precision_source to "default")' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 2 — fallback resets source annotation'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - fallback resets source annotation'
 
     rm -f "$out"
 }
@@ -277,87 +277,87 @@ scenario_message_stats_bin() {
 
     assert_line "$out" \
         pattern     '^consumer: summary_table$' \
-        asserts     'The summary_table consumer block is emitted in the -V histogram-bin-counters output under -mdm bin (per Issue #287 Commit 4 — summary_table was added to %migrated alongside #34s heatmap_cells/markers and histogram_view/bins).' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — the @consumer_order iteration emits one consumer: block per migrated consumer' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — consumer name string is locked; renames are breaking. features/287-message-stats-bin-counter-data-model.md § R8.1.'
+        asserts     'The summary_table consumer block is emitted in the -V histogram-bin-counters output under -mdm bin (per Issue #287 Commit 4 - summary_table was added to %migrated alongside #34s heatmap_cells/markers and histogram_view/bins).' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - the @consumer_order iteration emits one consumer: block per migrated consumer' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - consumer name string is locked; renames are breaking. features/287-message-stats-bin-counter-data-model.md section R8.1.'
 
     assert_line "$out" \
         pattern     '^  path: unified$' \
-        asserts     'Under -mdm bin (no opt-outs), the summary_table consumer reports path: unified — the bin-counter path is running end-to-end on the per-message-key statistics surface.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — path determined by %migrated AND not opted out' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R10 path vocabulary — unified is the post-migration label.'
+        asserts     'Under -mdm bin (no opt-outs), the summary_table consumer reports path: unified - the bin-counter path is running end-to-end on the per-message-key statistics surface.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - path determined by %migrated AND not opted out' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R10 path vocabulary - unified is the post-migration label.'
 
     assert_line "$out" \
         pattern     '^  partition_keying: \(category, log_key\)$' \
         asserts     'summary_tables partition keying is (category, log_key), distinct from time_bucket and metric_global. This is the F1 keying shape per #189 R3.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %partition_keying lookup' \
-        contract    'features/189-histogram-bin-counter-primitives.md § R3 — keying shape per consumer is locked; features/287 § R8.1 sets summary_tables shape.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %partition_keying lookup' \
+        contract    'features/189-histogram-bin-counter-primitives.md section R3 - keying shape per consumer is locked; features/287 section R8.1 sets summary_tables shape.'
 
     assert_line "$out" \
         pattern     '^  partition_count: [1-9][0-9]*$' \
-        asserts     'partition_count reports a positive integer — at least one (category, log_key) had a duration sample that triggered counter_update and lazily allocated a partition.' \
+        asserts     'partition_count reports a positive integer - at least one (category, log_key) had a duration sample that triggered counter_update and lazily allocated a partition.' \
         produced_by 'snapshot_counter_telemetry() in ltl, invoked from finalize_message_stats_unified()' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — partition_count field is locked; format is integer.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - partition_count field is locked; format is integer.'
 
     assert_line "$out" \
         pattern     '^  total_rebin_events: [0-9]+$' \
-        asserts     'total_rebin_events is present and a non-negative integer — the auto-resize lifecycle has either fired zero or more rebins across all partitions.' \
+        asserts     'total_rebin_events is present and a non-negative integer - the auto-resize lifecycle has either fired zero or more rebins across all partitions.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — total_rebin_events field is locked; format is integer.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - total_rebin_events field is locked; format is integer.'
 
     assert_line "$out" \
         pattern     '^  max_partition_bins: [0-9]+$' \
-        asserts     'max_partition_bins is present and a non-negative integer — the high-water-mark bin count across all partitions for this consumer (#187 Decision 5 telemetry).' \
+        asserts     'max_partition_bins is present and a non-negative integer - the high-water-mark bin count across all partitions for this consumer (#187 Decision 5 telemetry).' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — max_partition_bins is locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - max_partition_bins is locked.'
 
     assert_line "$out" \
         pattern     '^  partitions_with_overflow_count: [0-9]+$' \
         asserts     'partitions_with_overflow_count reports the count of partitions where the overflow counter was non-zero (per #187 Decision 4 / #189 R6). Zero on the test log; non-zero is the audit signal.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + § Decision 4 — overflow tally is the audit surface; field name and integer format are locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 4 - overflow tally is the audit surface; field name and integer format are locked.'
 
     assert_line "$out" \
         pattern     '^  partitions_with_underflow_count: [0-9]+$' \
         asserts     'partitions_with_underflow_count reports the symmetric tally for underflow per #187 Decision 4. Zero on the test log; non-zero is the audit signal.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + § Decision 4 — underflow tally is the audit surface.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 4 - underflow tally is the audit surface.'
 
     assert_line "$out" \
         pattern     '^  counter_memory_bytes: [0-9]+$' \
-        asserts     'counter_memory_bytes is present and a non-negative integer — the Devel::Size measurement of the counter store carrying the empirical-tuning signal for partition-count vs memory.' \
+        asserts     'counter_memory_bytes is present and a non-negative integer - the Devel::Size measurement of the counter store carrying the empirical-tuning signal for partition-count vs memory.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — counter_memory_bytes is locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - counter_memory_bytes is locked.'
 
     assert_line "$out" \
         pattern     '^  rebins_per_partition: p50=[0-9]+ p95=[0-9]+ p99=[0-9]+ max=[0-9]+$' \
         asserts     'rebins_per_partition reports the percentile distribution of per-partition rebin counts in the locked four-field format (p50, p95, p99, max). The seed-heuristic tuning signal per #187 Decision 5.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 5 + § Decision 8 — telemetry field name and four-quartile format are locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 5 + section Decision 8 - telemetry field name and four-quartile format are locked.'
 
     assert_line "$out" \
         pattern     '^  percentiles_emitted: p1 p5 p10 p25 p50 p75 p90 p95 p99 p999 p9999 p99999$' \
         asserts     'summary_table emits the 12-quantile ladder per #187 R3 for this surface. Order is fixed: p1 p5 p10 p25 p50 p75 p90 p95 p99 p999 p9999 p99999.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %percentile_set{summary_table}' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R3 — per-consumer percentile set is locked; features/287 § R8.1 sets summary_tables ladder.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %percentile_set{summary_table}' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R3 - per-consumer percentile set is locked; features/287 section R8.1 sets summary_tables ladder.'
 
     assert_line "$out" \
         pattern     '^  out_of_range_bounded: p1=(none|low|high)' \
         asserts     'out_of_range_bounded emits per-quantile audit code (none|low|high) per #187 Decision 4. Pattern checks at least p1 is reported; subsequent quantiles follow the same triple.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — reads $t->{out_of_range_bounded} populated by finalize_message_stats_unified()' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 4 + § Decision 8 — per-quantile audit code triple is locked.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - reads $t->{out_of_range_bounded} populated by finalize_message_stats_unified()' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 4 + section Decision 8 - per-quantile audit code triple is locked.'
 
     assert_line "$out" \
         pattern     '^consumer: csv_output$' \
         asserts     'csv_output consumer block is emitted in the -V histogram-bin-counters output. Without -o, csv_output reports feature_not_active; with -o, it reports the shared-partition short form.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — @consumer_order iteration' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — csv_output consumer is locked.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - @consumer_order iteration' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - csv_output consumer is locked.'
 
     assert_line "$out" \
         pattern     '^  path: feature_not_active$' \
         asserts     'Without -o, csv_output reports path: feature_not_active. csv_output is gated on $write_messages_to_csv (the -o flag); when not active, no telemetry block is emitted.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %feature_active map' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R10 — feature_not_active is the no-op label.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %feature_active map' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R10 - feature_not_active is the no-op label.'
 
     rm -f "$out"
 }
@@ -380,13 +380,13 @@ scenario_message_stats_csv_shared() {
         pattern     '^consumer: csv_output$' \
         asserts     'csv_output consumer block is emitted under -mdm bin -o.' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8'
 
     assert_line "$out" \
         pattern     '^  shares_partitions_with: summary_table$' \
         asserts     'Under -mdm bin -o, csv_output reports the locked shares_partitions_with short-form block, declaring that csv_output reads percentile values from the same per-key partition that summary_table populates (no duplicate store).' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %shares_with map carrying csv_output => summary_table' \
-        contract    'features/189-histogram-bin-counter-primitives.md § R7 — shared partitions across consumers; features/187 § Decision 8 — locked short-form block; features/287 § R8.1.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %shares_with map carrying csv_output => summary_table' \
+        contract    'features/189-histogram-bin-counter-primitives.md section R7 - shared partitions across consumers; features/187 section Decision 8 - locked short-form block; features/287 section R8.1.'
 
     # Cleanup: -o leaves CSV files in the cwd
     rm -f *MESSAGES-*.csv *STATS-*.csv 2>/dev/null || true
@@ -409,21 +409,21 @@ scenario_message_stats_raw() {
 
     assert_line "$out" \
         pattern     '^consumer: summary_table$' \
-        asserts     'summary_table consumer block is emitted even under -mdm raw — the consumer is migrated; the path label distinguishes engaged-vs-opt-out.' \
+        asserts     'summary_table consumer block is emitted even under -mdm raw - the consumer is migrated; the path label distinguishes engaged-vs-opt-out.' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8'
 
     assert_line "$out" \
         pattern     '^  path: user_opt_out$' \
-        asserts     'Under -mdm raw, summary_table reports path: user_opt_out — the consumer is migrated but the user pinned raw on this surface, so the pre-migration code runs. No telemetry block follows.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %consumer_opted_out_to_raw map (Issue #287 Commit 4)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R10 path vocabulary — user_opt_out is the migrated-but-pinned-raw label.'
+        asserts     'Under -mdm raw, summary_table reports path: user_opt_out - the consumer is migrated but the user pinned raw on this surface, so the pre-migration code runs. No telemetry block follows.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %consumer_opted_out_to_raw map (Issue #287 Commit 4)' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R10 path vocabulary - user_opt_out is the migrated-but-pinned-raw label.'
 
     assert_no_line "$out" \
         pattern     '^  partition_count:' \
-        asserts     'Under -mdm raw, no telemetry block follows path: user_opt_out — counter store is empty (producer never fired) and emit logic short-circuits.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — next-after-path-emit short-circuit' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — opt-out blocks emit only the path: line.'
+        asserts     'Under -mdm raw, no telemetry block follows path: user_opt_out - counter store is empty (producer never fired) and emit logic short-circuits.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - next-after-path-emit short-circuit' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - opt-out blocks emit only the path: line.'
 
     rm -f "$out"
 }
@@ -448,81 +448,81 @@ scenario_bucket_stats_bin() {
 
     assert_line "$out" \
         pattern     '^consumer: time_bucket_stats$' \
-        asserts     'The time_bucket_stats consumer block is emitted under -bdm bin (per Issue #289 — time_bucket_stats was added to %migrated alongside the #34/#287 consumers).' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — the @consumer_order iteration emits one consumer: block per migrated consumer' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — consumer name string is locked; renames are breaking. features/289-bucket-stats-bin-counter-data-model.md.'
+        asserts     'The time_bucket_stats consumer block is emitted under -bdm bin (per Issue #289 - time_bucket_stats was added to %migrated alongside the #34/#287 consumers).' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - the @consumer_order iteration emits one consumer: block per migrated consumer' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - consumer name string is locked; renames are breaking. features/289-bucket-stats-bin-counter-data-model.md.'
 
     assert_line "$out" \
         pattern     '^  path: unified$' \
-        asserts     'Under -bdm bin (no opt-outs), the time_bucket_stats consumer reports path: unified — the bin-counter path is running end-to-end on the per-time-bucket statistics surface.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — path determined by %migrated AND not opted out' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R10 path vocabulary — unified is the post-migration label.'
+        asserts     'Under -bdm bin (no opt-outs), the time_bucket_stats consumer reports path: unified - the bin-counter path is running end-to-end on the per-time-bucket statistics surface.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - path determined by %migrated AND not opted out' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R10 path vocabulary - unified is the post-migration label.'
 
     assert_line "$out" \
         pattern     '^  partition_keying: time_bucket$' \
-        asserts     'time_bucket_stats partition keying is time_bucket — one partition per time bucket, the same keying #34 uses for heatmap_cells/markers. Distinct from (category, log_key) and metric_global.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %partition_keying lookup' \
-        contract    'features/189-histogram-bin-counter-primitives.md § R3 — keying shape per consumer is locked; features/289 sets time_bucket_stats shape.'
+        asserts     'time_bucket_stats partition keying is time_bucket - one partition per time bucket, the same keying #34 uses for heatmap_cells/markers. Distinct from (category, log_key) and metric_global.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %partition_keying lookup' \
+        contract    'features/189-histogram-bin-counter-primitives.md section R3 - keying shape per consumer is locked; features/289 sets time_bucket_stats shape.'
 
     assert_line "$out" \
         pattern     '^  partition_count: [1-9][0-9]*$' \
-        asserts     'partition_count reports a positive integer — at least one time bucket had a duration sample that triggered counter_update and lazily allocated a partition.' \
+        asserts     'partition_count reports a positive integer - at least one time bucket had a duration sample that triggered counter_update and lazily allocated a partition.' \
         produced_by 'snapshot_counter_telemetry() in ltl, invoked from finalize_bucket_stats_unified()' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — partition_count field is locked; format is integer.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - partition_count field is locked; format is integer.'
 
     assert_line "$out" \
         pattern     '^  total_rebin_events: [0-9]+$' \
-        asserts     'total_rebin_events is present and a non-negative integer — the auto-resize lifecycle has fired zero or more rebins across all per-bucket partitions.' \
+        asserts     'total_rebin_events is present and a non-negative integer - the auto-resize lifecycle has fired zero or more rebins across all per-bucket partitions.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — total_rebin_events field is locked; format is integer.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - total_rebin_events field is locked; format is integer.'
 
     assert_line "$out" \
         pattern     '^  max_partition_bins: [0-9]+$' \
-        asserts     'max_partition_bins is present and a non-negative integer — the high-water-mark bin count across all per-bucket partitions (#187 Decision 5 telemetry).' \
+        asserts     'max_partition_bins is present and a non-negative integer - the high-water-mark bin count across all per-bucket partitions (#187 Decision 5 telemetry).' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — max_partition_bins is locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - max_partition_bins is locked.'
 
     assert_line "$out" \
         pattern     '^  partitions_with_overflow_count: [0-9]+$' \
         asserts     'partitions_with_overflow_count reports the count of per-bucket partitions where the overflow counter was non-zero (per #187 Decision 4 / #189 R6).' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + § Decision 4 — overflow tally is the audit surface; field name and integer format are locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 4 - overflow tally is the audit surface; field name and integer format are locked.'
 
     assert_line "$out" \
         pattern     '^  partitions_with_underflow_count: [0-9]+$' \
         asserts     'partitions_with_underflow_count reports the symmetric per-bucket underflow tally per #187 Decision 4.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 + § Decision 4 — underflow tally is the audit surface.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 4 - underflow tally is the audit surface.'
 
     assert_line "$out" \
         pattern     '^  counter_memory_bytes: [0-9]+$' \
-        asserts     'counter_memory_bytes is present and a non-negative integer — the Devel::Size measurement of the dedicated per-time-bucket counter store.' \
+        asserts     'counter_memory_bytes is present and a non-negative integer - the Devel::Size measurement of the dedicated per-time-bucket counter store.' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8 — counter_memory_bytes is locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - counter_memory_bytes is locked.'
 
     assert_line "$out" \
         pattern     '^  rebins_per_partition: p50=[0-9]+ p95=[0-9]+ p99=[0-9]+ max=[0-9]+$' \
         asserts     'rebins_per_partition reports the percentile distribution of per-partition rebin counts in the locked four-field format (p50, p95, p99, max).' \
         produced_by 'snapshot_counter_telemetry() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 5 + § Decision 8 — telemetry field name and four-quartile format are locked.'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 5 + section Decision 8 - telemetry field name and four-quartile format are locked.'
 
     assert_line "$out" \
         pattern     '^  percentiles_emitted: p1 p5 p10 p25 p50 p75 p90 p95 p99 p999 p9999 p99999$' \
         asserts     'time_bucket_stats emits the 12-quantile ladder per #187 R3 for this surface. Order is fixed: p1 p5 p10 p25 p50 p75 p90 p95 p99 p999 p9999 p99999.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %percentile_set{time_bucket_stats}' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R3 — per-consumer percentile set is locked; features/289 sets time_bucket_stats ladder.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %percentile_set{time_bucket_stats}' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R3 - per-consumer percentile set is locked; features/289 sets time_bucket_stats ladder.'
 
     assert_line "$out" \
         pattern     '^  out_of_range_bounded: p1=(none|low|high)' \
         asserts     'out_of_range_bounded emits per-quantile audit code (none|low|high) per #187 Decision 4. Pattern checks at least p1 is reported; subsequent quantiles follow the same triple.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — reads $t->{out_of_range_bounded} populated by finalize_bucket_stats_unified() from %bucket_stats_audit' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 4 + § Decision 8 — per-quantile audit code triple is locked.'
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - reads $t->{out_of_range_bounded} populated by finalize_bucket_stats_unified() from %bucket_stats_audit' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 4 + section Decision 8 - per-quantile audit code triple is locked.'
 
     assert_no_line "$out" \
         pattern     '^  shares_partitions_with: ' \
-        asserts     'time_bucket_stats has a DEDICATED counter store (not in %shares_with), so it emits the full telemetry block — never a shares_partitions_with short form. Inverting the heatmap sharing is a separate follow-up.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %shares_with map has no time_bucket_stats entry' \
-        contract    'features/289-bucket-stats-bin-counter-data-model.md § dedicated-store decision (divergence 2).'
+        asserts     'time_bucket_stats has a DEDICATED counter store (not in %shares_with), so it emits the full telemetry block - never a shares_partitions_with short form. Inverting the heatmap sharing is a separate follow-up.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %shares_with map has no time_bucket_stats entry' \
+        contract    'features/289-bucket-stats-bin-counter-data-model.md section dedicated-store decision (divergence 2).'
 
     rm -f "$out"
 }
@@ -542,15 +542,15 @@ scenario_bucket_stats_raw() {
 
     assert_line "$out" \
         pattern     '^consumer: time_bucket_stats$' \
-        asserts     'time_bucket_stats consumer block is emitted even under -bdm raw — the consumer is migrated; the path label distinguishes engaged-vs-opt-out.' \
+        asserts     'time_bucket_stats consumer block is emitted even under -bdm raw - the consumer is migrated; the path label distinguishes engaged-vs-opt-out.' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § Decision 8'
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8'
 
     assert_line "$out" \
         pattern     '^  path: user_opt_out$' \
-        asserts     'Under -bdm raw, time_bucket_stats reports path: user_opt_out — the consumer is migrated but the user pinned raw on this surface, so the pre-migration code runs. No telemetry block follows.' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl — %consumer_opted_out_to_raw map (Issue #289)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md § R10 path vocabulary — user_opt_out is the migrated-but-pinned-raw label.'
+        asserts     'Under -bdm raw, time_bucket_stats reports path: user_opt_out - the consumer is migrated but the user pinned raw on this surface, so the pre-migration code runs. No telemetry block follows.' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl - %consumer_opted_out_to_raw map (Issue #289)' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section R10 path vocabulary - user_opt_out is the migrated-but-pinned-raw label.'
 
     rm -f "$out"
 }

--- a/tests/validate-histogram-ticks.sh
+++ b/tests/validate-histogram-ticks.sh
@@ -208,13 +208,13 @@ test_single_width() {
     local oo
     oo=$(echo "$report" | sed -n 's/^OUT_OF_AXIS:\([0-9]*\)$/\1/p')
     if [[ "$oo" == "0" ]]; then
-        note_pass "no ┴/┻/┼/╋ outside axis lines (-hgw $hgw)"
+        note_pass "no tick characters outside axis lines (-hgw $hgw)"
     else
         emit_fail \
             label       "out-of-axis ticks (-hgw $hgw)" \
-            asserts     'Percentile tick characters (┴ ┻ ┼ ╋) appear only on the histogram x-axis frame row; appearance elsewhere means the tick emission code is firing on a non-axis row, which is a layout regression' \
-            produced_by 'print_histogram() in ltl — the tick characters are inserted into the same row that emits ┗ ━ ┳ ┛ for the histogram frame' \
-            contract    'Issue #185 § percentile tick marks on histogram x-axis — tick emission is confined to the axis row by construction; tick characters in other rows are not part of the contract' \
+            asserts     'Percentile tick characters (upward-tick and cross marks) appear only on the histogram x-axis frame row; appearance elsewhere means the tick emission code is firing on a non-axis row, which is a layout regression' \
+            produced_by 'print_histogram() in ltl - the tick characters are inserted into the same row that emits the histogram frame characters' \
+            contract    'Issue #185 section percentile tick marks on histogram x-axis - tick emission is confined to the axis row by construction; tick characters in other rows are not part of the contract' \
             detail      "found $oo lines containing ticks outside axis (-hgw $hgw)"
     fi
 
@@ -226,9 +226,9 @@ test_single_width() {
     else
         emit_fail \
             label       "tick colour parity (-hgw $hgw)" \
-            asserts     'Percentile tick characters are emitted with no ANSI wrapping, matching the rest of the frame which is also unwrapped; an ANSI escape sequence immediately preceding a tick means the tick will render in a different colour than ┗ ━ ┳ ┛' \
-            produced_by 'print_histogram() in ltl — tick characters are appended to the frame string with no additional colour wrapping' \
-            contract    'Issue #185 — visual unity of the axis frame requires tick chars to inherit the frame colour by being emitted in the same uncoloured stream' \
+            asserts     'Percentile tick characters are emitted with no ANSI wrapping, matching the rest of the frame which is also unwrapped; an ANSI escape sequence immediately preceding a tick means the tick will render in a different colour than the histogram frame characters' \
+            produced_by 'print_histogram() in ltl - tick characters are appended to the frame string with no additional colour wrapping' \
+            contract    'Issue #185 - visual unity of the axis frame requires tick chars to inherit the frame colour by being emitted in the same uncoloured stream' \
             detail      "$bad_colour tick chars carry ANSI colour wrapping (-hgw $hgw)"
     fi
 
@@ -241,7 +241,7 @@ test_single_width() {
             label       "tick/legend extraction (-hgw $hgw)" \
             asserts     'The inspector must successfully extract both an AXIS tick total and a LEGEND entry count from the single-histogram output; a missing anchor here means the histogram or its legend was not emitted, OR the inspector regexes drifted from the rendered output' \
             produced_by 'print_histogram() + legend rendering in ltl; inspector regexes in inspect_output() of this harness' \
-            contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — a grep that matches nothing is a failure, not a pass' \
+            contract    'tests/HARNESS-DESIGN.md section Harnesses must fail on missing anchors - a grep that matches nothing is a failure, not a pass' \
             detail      "could not extract axis/legend counts (-hgw $hgw): tick='$tick_total' legend='$legend_entries'"
     elif [[ "$tick_total" -ge 1 && "$tick_total" -le "$legend_entries" ]]; then
         note_pass "axis ticks ($tick_total) within [1, $legend_entries] legend entries (-hgw $hgw)"
@@ -249,8 +249,8 @@ test_single_width() {
         emit_fail \
             label       "tick/legend cardinality (-hgw $hgw)" \
             asserts     'The number of axis ticks is at least 1 and at most the number of legend entries; tick_count > legend_count means orphan ticks with no matching legend entry (the legend is the contract); tick_count < 1 means the percentile marker layer was not rendered at all' \
-            produced_by 'print_histogram() in ltl — tick column derivation maps each legend percentile to a column; duplicate columns collapse to one tick' \
-            contract    'Issue #185 — set-semantics: percentiles with identical (or column-quantised-identical) values collapse to one tick; orphan ticks have no place in the rendering' \
+            produced_by 'print_histogram() in ltl - tick column derivation maps each legend percentile to a column; duplicate columns collapse to one tick' \
+            contract    'Issue #185 - set-semantics: percentiles with identical (or column-quantised-identical) values collapse to one tick; orphan ticks have no place in the rendering' \
             detail      "axis ticks ($tick_total) outside [1, $legend_entries] legend entries (-hgw $hgw)"
     fi
 
@@ -279,8 +279,8 @@ test_multi_histogram() {
         emit_fail \
             label       "out-of-axis ticks (multi)" \
             asserts     'In a multi-histogram run, percentile tick characters still appear only on histogram x-axis frame rows; tick leakage into other rows is a layout regression that the single-width tests can miss because multi-histogram layout takes a different code path' \
-            produced_by 'print_histogram() in ltl — invoked once per metric for -hg duration,bytes; each invocation must restrict tick emission to its own axis row' \
-            contract    'Issue #185 — multi-histogram is the panel-stacking variant; the same axis-row containment invariant applies independently to each panel' \
+            produced_by 'print_histogram() in ltl - invoked once per metric for -hg duration,bytes; each invocation must restrict tick emission to its own axis row' \
+            contract    'Issue #185 - multi-histogram is the panel-stacking variant; the same axis-row containment invariant applies independently to each panel' \
             detail      "found $oo lines with ticks outside axis (multi)"
     fi
 
@@ -294,7 +294,7 @@ test_multi_histogram() {
                 label       "tick/legend extraction (multi hist#$hidx)" \
                 asserts     "The inspector must successfully extract both an AXIS tick total and a LEGEND entry count for histogram panel #$hidx; missing data here means the panel was not rendered, or its legend was emitted on a row the inspector cannot identify" \
                 produced_by 'print_histogram() (per-panel invocation) + inspect_output() per-segment splitting in this harness' \
-                contract    'tests/HARNESS-DESIGN.md § Harnesses must fail on missing anchors — multi-histogram extraction failures must not silently degrade to a passing test' \
+                contract    'tests/HARNESS-DESIGN.md section Harnesses must fail on missing anchors - multi-histogram extraction failures must not silently degrade to a passing test' \
                 detail      "could not extract counts for hist#$hidx (multi): tick='$tick' legend='$legend'"
         elif [[ "$tick" -ge 1 && "$tick" -le "$legend" ]]; then
             note_pass "hist#$hidx ticks ($tick) within [1, $legend] legend entries"
@@ -302,8 +302,8 @@ test_multi_histogram() {
             emit_fail \
                 label       "tick/legend cardinality (multi hist#$hidx)" \
                 asserts     "Histogram panel #$hidx has at least 1 axis tick and no more axis ticks than legend entries; each panel carries its own independent tick set matching its own legend" \
-                produced_by 'print_histogram() in ltl — tick column derivation runs independently per panel' \
-                contract    'Issue #185 — multi-histogram panels carry independent tick sets; cross-panel sharing would create the orphan-tick failure mode this assertion exists to prevent' \
+                produced_by 'print_histogram() in ltl - tick column derivation runs independently per panel' \
+                contract    'Issue #185 - multi-histogram panels carry independent tick sets; cross-panel sharing would create the orphan-tick failure mode this assertion exists to prevent' \
                 detail      "hist#$hidx ticks ($tick) outside [1, $legend] legend entries"
         fi
     done

--- a/tests/validate-index-read-back.sh
+++ b/tests/validate-index-read-back.sh
@@ -390,14 +390,14 @@ helper_self_test() {
         label       'seed_from_fixture produces ltl-index.csv' \
         asserts     'The seed_from_fixture helper drops the prebuilt fixture into the scenario cwd so subsequent assertions have a known starting state' \
         produced_by 'seed_from_fixture() in tests/validate-index-read-back.sh (copies $INDEX_FIXTURE to ./ltl-index.csv)' \
-        contract    'features/179-index-read-back.md § Validation — Index orchestration; tests/HARNESS-DESIGN.md § Orchestration helpers'
+        contract    'features/179-index-read-back.md section Validation - Index orchestration; tests/HARNESS-DESIGN.md section Orchestration helpers'
 
     assert_command \
         command     '[[ "$(grep -c "^file," ltl-index.csv || true)" -ge 1 && "$(grep -c "^selection," ltl-index.csv || true)" -ge 1 ]]' \
         label       'fixture seeds at least one file row and one selection row' \
         asserts     'The prebuilt fixture must carry both row kinds (file rows and selection rows) so scenarios exercising either tier have something to match against' \
         produced_by 'tests/fixtures/regenerate-index-readback-fixtures.sh (produces tests/fixtures/ltl-index-readback.csv)' \
-        contract    'features/179-index-read-back.md § Validation — Test scenarios; fixture invariant'
+        contract    'features/179-index-read-back.md section Validation - Test scenarios; fixture invariant'
 
     # Test delete_index_rows: remove all selection rows.
     delete_index_rows "entry_type=selection"
@@ -406,7 +406,7 @@ helper_self_test() {
         label       'delete_index_rows removes matching rows' \
         asserts     'The delete_index_rows orchestration helper removes every row whose predicate columns match, so scenarios can force Tier 2 fallback by deleting the relevant selection rows' \
         produced_by 'delete_index_rows() in tests/validate-index-read-back.sh (Text::CSV-based row filter)' \
-        contract    'features/179-index-read-back.md § Validation — Index orchestration supported operations'
+        contract    'features/179-index-read-back.md section Validation - Index orchestration supported operations'
 
     # Test edit_index_row: change duration_max in the file row.
     edit_index_row "entry_type=file" "duration_max=999999"
@@ -415,7 +415,7 @@ helper_self_test() {
         label       'edit_index_row applies new value' \
         asserts     'The edit_index_row orchestration helper writes the new column value to the first matching row, so scenarios can corrupt bounds (narrow duration_max, blank a column) without touching unrelated rows' \
         produced_by 'edit_index_row() in tests/validate-index-read-back.sh (Text::CSV-based first-match rewrite)' \
-        contract    'features/179-index-read-back.md § Validation — Index orchestration supported operations'
+        contract    'features/179-index-read-back.md section Validation - Index orchestration supported operations'
 
     # Test corrupt_index_file: truncate to half-size.
     local size_before size_after
@@ -427,7 +427,7 @@ helper_self_test() {
         label       "corrupt_index_file truncate shrinks file ($size_before -> $size_after bytes)" \
         asserts     'The corrupt_index_file helper (mode=truncate) cuts the index file mid-row so scenarios can drive the malformed-index code path' \
         produced_by 'corrupt_index_file() in tests/validate-index-read-back.sh (head -c $((sz/2)))' \
-        contract    'features/179-index-read-back.md § Validation — Index orchestration supported operations'
+        contract    'features/179-index-read-back.md section Validation - Index orchestration supported operations'
 }
 
 # ---------------------------------------------------------------------------
@@ -443,16 +443,16 @@ scenario_cold_no_index() {
 
     assert_line "$out" \
         pattern     '^index_used: no$' \
-        asserts     'With no ltl-index.csv in cwd at run start, the run-level header reports index_used=no — the read-back path has nothing to consult on a cold run' \
+        asserts     'With no ltl-index.csv in cwd at run start, the run-level header reports index_used=no - the read-back path has nothing to consult on a cold run' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1 — Run-level summary; locked index_used field'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1 - Run-level summary; locked index_used field'
 
     assert_command \
         command     '[[ -f ltl-index.csv ]] && grep -q "^file," ltl-index.csv && grep -q "^selection," ltl-index.csv' \
         label       'cold run writes index with file and selection rows' \
         asserts     'A cold run must still write a fresh ltl-index.csv at end-of-run carrying at least one file row and one selection row so the next run has a warm index to read back' \
         produced_by 'write_index_file() in ltl (end-of-run #46 write side)' \
-        contract    'features/179-index-read-back.md § Interactions with existing features § "With write side (#46)"'
+        contract    'features/179-index-read-back.md section Interactions with existing features section "With write side (#46)"'
 }
 
 scenario_warm_unfiltered() {
@@ -467,28 +467,28 @@ scenario_warm_unfiltered() {
         pattern     '^index_used: yes$' \
         asserts     'When the index file exists and has a usable row, the run-level header reports index_used=yes' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1 — Run-level summary'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1 - Run-level summary'
 
     # The unfiltered run matches a selection entry with filters=- (Tier 1)
     # — see spec §6.4: that selection entry and the file entry describe
     # the same population and would always agree.
     assert_line "$out" \
         pattern     '^  lookup: tier_1_selection$' \
-        asserts     'An unfiltered run matches the seeded unfiltered selection row (filters=-) and the per-file lookup reports tier_1_selection — the read-back path consults the selection row directly without falling back to the file row' \
+        asserts     'An unfiltered run matches the seeded unfiltered selection row (filters=-) and the per-file lookup reports tier_1_selection - the read-back path consults the selection row directly without falling back to the file row' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — Per-file lookup result; § Behavior — Pre-seeded values (Tier 1 selection row)'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - Per-file lookup result; section Behavior - Pre-seeded values (Tier 1 selection row)'
 
     assert_line "$out" \
         pattern     '^  freshness: fresh$' \
         asserts     'When the live file mtime and size match the values stored in the matched index row, the per-file freshness check reports fresh' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block, freshness sub-field)' \
-        contract    'features/179-index-read-back.md § Behavior — Freshness check; § "-V verbose output" Layer 2'
+        contract    'features/179-index-read-back.md section Behavior - Freshness check; section "-V verbose output" Layer 2'
 
     assert_line "$out" \
         pattern     '^drift_detected: no$' \
         asserts     'When the live calibrated bounds match the pre-seeded bounds, the run-level drift_detected field reports no' \
         produced_by 'detect_index_drift() in ltl + emit_index_readback_verbose() (run-level drift field)' \
-        contract    'features/179-index-read-back.md § Behavior — Drift detection; § "-V verbose output" Layer 4 — Drift detection result'
+        contract    'features/179-index-read-back.md section Behavior - Drift detection; section "-V verbose output" Layer 4 - Drift detection result'
 }
 
 scenario_cold_filtered_tier2_fallback() {
@@ -507,26 +507,26 @@ scenario_cold_filtered_tier2_fallback() {
         pattern     '^index_used: yes$' \
         asserts     'A filtered run with a missing selection row still reports index_used=yes because the file row is usable for pre-seeding even when no exact-filter selection row matches' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1; § Behavior — Pre-seeded values (Tier 2 fallback)'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1; section Behavior - Pre-seeded values (Tier 2 fallback)'
 
     assert_line "$out" \
         pattern     '^  lookup: tier_2_file$' \
         asserts     'When no selection row matches the requested filter signature, the per-file lookup falls back to the file row and reports tier_2_file' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § Tier 2 file-row fallback; § "-V verbose output" Layer 2'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section Tier 2 file-row fallback; section "-V verbose output" Layer 2'
 
     assert_line "$out" \
         pattern     '^index_filter_signature: -dmin=50$' \
         asserts     'The run-level index_filter_signature echoes the active CLI filters in canonical form so the reader can confirm which signature was used to probe the index' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1 — Run-level summary; locked field'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1 - Run-level summary; locked field'
 
     assert_command \
         command     'grep -q "^selection,.*,-dmin=50$" ltl-index.csv' \
         label       'selection row written for -dmin=50' \
         asserts     'After a Tier 2 fallback run, the end-of-run write appends a fresh selection row for the requested filter signature so the next run with the same filters hits Tier 1' \
         produced_by 'write_index_file() in ltl (end-of-run #46 write side; appends new selection row)' \
-        contract    'features/179-index-read-back.md § Interactions with existing features § "With write side (#46)"'
+        contract    'features/179-index-read-back.md section Interactions with existing features section "With write side (#46)"'
 }
 
 scenario_warm_tier1_filtered() {
@@ -543,25 +543,25 @@ scenario_warm_tier1_filtered() {
         pattern     '^index_used: yes$' \
         asserts     'A warm filtered run with a matching selection row reports index_used=yes' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1'
 
     assert_line "$out" \
         pattern     '^  lookup: tier_1_selection$' \
         asserts     'When the index has a fresh selection row matching the active filter signature, the per-file lookup hits Tier 1 directly without consulting the file row' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § Tier 1 selection row; § "-V verbose output" Layer 2'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section Tier 1 selection row; section "-V verbose output" Layer 2'
 
     assert_line "$out" \
         pattern     '^index_filter_signature: -dmin=50$' \
         asserts     'The run-level index_filter_signature echoes the active CLI filters in canonical form even when Tier 1 matches' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1 — Run-level summary'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1 - Run-level summary'
 
     assert_line "$out" \
         pattern     '^drift_detected: no$' \
         asserts     'When the live calibrated bounds match the Tier 1 selection row bounds, drift_detected reports no' \
         produced_by 'detect_index_drift() in ltl + emit_index_readback_verbose() (run-level drift field)' \
-        contract    'features/179-index-read-back.md § Behavior — Drift detection; § "-V verbose output" Layer 4'
+        contract    'features/179-index-read-back.md section Behavior - Drift detection; section "-V verbose output" Layer 4'
 }
 
 scenario_warm_tier2_different_filters() {
@@ -578,20 +578,20 @@ scenario_warm_tier2_different_filters() {
         pattern     '^  lookup: tier_2_file$' \
         asserts     'When the active filter signature does not match any seeded selection row (fixture has -dmin=50 but run uses -dmin=100), the per-file lookup falls back to Tier 2 (file row)' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § Tier 2 fallback'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section Tier 2 fallback'
 
     assert_line "$out" \
         pattern     '^index_filter_signature: -dmin=100$' \
         asserts     'The run-level index_filter_signature reflects the active CLI filters (-dmin=100) regardless of which seeded rows the index already carries' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1'
 
     assert_command \
         command     'grep -q "^selection,.*,-dmin=50$" ltl-index.csv && grep -q "^selection,.*,-dmin=100$" ltl-index.csv' \
         label       'both -dmin=50 and -dmin=100 selection rows preserved after write' \
-        asserts     'After the run, the end-of-run write must preserve the pre-existing -dmin=50 selection row AND append a new -dmin=100 selection row — the write side never discards selection rows for filter signatures it did not see this run' \
+        asserts     'After the run, the end-of-run write must preserve the pre-existing -dmin=50 selection row AND append a new -dmin=100 selection row - the write side never discards selection rows for filter signatures it did not see this run' \
         produced_by 'write_index_file() in ltl (end-of-run #46 write side; merge-with-existing semantics)' \
-        contract    'features/179-index-read-back.md § Interactions with existing features § "With write side (#46)" — selection rows accumulate per filter signature'
+        contract    'features/179-index-read-back.md section Interactions with existing features section "With write side (#46)" - selection rows accumulate per filter signature'
 }
 
 scenario_stale_mtime() {
@@ -612,15 +612,15 @@ scenario_stale_mtime() {
 
     assert_line "$out" \
         pattern     '^index_used: no$' \
-        asserts     'When the live file mtime no longer matches the value stored in the index row, the freshness check fails and the run-level header reports index_used=no — stale rows must not pre-seed' \
+        asserts     'When the live file mtime no longer matches the value stored in the index row, the freshness check fails and the run-level header reports index_used=no - stale rows must not pre-seed' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block; gated on freshness check)' \
-        contract    'features/179-index-read-back.md § Behavior — Freshness check; § "-V verbose output" Layer 1'
+        contract    'features/179-index-read-back.md section Behavior - Freshness check; section "-V verbose output" Layer 1'
 
     assert_line "$out" \
         pattern     '^  freshness: stale_mtime$' \
         asserts     'Per-file freshness reports the specific reason stale_mtime (not just "stale") so the reader can distinguish mtime drift from size drift' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block, freshness sub-field; staleness reason)' \
-        contract    'features/179-index-read-back.md § Behavior — Freshness check; § "-V verbose output" Layer 2 — locked staleness reason codes'
+        contract    'features/179-index-read-back.md section Behavior - Freshness check; section "-V verbose output" Layer 2 - locked staleness reason codes'
 }
 
 scenario_stale_size() {
@@ -641,13 +641,13 @@ scenario_stale_size() {
         pattern     '^index_used: no$' \
         asserts     'When the live file size no longer matches the value stored in the index row, the freshness check fails and the run-level header reports index_used=no' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block; gated on freshness check)' \
-        contract    'features/179-index-read-back.md § Behavior — Freshness check'
+        contract    'features/179-index-read-back.md section Behavior - Freshness check'
 
     assert_line "$out" \
         pattern     '^  freshness: stale_size$' \
         asserts     'Per-file freshness reports the specific reason stale_size when size drift is the cause (distinct from stale_mtime) so the reader can identify whether truncation/append vs touch caused the staleness' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block, freshness sub-field; staleness reason)' \
-        contract    'features/179-index-read-back.md § Behavior — Freshness check; § "-V verbose output" Layer 2 — locked staleness reason codes'
+        contract    'features/179-index-read-back.md section Behavior - Freshness check; section "-V verbose output" Layer 2 - locked staleness reason codes'
 }
 
 scenario_drift_refresh_tier1() {
@@ -673,27 +673,27 @@ scenario_drift_refresh_tier1() {
 
     assert_line "$out" \
         pattern     '^index_used: yes$' \
-        asserts     'A Tier 1 run with a matching selection row still reports index_used=yes even when the seeded bounds have drifted from live — drift detection does not invalidate the pre-seed' \
+        asserts     'A Tier 1 run with a matching selection row still reports index_used=yes even when the seeded bounds have drifted from live - drift detection does not invalidate the pre-seed' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1; § Behavior — Drift detection does not gate index_used'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1; section Behavior - Drift detection does not gate index_used'
 
     assert_line "$out" \
         pattern     '^  lookup: tier_1_selection$' \
         asserts     'When the index has a fresh selection row matching the active filter signature, the per-file lookup reports tier_1_selection regardless of whether the seeded bounds have drifted' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § Tier 1 selection row'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section Tier 1 selection row'
 
     assert_line "$out" \
         pattern     '^drift_detected: yes$' \
         asserts     'When live calibrated bounds differ from the pre-seeded bounds in the matched index row, the run-level drift_detected field reports yes' \
         produced_by 'detect_index_drift() in ltl + emit_index_readback_verbose() (run-level drift field)' \
-        contract    'features/179-index-read-back.md § Behavior — Drift detection; § "-V verbose output" Layer 4 — Drift detection result'
+        contract    'features/179-index-read-back.md section Behavior - Drift detection; section "-V verbose output" Layer 4 - Drift detection result'
 
     assert_line "$out" \
         pattern     "^  duration_max: live=$cal_max preseed=$narrowed drifted=yes$" \
-        asserts     'The per-bound drift detail reports the live calibrated value, the preseeded value from the index row, and a drifted=yes flag — the reader can see exactly which bound moved and by how much' \
+        asserts     'The per-bound drift detail reports the live calibrated value, the preseeded value from the index row, and a drifted=yes flag - the reader can see exactly which bound moved and by how much' \
         produced_by 'emit_index_readback_verbose() in ltl (drift detail block, per-bound line)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 4 — Drift detection result; locked per-bound line format'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 4 - Drift detection result; locked per-bound line format'
 
     # Re-run: the previous write refreshed the selection row, drift should be gone.
     current_scenario="drift-refresh-tier1-recovery"
@@ -702,9 +702,9 @@ scenario_drift_refresh_tier1() {
 
     assert_line "$out2" \
         pattern     '^drift_detected: no$' \
-        asserts     'After a drift-detecting run, the end-of-run write refreshes the selection row with the live calibrated bounds, so the very next run sees matching values and reports drift_detected=no — drift is self-healing' \
+        asserts     'After a drift-detecting run, the end-of-run write refreshes the selection row with the live calibrated bounds, so the very next run sees matching values and reports drift_detected=no - drift is self-healing' \
         produced_by 'write_index_file() in ltl (end-of-run #46 write refreshes selection row bounds) + detect_index_drift() (next run)' \
-        contract    'features/179-index-read-back.md § Behavior — Drift detection § "Drift is self-healing"; § Interactions with existing features § "With write side (#46)"'
+        contract    'features/179-index-read-back.md section Behavior - Drift detection section "Drift is self-healing"; section Interactions with existing features section "With write side (#46)"'
 }
 
 scenario_drift_refresh_tier2() {
@@ -731,21 +731,21 @@ scenario_drift_refresh_tier2() {
 
     assert_line "$out" \
         pattern     '^  lookup: tier_2_file$' \
-        asserts     'When no selection row matches the active (unfiltered) filter signature, the per-file lookup falls back to the file row and reports tier_2_file — drift detection applies to whichever tier was matched' \
+        asserts     'When no selection row matches the active (unfiltered) filter signature, the per-file lookup falls back to the file row and reports tier_2_file - drift detection applies to whichever tier was matched' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § Tier 2 fallback'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section Tier 2 fallback'
 
     assert_line "$out" \
         pattern     '^drift_detected: yes$' \
-        asserts     'Drift detection applies to Tier 2 (file row) lookups as well as Tier 1 — when live calibrated bounds differ from the file rows preseeded bounds, drift_detected reports yes' \
+        asserts     'Drift detection applies to Tier 2 (file row) lookups as well as Tier 1 - when live calibrated bounds differ from the file rows preseeded bounds, drift_detected reports yes' \
         produced_by 'detect_index_drift() in ltl + emit_index_readback_verbose() (run-level drift field)' \
-        contract    'features/179-index-read-back.md § Behavior — Drift detection (tier-agnostic)'
+        contract    'features/179-index-read-back.md section Behavior - Drift detection (tier-agnostic)'
 
     assert_line "$out" \
         pattern     "^  duration_max: live=$cal_max preseed=$narrowed drifted=yes$" \
-        asserts     'The per-bound drift detail format (live=X preseed=Y drifted=yes) is identical for Tier 1 and Tier 2 — the reader sees the same diagnostic regardless of which row was matched' \
+        asserts     'The per-bound drift detail format (live=X preseed=Y drifted=yes) is identical for Tier 1 and Tier 2 - the reader sees the same diagnostic regardless of which row was matched' \
         produced_by 'emit_index_readback_verbose() in ltl (drift detail block, per-bound line; tier-agnostic format)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 4 — locked per-bound line format'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 4 - locked per-bound line format'
 }
 
 scenario_multi_file_all_fresh_tier2_unfiltered() {
@@ -763,26 +763,26 @@ scenario_multi_file_all_fresh_tier2_unfiltered() {
         pattern     '^index_used: yes$' \
         asserts     'A multi-file run where every file matches some index row (Tier 2 fallback for all) reports index_used=yes at the run level' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1; § Behavior — Multi-file aggregation'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1; section Behavior - Multi-file aggregation'
 
     assert_command \
         command     "[[ \"\$(grep -c '^  lookup: tier_2_file\$' \"$out\" || true)\" -eq 2 ]]" \
         label       'both files report tier_2_file' \
-        asserts     'In a multi-file run, each file produces its own per-file lookup block — when all files fall back to Tier 2, the output contains exactly one tier_2_file line per file' \
+        asserts     'In a multi-file run, each file produces its own per-file lookup block - when all files fall back to Tier 2, the output contains exactly one tier_2_file line per file' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block emitted once per input file)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — Per-file lookup result; § Behavior — Multi-file aggregation'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - Per-file lookup result; section Behavior - Multi-file aggregation'
 
     assert_line "$out" \
         pattern     '^aggregated_preseed:$' \
-        asserts     'When all files are usable for pre-seeding, the run emits an aggregated_preseed block summarizing the merged bounds used for the run — this header is the locked anchor for the aggregation section' \
+        asserts     'When all files are usable for pre-seeding, the run emits an aggregated_preseed block summarizing the merged bounds used for the run - this header is the locked anchor for the aggregation section' \
         produced_by 'emit_index_readback_verbose() in ltl (aggregated_preseed block, multi-file path)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 3 — Aggregated pre-seed values'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 3 - Aggregated pre-seed values'
 
     assert_line "$out" \
         pattern     '^  duration_max: .* \(from .*\)$' \
         asserts     'Each aggregated bound line carries (from <path>) provenance so the reader can see which input file contributed the winning value to the merged pre-seed' \
         produced_by 'emit_index_readback_verbose() in ltl (aggregated_preseed block, per-bound line with provenance suffix)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 3 — Aggregated pre-seed values; locked (from <path>) provenance suffix'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 3 - Aggregated pre-seed values; locked (from <path>) provenance suffix'
 }
 
 scenario_multi_file_all_fresh_tier1() {
@@ -798,14 +798,14 @@ scenario_multi_file_all_fresh_tier1() {
         pattern     '^index_used: yes$' \
         asserts     'A multi-file run where every file has a matching selection row (Tier 1 for all) reports index_used=yes at the run level' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 1'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 1'
 
     assert_command \
         command     "[[ \"\$(grep -c '^  lookup: tier_1_selection\$' \"$out\" || true)\" -eq 2 ]]" \
         label       'both files report tier_1_selection' \
-        asserts     'In a multi-file run with matching selection rows for both files, each per-file lookup block independently reports tier_1_selection — multi-file aggregation does not collapse or share per-file lookup results' \
+        asserts     'In a multi-file run with matching selection rows for both files, each per-file lookup block independently reports tier_1_selection - multi-file aggregation does not collapse or share per-file lookup results' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block emitted once per input file)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — Per-file lookup result; § Behavior — Multi-file aggregation'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - Per-file lookup result; section Behavior - Multi-file aggregation'
 }
 
 scenario_multi_file_mixed_tiers() {
@@ -821,27 +821,27 @@ scenario_multi_file_mixed_tiers() {
 
     assert_line "$out" \
         pattern     '^index_used: no$' \
-        asserts     'When the input files match at different tiers, the run reports index_used=no — multi-file aggregation requires uniform tier matches across all files to be usable for pre-seeding' \
+        asserts     'When the input files match at different tiers, the run reports index_used=no - multi-file aggregation requires uniform tier matches across all files to be usable for pre-seeding' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block; multi-file mixed-tier branch)' \
-        contract    'features/179-index-read-back.md § Behavior — Multi-file aggregation § "Mixed-tier runs disable pre-seeding"'
+        contract    'features/179-index-read-back.md section Behavior - Multi-file aggregation section "Mixed-tier runs disable pre-seeding"'
 
     assert_line "$out" \
         pattern     '^  lookup: tier_1_selection$' \
-        asserts     'Even when the run as a whole rejects pre-seeding due to mixed tiers, each per-file lookup block still reports its individual would-have-been tier so the reader can diagnose the mismatch — here ACCESS_LOG retains its Tier 1 selection match' \
+        asserts     'Even when the run as a whole rejects pre-seeding due to mixed tiers, each per-file lookup block still reports its individual would-have-been tier so the reader can diagnose the mismatch - here ACCESS_LOG retains its Tier 1 selection match' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block; reports individual tier independent of aggregate decision)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — per-file lookup reports individual tier'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - per-file lookup reports individual tier'
 
     assert_line "$out" \
         pattern     '^  lookup: tier_2_file$' \
-        asserts     'In the mixed-tier multi-file scenario, the file whose selection row was deleted (SCRIPT_LOG) reports tier_2_file in its per-file lookup block — the diagnostic surfaces exactly which file dragged the run into mixed-tier territory' \
+        asserts     'In the mixed-tier multi-file scenario, the file whose selection row was deleted (SCRIPT_LOG) reports tier_2_file in its per-file lookup block - the diagnostic surfaces exactly which file dragged the run into mixed-tier territory' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — per-file lookup reports individual tier'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - per-file lookup reports individual tier'
 
     assert_no_line "$out" \
         pattern     '^aggregated_preseed:$' \
-        asserts     'When the run is mixed-tier (index_used=no), the aggregated_preseed block is suppressed — there is no merged pre-seed to report so the section is omitted entirely rather than emitted with empty values' \
+        asserts     'When the run is mixed-tier (index_used=no), the aggregated_preseed block is suppressed - there is no merged pre-seed to report so the section is omitted entirely rather than emitted with empty values' \
         produced_by 'emit_index_readback_verbose() in ltl (aggregated_preseed block gated on index_used=yes)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 3 — Aggregated pre-seed values § "Suppressed when index_used=no"'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 3 - Aggregated pre-seed values section "Suppressed when index_used=no"'
 }
 
 scenario_multi_file_one_stale() {
@@ -862,21 +862,21 @@ scenario_multi_file_one_stale() {
 
     assert_line "$out" \
         pattern     '^index_used: no$' \
-        asserts     'When any file in a multi-file run is stale, the entire run reports index_used=no — multi-file aggregation requires every file to be fresh; one stale file disables pre-seeding for the run' \
+        asserts     'When any file in a multi-file run is stale, the entire run reports index_used=no - multi-file aggregation requires every file to be fresh; one stale file disables pre-seeding for the run' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block; multi-file freshness aggregation)' \
-        contract    'features/179-index-read-back.md § Behavior — Multi-file aggregation § "Any stale file disables pre-seeding"'
+        contract    'features/179-index-read-back.md section Behavior - Multi-file aggregation section "Any stale file disables pre-seeding"'
 
     assert_line "$out" \
         pattern     '^  freshness: stale_mtime$' \
         asserts     'In a multi-file run with one stale file, the per-file lookup block for the stale file reports its specific freshness reason (stale_mtime) so the reader can identify which file caused the run to reject pre-seeding' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block, freshness sub-field)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — locked staleness reason codes'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - locked staleness reason codes'
 
     assert_line "$out" \
         pattern     '^  freshness: fresh$' \
-        asserts     'The non-stale file in a mixed-freshness multi-file run still reports freshness=fresh in its per-file lookup block — per-file freshness is reported independently regardless of the aggregate decision' \
+        asserts     'The non-stale file in a mixed-freshness multi-file run still reports freshness=fresh in its per-file lookup block - per-file freshness is reported independently regardless of the aggregate decision' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file lookup block, freshness sub-field)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — per-file freshness reported independently'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - per-file freshness reported independently'
 }
 
 scenario_malformed_index() {
@@ -895,9 +895,9 @@ scenario_malformed_index() {
 
     assert_line "$out" \
         pattern     '^index_used: no$' \
-        asserts     'When the index file cannot be parsed as valid CSV (mismatched quotes), the read-back path treats it as unusable and the run reports index_used=no — a malformed index must not silently pre-seed with garbage values' \
+        asserts     'When the index file cannot be parsed as valid CSV (mismatched quotes), the read-back path treats it as unusable and the run reports index_used=no - a malformed index must not silently pre-seed with garbage values' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block; CSV-parse-failure branch)' \
-        contract    'features/179-index-read-back.md § Behavior — Malformed index handling; § Acceptance criteria'
+        contract    'features/179-index-read-back.md section Behavior - Malformed index handling; section Acceptance criteria'
 
     assert_command \
         command     'perl -MText::CSV -e '"'"'
@@ -908,9 +908,9 @@ scenario_malformed_index() {
             exit (($err && (split / /, $err)[0] ne "EOF") ? 1 : 0);
         '"'" \
         label       'end-of-run write rewrites malformed index as valid CSV' \
-        asserts     'After a run started against a malformed index, the end-of-run write side overwrites the file with valid CSV — the index file is self-healing on the next run rather than requiring manual cleanup' \
+        asserts     'After a run started against a malformed index, the end-of-run write side overwrites the file with valid CSV - the index file is self-healing on the next run rather than requiring manual cleanup' \
         produced_by 'write_index_file() in ltl (end-of-run #46 write side; full rewrite from in-memory state)' \
-        contract    'features/179-index-read-back.md § Behavior — Malformed index handling § "Self-healing on write"; § Interactions with existing features § "With write side (#46)"'
+        contract    'features/179-index-read-back.md section Behavior - Malformed index handling section "Self-healing on write"; section Interactions with existing features section "With write side (#46)"'
 }
 
 scenario_missing_bound_column() {
@@ -925,21 +925,21 @@ scenario_missing_bound_column() {
 
     assert_line "$out" \
         pattern     '^index_used: yes$' \
-        asserts     'An index row with one bound column blanked out (set to literal "-") is still usable for pre-seeding — index_used reports yes because the rest of the row carries valid data' \
+        asserts     'An index row with one bound column blanked out (set to literal "-") is still usable for pre-seeding - index_used reports yes because the rest of the row carries valid data' \
         produced_by 'emit_index_readback_verbose() in ltl (run-level header block; partial-bounds branch)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § "Missing bound columns are tolerated"'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section "Missing bound columns are tolerated"'
 
     assert_line "$out" \
         pattern     '^  preseed_duration_max: -$' \
-        asserts     'When a specific bound column is "-" in the matched index row, the per-file preseed line for that bound echoes the literal "-" — the reader sees that the bound is unavailable rather than seeing a default that silently masks the gap' \
+        asserts     'When a specific bound column is "-" in the matched index row, the per-file preseed line for that bound echoes the literal "-" - the reader sees that the bound is unavailable rather than seeing a default that silently masks the gap' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file preseed block, per-bound line)' \
-        contract    'features/179-index-read-back.md § "-V verbose output" Layer 2 — Per-file preseed values; locked "-" rendering for missing bounds'
+        contract    'features/179-index-read-back.md section "-V verbose output" Layer 2 - Per-file preseed values; locked "-" rendering for missing bounds'
 
     assert_no_line "$out" \
         pattern     '^  preseed_duration_min: -$' \
-        asserts     'Blanking one bound (duration_max) must not cascade — the other bound columns (duration_min, etc.) still report their seeded values; this confirms per-bound granularity of the missing-bound handling' \
+        asserts     'Blanking one bound (duration_max) must not cascade - the other bound columns (duration_min, etc.) still report their seeded values; this confirms per-bound granularity of the missing-bound handling' \
         produced_by 'emit_index_readback_verbose() in ltl (per-file preseed block, per-bound line emitted per-column)' \
-        contract    'features/179-index-read-back.md § Behavior — Pre-seeded values § "Missing bound columns are tolerated" (per-bound, not row-wide)'
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values section "Missing bound columns are tolerated" (per-bound, not row-wide)'
 }
 
 scenario_expired_selection_entry() {
@@ -960,9 +960,9 @@ scenario_expired_selection_entry() {
     assert_command \
         command     "grep -q '^selection,${current_year}' ltl-index.csv" \
         label       "selection row refreshed with current entry_date (${current_year})" \
-        asserts     'A selection row with entry_date older than the retention horizon (91 days here) is replaced by a fresh selection row at end-of-run write — read-back itself does not expire rows, but the write side does, so expiration is self-healing on the next run' \
+        asserts     'A selection row with entry_date older than the retention horizon (91 days here) is replaced by a fresh selection row at end-of-run write - read-back itself does not expire rows, but the write side does, so expiration is self-healing on the next run' \
         produced_by 'write_index_file() in ltl (end-of-run #46 write side; purges expired rows then writes fresh ones with current entry_date)' \
-        contract    'features/179-index-read-back.md § Interactions with existing features § "With write side (#46)" — expiration semantics delegated to #46; § Behavior — read-back does not expire'
+        contract    'features/179-index-read-back.md section Interactions with existing features section "With write side (#46)" - expiration semantics delegated to #46; section Behavior - read-back does not expire'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -56,8 +56,8 @@ failures=()
 # Per tests/HARNESS-DESIGN.md § Self-documenting assertions, these three
 # fields are surfaced alongside every failure.
 REGRESSION_ASSERTS='ltl output (after stripping ANSI, timing, memory, and other nondeterministic content) is byte-identical to the captured reference file for this scenario'
-REGRESSION_PRODUCED_BY='print_bar_graph(), print_summary_table(), print_heatmap_row(), and the layout engine in ltl — composite rendered output'
-REGRESSION_CONTRACT='tests/HARNESS-DESIGN.md § Self-documenting assertions + this harness re-runs the commands from capture-regression.sh against tests/reference-output/; rebaselining is a per-release activity, not an automatic remediation'
+REGRESSION_PRODUCED_BY='print_bar_graph(), print_summary_table(), print_heatmap_row(), and the layout engine in ltl - composite rendered output'
+REGRESSION_CONTRACT='tests/HARNESS-DESIGN.md section Self-documenting assertions + this harness re-runs the commands from capture-regression.sh against tests/reference-output/; rebaselining is a per-release activity, not an automatic remediation'
 
 # Emit a regression-suite failure in the self-documenting multi-line form
 # required by tests/HARNESS-DESIGN.md § Self-documenting assertions.

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -164,31 +164,31 @@ scenario_runtime_config_command_line() {
         pattern     '^=== runtime-config ===$' \
         asserts     'The runtime-config -V section header is emitted whenever -V runtime-config (or bare -V) is requested.' \
         produced_by 'emit_runtime_config_verbose() in ltl' \
-        contract    'tests/HARNESS-DESIGN.md § Reserved section names — runtime-config is stability-contracted'
+        contract    'tests/HARNESS-DESIGN.md section Reserved section names - runtime-config is stability-contracted'
 
     assert_line "$RUN_STDOUT" \
         pattern     '^=== runtime-config / command-line ===$' \
         asserts     'The command-line sub-section is always present per the locked contract; empty body means no flags supplied on the CLI.' \
         produced_by 'emit_runtime_config_verbose() in ltl (Issue #231 section)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — command-line sub-section always emits'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - command-line sub-section always emits'
 
     assert_line "$RUN_STDOUT" \
         pattern     '^bucket-size: 60$' \
         asserts     'A flag supplied on the CLI with a valid value appears in the command-line sub-section with the resolved value and no annotation.' \
         produced_by 'emit_runtime_config_verbose() in ltl (command-line sub-section body)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — value with no annotation means user-supplied, valid, unchanged'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - value with no annotation means user-supplied, valid, unchanged'
 
     assert_line "$RUN_STDOUT" \
         pattern     '^percentile-precision: 7$' \
         asserts     'Multi-flag invocation surfaces each supplied flag as its own row in command-line sub-section.' \
         produced_by 'emit_runtime_config_verbose() in ltl' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 
     assert_line "$RUN_STDOUT" \
         pattern     '^=== END runtime-config / command-line ===$' \
-        asserts     'command-line sub-section closes with its END delimiter per HARNESS-DESIGN.md § Delimiter contract.' \
+        asserts     'command-line sub-section closes with its END delimiter per HARNESS-DESIGN.md section Delimiter contract.' \
         produced_by 'emit_runtime_config_verbose() in ltl' \
-        contract    'tests/HARNESS-DESIGN.md § Delimiter contract'
+        contract    'tests/HARNESS-DESIGN.md section Delimiter contract'
 }
 
 scenario_runtime_config_env_only() {
@@ -201,13 +201,13 @@ scenario_runtime_config_env_only() {
         pattern     '^=== runtime-config / environment-variable ===$' \
         asserts     'The environment-variable sub-section is always present per the locked contract.' \
         produced_by 'emit_runtime_config_verbose() in ltl' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — env-var sub-section always emits'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - env-var sub-section always emits'
 
     assert_line "$TMP_DIR/rc-env.stdout" \
         pattern     '^bucket-size: 30$' \
         asserts     'A flag supplied via LTL_CONFIG with no CLI override appears in the environment-variable sub-section with no annotation.' \
         produced_by 'emit_runtime_config_verbose() in ltl (environment-variable sub-section body)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 }
 
 scenario_runtime_config_env_overridden() {
@@ -220,13 +220,13 @@ scenario_runtime_config_env_overridden() {
         pattern     '^bucket-size: 60$' \
         asserts     'When the same flag appears in both env and CLI, the command-line sub-section row carries the resolved (CLI-supplied) value with no annotation.' \
         produced_by 'emit_runtime_config_verbose() in ltl (command-line sub-section)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — CLI wins; env-side carries override annotation'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - CLI wins; env-side carries override annotation'
 
     assert_line "$TMP_DIR/rc-over.stdout" \
         pattern     '^bucket-size: 60; overridden$' \
         asserts     'When the same flag appears in both env and CLI, the environment-variable sub-section row carries `; overridden` annotation. (The displayed value is the resolved CLI value; reconstructing the original env value is out of scope.)' \
         produced_by 'emit_runtime_config_verbose() in ltl (environment-variable sub-section)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — annotation grammar uses semicolon-separated `; overridden`'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - annotation grammar uses semicolon-separated `; overridden`'
 }
 
 scenario_warning_g_non_numeric() {
@@ -239,7 +239,7 @@ scenario_warning_g_non_numeric() {
         pattern     "^-g value 'bogus_value' is not numeric; treating as positional argument and using default threshold 85\\.$" \
         asserts     'When -g is given a non-numeric value, ltl now warns to stderr that the value was treated as a positional argument and the default threshold 85 was used. Was previously silent.' \
         produced_by 'adapt_to_command_line_options() in ltl (group-similar non-numeric branch)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — silent-override gap closure'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - silent-override gap closure'
 }
 
 scenario_warning_hm_non_builtin() {
@@ -252,7 +252,7 @@ scenario_warning_hm_non_builtin() {
         pattern     "^-hm value 'bogus_metric' is not a built-in metric \\(duration\\|bytes\\|count\\) and no -udm configs are defined; treating as positional argument and using default metric 'duration'\\.$" \
         asserts     'When -hm is given a value that is neither a built-in metric nor matchable to a -udm config (because no -udm was given), ltl now warns that the value was treated as a positional argument and the default metric was used. Was previously silent.' \
         produced_by 'adapt_to_command_line_options() in ltl (heatmap non-builtin pushback branch)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — silent-override gap closure'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - silent-override gap closure'
 }
 
 scenario_warning_pbpd_overrides_pp() {
@@ -265,7 +265,7 @@ scenario_warning_pbpd_overrides_pp() {
         pattern     '^-pbpd 100 overrides --percentile-precision 7; using 100 buckets per decade\.$' \
         asserts     'When both -pbpd and --percentile-precision are supplied, -pbpd wins. The override is now surfaced on stderr in addition to the -V histogram-bin-counters annotation it already had. Was previously only visible via -V.' \
         produced_by 'adapt_to_command_line_options() in ltl (percentile-precision resolution; -pbpd-wins branch)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — silent-override gap closure'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - silent-override gap closure'
 }
 
 scenario_error_unknown_exact_percentiles() {
@@ -277,13 +277,13 @@ scenario_error_unknown_exact_percentiles() {
     assert_exit "$RUN_EXIT" 1 \
         asserts     '--exact-percentiles is not a known flag; ltl rejects it as an unknown option and exits non-zero. The flag is no longer part of the CLI surface; opt-out is via the per-surface data-model selector (-dm raw / -hgdm raw / -hmdm raw / -mdm raw / -bdm raw) per Issue #266.' \
         produced_by 'Getopt::Long rejecting an unrecognized long option in adapt_to_command_line_options()' \
-        contract    'Issue #266 + Issue #287 — --exact-percentiles was the legacy F2/F3 opt-out; the data-model selectors are the locked replacement.'
+        contract    'Issue #266 + Issue #287 - --exact-percentiles was the legacy F2/F3 opt-out; the data-model selectors are the locked replacement.'
 
     assert_line "$RUN_STDERR" \
         pattern     '^Unknown option: exact-percentiles' \
         asserts     'The user-visible error names the unknown option so the user knows which flag was rejected.' \
         produced_by 'Getopt::Long default error formatter' \
-        contract    'Issue #266 + Issue #287 — flag-removal error surface.'
+        contract    'Issue #266 + Issue #287 - flag-removal error surface.'
 }
 
 # Issue #287: assert that the per-surface data-model selectors surface in
@@ -299,20 +299,20 @@ scenario_runtime_config_data_model_selectors() {
     assert_line "$RUN_STDOUT" \
         pattern     '^message-stats-data-model: bin$' \
         asserts     'A user-supplied -mdm bin appears in the runtime-config / command-line sub-section with its resolved value and no annotation, per #266 + #231.' \
-        produced_by 'emit_runtime_config_verbose() in ltl — %resolved_values lookup for message-stats-data-model' \
-        contract    'features/266-data-model-selectors.md § -V runtime-config surfacing + features/287-message-stats-bin-counter-data-model.md § R8.3 — selector row format is locked.'
+        produced_by 'emit_runtime_config_verbose() in ltl - %resolved_values lookup for message-stats-data-model' \
+        contract    'features/266-data-model-selectors.md section -V runtime-config surfacing + features/287-message-stats-bin-counter-data-model.md section R8.3 - selector row format is locked.'
 
     assert_line "$RUN_STDOUT" \
         pattern     '^bucket-stats-data-model: bin$' \
         asserts     'A user-supplied -bdm bin appears in the runtime-config / command-line sub-section with its resolved value and no annotation, per #266 + #231 (Issue #289 honors -bdm bin end-to-end).' \
-        produced_by 'emit_runtime_config_verbose() in ltl — %resolved_values lookup for bucket-stats-data-model' \
-        contract    'features/266-data-model-selectors.md § -V runtime-config surfacing + features/289-bucket-stats-bin-counter-data-model.md — selector row format is locked.'
+        produced_by 'emit_runtime_config_verbose() in ltl - %resolved_values lookup for bucket-stats-data-model' \
+        contract    'features/266-data-model-selectors.md section -V runtime-config surfacing + features/289-bucket-stats-bin-counter-data-model.md - selector row format is locked.'
 
     assert_line "$RUN_STDOUT" \
         pattern     '^data-model: bin$' \
         asserts     'A user-supplied omnibus -dm bin appears as the data-model row in the command-line sub-section, alongside any per-surface override.' \
         produced_by 'emit_runtime_config_verbose() in ltl' \
-        contract    'features/266-data-model-selectors.md § -V runtime-config surfacing.'
+        contract    'features/266-data-model-selectors.md section -V runtime-config surfacing.'
 }
 
 scenario_error_unknown_so() {
@@ -323,7 +323,7 @@ scenario_error_unknown_so() {
     assert_exit "$RUN_EXIT" 1 \
         asserts     '-so with an unknown enum value is a hard error and exits with code 1.' \
         produced_by 'adapt_to_command_line_options() in ltl (sort-on enum validation), via print_usage() exit 1' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — hard-error paths pin current exit code; exit-code policy normalization is deferred to a separate ticket per scoping decision'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - hard-error paths pin current exit code; exit-code policy normalization is deferred to a separate ticket per scoping decision'
 
     # ltl emits the error banner (including "Error: invalid sort type used") on
     # stdout via print_usage(); only the bare "Died at ..." Perl trace goes to
@@ -332,7 +332,7 @@ scenario_error_unknown_so() {
         pattern     'invalid sort type' \
         asserts     'The user-visible diagnostic (emitted via print_usage to stdout) identifies the failed validation (sort type).' \
         produced_by 'print_usage("invalid sort type used") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — pinning current diagnostic surface; new error-format normalization is out of scope'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - pinning current diagnostic surface; new error-format normalization is out of scope'
 }
 
 scenario_error_unknown_du() {
@@ -343,13 +343,13 @@ scenario_error_unknown_du() {
     assert_exit "$RUN_EXIT" 1 \
         asserts     '-du with an unknown enum value is a hard error (exit 1 via print_usage).' \
         produced_by 'adapt_to_command_line_options() in ltl (duration-unit enum validation)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 
     assert_line "$RUN_STDOUT" \
         pattern     "Invalid duration unit" \
         asserts     'The user-visible diagnostic (stdout) identifies the failed validation (duration unit).' \
         produced_by 'print_usage("Invalid duration unit ...") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 }
 
 scenario_error_unknown_ru() {
@@ -360,13 +360,13 @@ scenario_error_unknown_ru() {
     assert_exit "$RUN_EXIT" 1 \
         asserts     '-ru with an unknown enum value is a hard error (exit 1 via print_usage).' \
         produced_by 'adapt_to_command_line_options() in ltl (rate-unit enum validation)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 
     assert_line "$RUN_STDOUT" \
         pattern     "Invalid rate unit" \
         asserts     'The user-visible diagnostic (stdout) identifies the failed validation (rate unit).' \
         produced_by 'print_usage("Invalid rate unit ...") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 }
 
 scenario_error_no_files() {
@@ -381,13 +381,13 @@ scenario_error_no_files() {
     assert_exit "$RUN_EXIT" 2 \
         asserts     'A non-existent file path is a hard error after glob expansion produces no matches (exit 2, distinct from the print_usage exit-1 paths).' \
         produced_by 'adapt_to_command_line_options() in ltl (post-glob @in_files empty check)' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — exit-code disparity (1 vs 2) intentionally pinned; harmonization deferred to a separate ticket'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - exit-code disparity (1 vs 2) intentionally pinned; harmonization deferred to a separate ticket'
 
     assert_line "$RUN_STDOUT" \
         pattern     'unable to open any files' \
         asserts     'The user-visible diagnostic (stdout) surfaces the empty-@in_files condition.' \
         produced_by 'print_usage("unable to open any files") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231'
 }
 
 scenario_no_warning_on_clean_run() {
@@ -405,7 +405,7 @@ scenario_no_warning_on_clean_run() {
         pattern     "is not numeric|is not a built-in metric|overrides --percentile-precision|--exact-percentiles is deprecated" \
         asserts     'A clean run produces none of the four silent-override warnings. This guards against the warnings firing on inputs they were not designed for.' \
         produced_by 'adapt_to_command_line_options() in ltl' \
-        contract    'features/225-test-harness-coverage-gaps.md § #231 — warnings are gated on specific input shapes'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - warnings are gated on specific input shapes'
 }
 
 # ---------- Run -----------------------------------------------------------

--- a/tests/validate-statistics.sh
+++ b/tests/validate-statistics.sh
@@ -122,12 +122,12 @@ if [[ $L3_ENABLED -eq 1 ]]; then
         echo "       Install command depends on which Python this is:" >&2
         case "$PY" in
             /opt/homebrew/*|/usr/local/Cellar/*|/usr/local/opt/*)
-                echo "         $PY is Homebrew Python — PEP 668 blocks 'pip install --user'." >&2
+                echo "         $PY is Homebrew Python - PEP 668 blocks 'pip install --user'." >&2
                 echo "         Install via brew (numpy and scipy ship as brew formulas):" >&2
                 echo "           brew install numpy scipy" >&2
                 ;;
             /Library/Developer/CommandLineTools/*|/usr/bin/*)
-                echo "         $PY is Apple Command-Line-Tools Python — pip --user works:" >&2
+                echo "         $PY is Apple Command-Line-Tools Python - pip --user works:" >&2
                 echo "           $PY -m pip install --user numpy scipy" >&2
                 ;;
             *)


### PR DESCRIPTION
Closes #291.

## Problem

Non-ASCII characters in machine-parseable output put `grep` into binary mode, silently suppressing matches unless `-a` is passed. A search for an expected line then returns nothing — reading as "the line is missing" rather than "the encoding broke the match."

## Change

Restrict the two emitted surfaces to ASCII:

- **`ltl` `-V` output**: the consolidation `Reduction: N -> N` line (2 spots) now uses `->` instead of the rightwards-arrow glyph.
- **`tests/validate-*.sh` assertion metadata and diagnostics**: `§` → `section`, `—` (em-dash) → `-`, `→` → `->`. Four emitted descriptions that embedded box-drawing glyphs (e.g. `(┌┬┐)`, `no ┴/┻/┼/╋`) are reworded into plain words.

## Intentionally untouched

- Box-drawing glyphs in **regex match-patterns** (`pattern '│'`, `qr/[\x{2534}...]/`) — they validate `ltl`'s rendered output.
- `ltl` visual rendering (bar graphs / histograms / heatmaps) and `--explain` prose — not `-V` machine output.
- Code comments and `tests/HARNESS-DESIGN.md` — never emitted.
- The `Welford-Pébay` proper-name accent — preserved where it must match `ltl` output.

## Verification

- `perl -c ltl` OK; `bash -n` OK on all 14 harnesses.
- All touched harnesses run **exit 0**.
- `validate-help-content.sh` has one **pre-existing, unrelated** failure (`bucket-stats-buckets-per-decade` missing from `docs/usage.md` on the clean release branch) — out of scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)