### PR TITLE
Issue #293: Unify the precision lever (--data-model-precision)

### DIFF
--- a/docs/explain/histogram.md
+++ b/docs/explain/histogram.md
@@ -77,7 +77,7 @@ ltl -hg duration,bytes access.log             # multiple histograms in one invoc
 ltl -hg duration -hgw 50 access.log           # narrow histogram (50% of terminal)
 ltl -hg duration -hgh 16 access.log           # taller histogram (16 rows vs default 8)
 ltl -hg duration -h "/api/v2/" access.log     # overlay highlight of matching entries
-ltl -hg duration -pp 7 access.log             # tighter percentile precision (slower)
+ltl -hg duration -dmp 7 access.log            # tighter precision (slower)
 ```
 
 ---
@@ -93,7 +93,7 @@ ltl -hg duration -pp 7 access.log             # tighter percentile precision (sl
 
 ## How ltl renders this
 
-The histogram uses log-spaced bins with HDR-histogram-style precision. Default precision (53 buckets per decade, controlled by `-pbpd`) gives ~1.3% resolution. The histogram width (default 95% of terminal) and height (default 8 rows) are tunable via `-hgw` and `-hgh`. Highlight overlays (`-h regex`) render colored sub-bars within each main bar, showing the proportion of highlighted entries at each value range. The percentile tick marks on the baseline are computed from the same observations as the summary-table p99/p999 values, so the visual ticks and the numeric statistics agree by construction.
+The histogram uses log-spaced bins with HDR-histogram-style precision. Bin-counter resolution is controlled by `--data-model-precision` (tier 1..9, default 5); higher tiers give finer resolution. The histogram width (default 95% of terminal) and height (default 8 rows) are tunable via `-hgw` and `-hgh`. Highlight overlays (`-h regex`) render colored sub-bars within each main bar, showing the proportion of highlighted entries at each value range. The percentile tick marks on the baseline are computed from the same observations as the summary-table p99/p999 values, so the visual ticks and the numeric statistics agree by construction.
 
 ---
 
@@ -103,4 +103,4 @@ The histogram uses log-spaced bins with HDR-histogram-style precision. Default p
 - `ltl --explain percentiles` — what p50, p95, p99, p999, p9999, p99999 mean and how to read them
 - `ltl --explain iqr` — the body-spread statistic that pairs with p25/p75
 - `ltl --explain skewness`, `ltl --explain kurtosis`, `ltl --explain bimodality_coef` — distribution-shape statistics that quantify what the histogram shows
-- Flags: `-hg`, `-hgw`, `-hgh`, `-pbpd`, `-pp`, `-ep`
+- Flags: `-hg`, `-hgw`, `-hgh`, `-dmp`

--- a/docs/explain/statistics.md
+++ b/docs/explain/statistics.md
@@ -199,14 +199,14 @@ Percentiles answer the question "what value is faster than (or equal to) N% of a
 ```text
 ltl -so p999 -n 20 access.log         # find APIs with the worst p999 tail latency
 ltl -so p9999 -n 20 access.log        # tail-of-tail analysis; needs many samples
-ltl -pp 7 access.log                  # tighten percentile precision (slower; more memory)
+ltl -dmp 7 access.log                 # tighten precision (slower; more memory)
 ```
 
 **How ltl computes this.** ltl computes percentiles from one of two data models, each using its own algorithm. The two models answer slightly different questions about the same data and produce different values, especially at the tail percentiles. Neither is "the truth" relative to the other — both are valid; the right one depends on what you're trying to learn.
 
 **Raw values data model** — every observation is held in memory; the percentile is selected by **nearest-rank**, i.e. an actually-observed sample at the computed rank in the sorted array. The returned `p99` is a real request that happened. No interpolation, no synthesised values.
 
-**Bin counter data model** — observations are accumulated into log-spaced bins; the percentile is computed by **exponential interpolation within the bucket**, a synthesised value placed inside the bin that contains the target rank on the log scale spanning the bin's lower and upper edges. The returned value is generally not an observed sample. Bin resolution determines how tight the interpolation is — the default 53 buckets per decade gives roughly 1.3% relative bin width.
+**Bin counter data model** — observations are accumulated into log-spaced bins; the percentile is computed by **exponential interpolation within the bucket**, a synthesised value placed inside the bin that contains the target rank on the log scale spanning the bin's lower and upper edges. The returned value is generally not an observed sample. Bin resolution determines how tight the interpolation is; it is governed by the precision lever (`--data-model-precision`).
 
 **Why the values differ.** Nearest-rank returns a real sample; within-bucket interpolation returns a synthesised value inside the matching log-spaced bin. On the same input the two algorithms will report different `p99` (and other percentile) values, particularly in the tail. This is the data model, not a precision deviation. If you switch a surface between models, expect the percentile column to move.
 
@@ -218,9 +218,9 @@ ltl -pp 7 access.log                  # tighten percentile precision (slower; mo
 
 **Resource cost comparison.** The raw values data model scales with observation count: every sample occupies its own slot until the run completes. The bin counter data model scales with bin count: one partition per logical series, with a fixed bin footprint per partition regardless of how many observations stream through it. On small inputs the two are comparable; as sample counts grow the raw cost climbs linearly while the bin cost stays flat per partition. The crossover depends on how many distinct partitions you have — many low-volume series favour the raw values data model; few high-volume series favour the bin counter data model.
 
-**Flags.** Surfaces use sensible internal defaults (see the data-model selectors in `--help`); `--data-model raw` and `--data-model bin` pin every surface to one model. Per-surface selectors (`--histogram-data-model`, `--heatmap-data-model`, `--message-stats-data-model`, `--bucket-stats-data-model`) override the global setting. Bin resolution is tuned with `--percentile-buckets-per-decade` (default 53) or `--percentile-precision` (named tiers 1..9).
+**Flags.** Surfaces use sensible internal defaults (see the data-model selectors in `--help`); `--data-model raw` and `--data-model bin` pin every surface to one model. Per-surface selectors (`--histogram-data-model`, `--heatmap-data-model`, `--message-stats-data-model`, `--bucket-stats-data-model`) override the global setting. Bin resolution is tuned with `--data-model-precision` (tier 1..9, default 5).
 
-**See also.** `min`, `max`, `iqr`, `skewness`, `kurtosis`, `bimodality_coef`. Flags: `--percentile-buckets-per-decade`, `--percentile-precision`, `--data-model`.
+**See also.** `min`, `max`, `iqr`, `skewness`, `kurtosis`, `bimodality_coef`. Flags: `--data-model-precision`, `--data-model`.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -198,7 +198,7 @@ ltl computes percentiles from one of two data models, each with its own algorith
 
 **Raw values data model.** Every observation is held in memory and the percentile is selected by **nearest-rank** — an actually-observed sample at the computed rank in the sorted array. The returned value is a real request that happened. Scales with observation count.
 
-**Bin counter data model.** Observations are accumulated into log-spaced bins and the percentile is computed by **exponential interpolation within the bucket** — a synthesised value placed inside the bin that contains the target rank, on the log scale spanning the bin's lower and upper edges. The returned value is generally not an observed sample. Bin resolution sets the interpolation tightness — the default of 53 buckets per decade gives roughly 1.3% relative bin width. Scales with partition count rather than observation count.
+**Bin counter data model.** Observations are accumulated into log-spaced bins and the percentile is computed by **exponential interpolation within the bucket** — a synthesised value placed inside the bin that contains the target rank, on the log scale spanning the bin's lower and upper edges. The returned value is generally not an observed sample. Bin resolution sets the interpolation tightness; it is governed by the precision lever (see *Tuning precision* below). Scales with partition count rather than observation count.
 
 **Per-surface defaults.** Four consumer surfaces use percentile output; each has a default data model today:
 
@@ -221,26 +221,22 @@ ltl computes percentiles from one of two data models, each with its own algorith
 
 Per-surface flag overrides `-dm`; `-dm` overrides the per-surface default. Invalid values (anything other than `raw` or `bin`) cause ltl to exit at option-parse time with a clear error. Conflicting flags on the same axis follow standard last-one-wins ordering.
 
-**Tuning the bin counter algorithm.** When a surface uses the bin counter data model, bin resolution determines how tight the within-bucket interpolation is. Raise resolution for tighter values in the tail percentiles (`p999`, `p9999`); lower it to reduce per-partition memory cost. The default (tier 5 / 53 bpd) suits most analyses.
+**Tuning precision.** A single lever sets how finely the bin counter surfaces resolve. Raise it for tighter values in the tail percentiles (`p999`, `p9999`); lower it to reduce per-partition memory cost. The default suits most analyses — you rarely need to touch it.
 
 | Option | Description |
 |--------|-------------|
-| `-pp, --percentile-precision <N>` | Precision tier 1..9 (default: 5). Higher tiers give tighter percentile values at the cost of more memory per partition. |
-| `-pbpd, --percentile-buckets-per-decade <N>` | Buckets per decade directly (default: 53; valid 4..616). Overrides `--percentile-precision` when both supplied. |
+| `-dmp, --data-model-precision <N>` | Precision tier 1..9 (default: 5). Higher tiers give finer resolution on the bin counter surfaces at higher memory cost. |
 
-Per-message-key percentiles are the highest-cost consumer because they fan out to one partition per unique message; tier 1–4 trades resolution for less memory there. The histogram and heatmap surfaces are unaffected — they use their own internal resolution tuned for display rendering and ignore these knobs.
+Precision increases in stages across the surfaces as you raise the tier, so the lever buys fidelity where it costs least first. Above the default, the histogram and heatmap are already at their finest, and the per-time-bucket statistics sharpen ahead of the per-message-key statistics — the per-message surface is the highest-cost consumer (one partition per unique message), so it reaches full resolution last. Below the default, every bin counter surface coarsens, including the histogram and heatmap shape.
 
-Use `-V histogram-bin-counters` to inspect the resolved precision, the source (default, flag, or override), and per-consumer state.
+Use `-V histogram-bin-counters` to inspect the resolved tier and its source, and `-V percentile-algorithm` to see each surface's resolved resolution.
 
 ```bash
 # Default behavior (per-surface defaults above)
 ltl access.log
 
 # Higher precision tier for tight tail-percentile analysis
-ltl -pp 7 access.log
-
-# Direct buckets-per-decade override
-ltl -pbpd 100 access.log
+ltl -dmp 7 access.log
 
 # Pin every surface to the raw values data model
 ltl -dm raw access.log
@@ -310,10 +306,7 @@ Histograms show the overall distribution shape of a metric across the entire tim
 | `-hg, --histogram [metric]` | Show an overall distribution histogram after the bar graph (`duration`, `bytes`, or `count`) |
 | `-hgw, --histogram-width <N>` | Histogram width as percentage of terminal (default: 95) |
 | `-hgh, --histogram-height <N>` | Histogram height in rows (default: 8) |
-| `-hgbpd, --histogram-buckets-per-decade <N>` | Bar resolution: bars per order-of-magnitude of value range (default: 8) |
-| `-hgb, --histogram-buckets <N>` | Override total histogram bucket count (default: 0 = auto-calculate from `-hgbpd`) |
-
-**Bar resolution (`-hgbpd`).** The default of 8 gives roughly the bar density of the legacy histogram and is suitable for most analyses. Raise it (16, 32, 53) when the default's bars look too wide to distinguish distinct modes in the data — each step gives narrower, more numerous bars and a more detailed distribution shape, at the cost of proportionally more memory during analysis. Values above 53 rarely add visible detail at typical histogram heights.
+| `-hgb, --histogram-buckets <N>` | Override total histogram bucket count (default: 0 = auto-calculate) |
 
 ```bash
 # Show duration and bytes histograms side by side
@@ -322,8 +315,6 @@ ltl -hg duration,bytes access.log
 ltl -hg duration -hgh 15 access.log
 # All available metric histograms
 ltl -hg access.log
-# Higher bar resolution to distinguish closely-spaced modes
-ltl -hg duration -hgbpd 16 access.log
 ```
 
 ### User-Defined Metrics
@@ -412,7 +403,6 @@ Section content is governed by per-section stability contracts — additions are
 |---------|---------|
 | `-g <non-numeric>` (e.g. `-g logfile.log`) | The non-numeric value is treated as a positional argument and the default similarity threshold (85) is applied. |
 | `-hm <unknown-metric>` without any `-udm` configured (e.g. `-hm bogus`) | The value is treated as a positional argument and the default heatmap metric (`duration`) is applied. |
-| Both `-pbpd` and `--percentile-precision` supplied | `-pbpd` wins; the warning surfaces the override so it is visible without `-V`. |
 | `--data-model`, `--histogram-data-model`, `--heatmap-data-model`, `--message-stats-data-model`, or `--bucket-stats-data-model` supplied with a value other than `raw` or `bin` | ltl exits with `<flag>: '<value>' is not a valid data model; valid values are 'raw' and 'bin'`. |
 
 To inspect the resolved configuration after warnings have fired, use `-V runtime-config` and read the `command-line` and `environment-variable` sub-sections.

--- a/features/187-histogram-bin-counter-percentiles.md
+++ b/features/187-histogram-bin-counter-percentiles.md
@@ -1124,6 +1124,19 @@ Non-binding guidance for #189's implementation — the contract above is what mu
 
 **Per-surface resolution (amended 2026-05-27, #289).** The default 53 is the global **floor**, appropriate for unbounded-cardinality surfaces (the per-message-key surface can hold millions of partitions, where 53 keeps memory bounded). A surface with bounded partition cardinality may pin a finer resolution through its own lever without violating the uniform contract: only the *algorithm, lifecycle, in-bin rule, and out-of-range handling* are uniform across consumers (per F1 / Decisions 1, 4, 5) — the precision parameter is explicitly an analyst's lever and is therefore legitimately per-surface. The per-time-bucket statistics surface (#289) exposes `-bsbpd` / `--bucket-stats-buckets-per-decade` (same `=i` form, 4..616 range, mirroring `-pbpd`). Its memory-vs-accuracy sweep on the canonical datasets kept the per-time-bucket **default at 53** — finer resolution costs ~linear memory (53→616 ≈ 6.5× per partition) while measurably improving only p99/p999 on heavily-quantized data, and the worst tail gaps there are the algorithmic nearest-rank-vs-interpolation difference that finer bins cannot close — so finer is the analyst's opt-in for SRE precision work, not the default. Each surface's effective resolution is observable as `effective_bpd` in the `-V percentile-algorithm` section.
 
+> **Amendment 2026-05-27 (#293) — single precision lever, per-surface tier table. This supersedes the two-flag surface and the per-surface raw flags below.** The resolution knob is now a **single tiered lever**, `--data-model-precision` / `-dmp` (1..9, default 5). Per-surface fidelity is no longer set by separate raw flags; instead one tier resolves a per-surface bins-per-decade through a locked table (source of truth: `features/293-precision-lever-unification.md`):
+>
+> | Surface | 1 | 2 | 3 | 4 | **5** | 6 | 7 | 8 | 9 |
+> |---|--|--|--|--|--|--|--|--|--|
+> | Histogram | 53 | 80 | 115 | 256 | **616** | 616 | 616 | 616 | 616 |
+> | Heatmap | 53 | 80 | 115 | 256 | **616** | 616 | 616 | 616 | 616 |
+> | Bucket-stats | 16 | 32 | 53 | 53 | **53** | 115 | 616 | 616 | 616 |
+> | Per-message | 4 | 8 | 16 | 32 | **53** | 80 | 115 | 256 | 616 |
+>
+> Tier 5 (default) reproduces the established per-surface defaults (histogram/heatmap 616, bucket-stats 53, per-message 53), so the default is behavior-neutral. Above tier 5 the bounded-cardinality surfaces sharpen faster than the unbounded per-message surface (bucket-stats reaches 616 at tier 7; per-message at tier 9), giving the SRE "sharp per-time-bucket, finely-tunable per-message" without a second flag. Below tier 5 every bin surface coarsens, including histogram/heatmap (a deliberate trade against shape fidelity — turning the dial down is an explicit choice).
+>
+> The removed raw flags — `-pbpd` / `--percentile-buckets-per-decade`, `-bsbpd` / `--bucket-stats-buckets-per-decade`, and the legacy display knob `-hgbpd` / `--histogram-buckets-per-decade` — no longer exist. There is no `-pbpd`-wins conflict logic (no competing flags remain). The histogram's visual bar density is unchanged (fixed internal display geometry, distinct from the data-model resolution this lever governs). Validation is the tier range 1..9 (out-of-range warns and resets to 5). The per-surface `effective_bpd` in `-V percentile-algorithm` remains authoritative for each surface's resolved resolution.
+
 **CLI flag surface (contract)**:
 
 1. **Numeric lever** (development/testing/research):
@@ -1479,6 +1492,12 @@ Non-binding.
 ### Decision 8 — `-V` reporting verbosity and format — **LOCKED (2026-05-19); section name amended 2026-05-20**
 
 > **Amendment 2026-05-20 (#34 Phase 2)**: section name changed from `=== PERCENTILE MODE ===` to `=== BIN-COUNTER MODE ===`. The substrate is HdrHistogram-style histogram bin counters; percentiles are one of three derivations from it, alongside bin counts (`histogram_bins`) and cell colors (`heatmap_cells`), which are not percentiles. The original name described the output of one consumer family; the amended name describes the substrate the entire contract is built on. Function name in code amended from `emit_percentile_mode_verbose` to `emit_bin_counter_mode_verbose` for the same reason. The user-facing `--exact-percentiles` / `-ep` flag is unchanged — it correctly names the user's choice rather than the substrate. All field names, consumer-name strings, and per-consumer field-name lockings within Decision 8 remain in effect verbatim.
+
+> **Amendment 2026-05-27 (#293) — run-level precision lines.** The single precision lever (Decision 2 #293 amendment) re-locks the two run-level lines below:
+> - The `percentile_precision:` line is **renamed** to `data_model_precision: <TIER> (<source>)`, where `<TIER>` is 1..9 and `<source>` is `default` or `--data-model-precision N`. The `n/a` rendering (for non-tier `-pbpd` values) is dissolved — with only the tiered lever, every value maps to a tier, so `n/a` can no longer occur. The `; overridden` source annotation is dissolved — no competing flag remains.
+> - The run-level `buckets_per_decade:` line is **removed**. Resolution is now per-surface (one tier yields a different bpd per surface), so a single run-level bpd would be ambiguous. The authoritative per-surface resolution is the `effective_bpd:` line in the `=== percentile-algorithm ===` section, one per surface.
+>
+> All other Decision 8 field names, consumer-name strings, and per-consumer lockings remain in effect verbatim.
 
 #### Contract
 

--- a/features/293-precision-lever-unification.md
+++ b/features/293-precision-lever-unification.md
@@ -1,0 +1,131 @@
+# Issue #293 — Unify the precision lever
+
+Rename `--percentile-precision` → `--data-model-precision` (tiered 1..9, default 5),
+make it the single resolution knob, derive each bin-counter surface's bins-per-decade
+from the tier, and remove the raw bpd flags (`-pbpd`, `-bsbpd`).
+
+This reopens #187 Decision 2 (the locked precision-lever contract) and must be re-locked
+there.
+
+## Scope and sequencing
+
+Both phases land in this ticket, on branch `293-unify-precision-lever`, as two commits.
+The flag removal is not deferred — it happens here.
+
+**Commit 1 — the single lever.** Rename `--percentile-precision` → `--data-model-precision`
+(short form `-dmp`), tiered 1..9, default 5. The tier resolves a **per-surface** bpd via
+the table below — each surface reads its own row, not one shared bpd. All four bin-counter
+surfaces derive their resolution from this one lever.
+
+**Commit 2 — remove the redundant knobs.** Delete `-pbpd` / `--percentile-buckets-per-decade`
+and `-bsbpd` / `--bucket-stats-buckets-per-decade` outright. Resolve the data-model-selector
+(`-hgdm`/`-hmdm`/`-mdm`/`-bdm`/`-dm`) vs. precision categorization so their relationship is
+clear: the selectors choose *which* data model a surface uses (raw vs. bin); the precision
+lever sets *how finely* the bin model resolves. There is no precedence/conflict logic between
+the lever and the removed flags — the flags simply no longer exist.
+
+## Precision-tier → bins-per-decade (source of truth)
+
+| Surface | **1** | **2** | **3** | **4** | **5** *(default)* | **6** | **7** | **8** | **9** |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| **Histogram** | 53 | 80 | 115 | 256 | **616** | 616 | 616 | 616 | 616 |
+| **Heatmap** | 53 | 80 | 115 | 256 | **616** | 616 | 616 | 616 | 616 |
+| **Bucket-stats** | 16 | 32 | 53 | 53 | **53** | 115 | 616 | 616 | 616 |
+| **Per-message** | 4 | 8 | 16 | 32 | **53** | 80 | 115 | 256 | 616 |
+
+### Intent encoded in the curves
+
+- **Tier 5 is the default and reproduces today's per-message and bucket-stats behavior**
+  (both 53 bpd). A user who never touches the lever sees no change on those surfaces.
+- **Above tier 5, bucket-stats climbs faster than per-message and reaches 616 earlier**
+  (tier 7 vs tier 9). This lets one lever serve the SRE case "sharp per-time-bucket
+  percentiles, coarser per-message" without a second flag:
+  - tier 7 → bucket-stats 616, per-message 115
+  - tier 8 → bucket-stats 616, per-message 256
+  - tier 9 → both 616
+  Tiers 8–9 tune per-message only (bucket-stats already maxed at 7).
+- **Per-message is the slow climber** — it is the highest-cardinality surface (one
+  partition per log key, 10⁵+), so bpd multiplies its memory hardest. It only reaches
+  616 at tier 9, the explicit "I accept the memory" setting.
+- **Bucket-stats steps 53 → 115 → 616** (it does not stop at 256).
+
+### Open points flagged against the current code
+
+- **Histogram and heatmap are pinned at 616 today** (`$histogram_stream_bpd`,
+  `$heatmap_stream_bpd`) with no exposed lever. The table above lets the lever *coarsen*
+  them below tier 5 (53/80/115/256) — a **new behavior**, not a codification of current
+  behavior.
+
+## Observability (verbose `-V` output)
+
+The `-V percentile-algorithm` section is the trace surface for this feature. It must let a
+human (and the #224 L3 oracle) confirm that the table was applied: which tier is active,
+where it came from, and the bpd each surface resolved to.
+
+- **Tier line.** Rename the existing `-V` content key `percentile_precision:` →
+  `data_model_precision:`, emitted as `data_model_precision: <tier> (<source>)`. The
+  `<source>` annotation drops all `-pbpd` / `--percentile-precision` vocabulary (those flags
+  are gone); it is `default` or `--data-model-precision N`.
+  - This is a **`-V` content-key rename → breaking change.** It triggers the HARNESS-DESIGN
+    consultation: discover every consumer (`grep -rn 'percentile_precision' tests/`), update
+    them in the **same commit**, and execute each affected harness to confirm it still
+    asserts (exit 0 is insufficient — the assertion lines must match).
+- **Per-surface bpd.** Keep the existing per-surface `effective_bpd: N` line in each surface
+  block, now **derived from the active tier via the table** rather than read from a
+  per-surface global. The tier line plus the four `effective_bpd` lines together prove the
+  resolution end-to-end (e.g. tier 7 → histogram 616, heatmap 616, bucket-stats 616,
+  per-message 115). The L3 oracle continues to read `effective_bpd` per surface.
+
+## Test-harness integration
+
+Every named consumer of the renamed `-V` key and the removed flags is updated in the same
+commit as the change that affects it. Per HARNESS-DESIGN, a grep that matches nothing is a
+failure, and exit 0 is not proof — each touched harness is executed and confirmed to assert.
+
+- **`validate-runtime-config.sh`**
+  - Rewrite the precision assertion (today `^percentile-precision: 7$`) for the new key
+    name (`^data_model_precision: 7 ...$`) and the new source vocabulary.
+  - **Delete** the `warning-pbpd-overrides-pp` scenario — the `-pbpd` vs `--percentile-precision`
+    conflict it tests no longer exists.
+  - **Add table-assertion scenarios:** run `-dmp` at representative tiers and assert each
+    surface's `effective_bpd` matches the table cell. The table becomes a tested contract,
+    not just a doc — derivation regressions are caught.
+- **`validate-histogram-bin-counters.sh`** — asserts the bin-counter `-V` telemetry,
+  including the bpd-bearing lines; update for the renamed key / derived bpd.
+- **`validate-statistics.sh`** — the L3 oracle reads `effective_bpd` from `-V`; confirm it
+  still resolves the correct per-surface bpd after derivation moves to the table.
+- **`validate-help-content.sh` / `validate-help-layout.sh`** — assert visible long-form flags
+  appear in `docs/usage.md` / `README.md`; update for the renamed flag and the two removed
+  flags (the harness halts at the first missing long-form — re-run after removal to confirm
+  no further gaps hide behind it).
+- **`validate-explain.sh`** — `--explain` prose references `-pbpd` / `-pp`; update to the new
+  lever and remove references to the deleted flags.
+
+## Documentation (one sweep, same commit as the change)
+
+Light and to the point. The message every user-facing surface lands, in analyst terms:
+there is **one lever** (`--data-model-precision`, 1..9, default 5) for dialing in precision;
+turning it up **increases precision in stages across the surfaces** (not all at once); the
+trade-off is **precision vs. memory**, and the staging lets the analyst buy precision where
+it matters at a controlled memory cost.
+
+Per the user-facing-docs rule: describe what the analyst gets, never the mechanism. No
+bins-per-decade numbers as the headline, no internal identifiers, no issue numbers, no
+per-surface table dumped into `--help`. Stay silent on backward-compat — describe the knob
+as it is now, with no reference to the removed flags.
+
+- **`print_help()` (`-dmp`):** one terse line — precision tier 1..9 (default 5), higher =
+  finer resolution at higher memory cost.
+- **`docs/usage.md`:** a short paragraph carrying the single-lever + staging + memory
+  trade-off message, **plus one sentence naming the staging order** across surfaces
+  (which surfaces sharpen first as the tier rises, through to the per-message surface at the
+  top) — without bpd numbers and without the tier table.
+- **`README.md`:** options-reference entry updated for the renamed flag; the two removed
+  flags deleted.
+- **`--explain` prose** (`$explain_percentiles_compute`, `$explain_iqr_compute`): update the
+  existing sentences that name `-pbpd` / `--percentile-precision` to point at the one lever
+  and convey that the bin-counter surfaces resolve at the precision the tier sets. Do not
+  grow the topics — edit what is already there.
+
+All of the above plus any remaining `-pbpd`/`-pp`/`-bsbpd` mention are swept in the same
+commit as the change that affects them.

--- a/ltl
+++ b/ltl
@@ -411,8 +411,11 @@ my $histogram_height_explicit = 0;            # Flag: true if user explicitly se
 my $histogram_gap = 6;                        # Horizontal padding between histograms
 my $histogram_legend_spacing = 1;             # Vertical gap between histogram and legend
 
-# Histogram bucket calculation (HdrHistogram-style)
-my $histogram_buckets_per_decade = 8;         # Default: ~5% precision (4=10%, 8=5%, 16=2.5%, 32=1%)
+# Visual histogram bar density: the number of display bars per decade for the
+# rendered histogram. This is display geometry — distinct from the bin-counter
+# data-model resolution (%TIER_BPD), which the precision lever governs. Fixed
+# internal constant; not user-tunable.
+my $histogram_buckets_per_decade = 8;
 my $histogram_bucket_override = 0;            # If > 0, use this exact bucket count instead of calculating
 
 # Bin-counter data-model resolution lever (Issue #293). A single tiered
@@ -463,6 +466,11 @@ my %csv_family_decimals;                             # populated during option r
 # when the user did not pass the flag). resolve_data_model()/choose_data_model()
 # read these to dispatch raw vs bin reductions at the caller. Defaults live in
 # the call sites, not here — the flags exist purely to override.
+#
+# These selectors and the precision lever (%TIER_BPD / --data-model-precision)
+# are orthogonal: the selector chooses WHICH data model a surface uses (raw
+# nearest-rank vs bin counter); the precision lever sets HOW FINELY the bin
+# model resolves. Precision applies only on surfaces resolving to 'bin'.
 my $data_model_omnibus             = undef;   # -dm   / --data-model
 my $data_model_histogram           = undef;   # -hgdm / --histogram-data-model
 my $data_model_heatmap             = undef;   # -hmdm / --heatmap-data-model
@@ -1520,10 +1528,7 @@ sub _classify_argv_provenance {
                 'group-ceiling|gc', 'heatmap|hm', 'heatmap-width|hmw',
                 'light-background|lbg', 'dark-background|dbg', 'histogram|hg',
                 'histogram-width|hgw', 'histogram-height|hgh',
-                'hgbpd|histogram-buckets-per-decade',
                 'hgb|histogram-buckets',
-                'pbpd|percentile-buckets-per-decade',
-                'bsbpd|bucket-stats-buckets-per-decade',
                 'dmp|data-model-precision',
                 'dm|data-model',
                 'hgdm|histogram-data-model',
@@ -1633,10 +1638,7 @@ sub emit_runtime_config_verbose {
         'group-ceiling'                     => $consolidation_final_ceiling,
         'heatmap'                           => $heatmap_metric,
         'heatmap-width'                     => $heatmap_width,
-        'histogram-buckets-per-decade'      => $histogram_buckets_per_decade,
         'histogram-buckets'                 => $histogram_bucket_override,
-        'percentile-buckets-per-decade'     => $percentile_buckets_per_decade,
-        'bucket-stats-buckets-per-decade'   => $bucket_stats_buckets_per_decade,
         'data-model-precision'              => $data_model_precision_level,
         # Issue #266: explicit data-model selectors. Emitted only when the
         # user supplied them (per the existing provenance partitioning at
@@ -3044,14 +3046,14 @@ my $explain_cv_compute = q{Derived from already-computed `std_dev` and `mean`: `
 # --- iqr ---
 my $explain_iqr_intuition = q{Interquartile range = `p75 - p25`. IQR captures the spread of the *middle 50%* of observations -- the range between the lower quartile and the upper quartile. Half of all values fall inside this band; one quarter are slower, one quarter are faster.};
 my $explain_iqr_operational = q{IQR is the *robust* spread statistic: by construction it ignores the bottom 25% and top 25%, which contain all the outliers, fast-path edge cases, and pathological-tail events. This makes IQR resistant to the failure modes that compromise `std_dev` (single 10-second outlier dominates) and `cv` (right-skew inflates std_dev). For SRE work where you want "what's the typical operational range this API behaves in", IQR is usually the right answer -- mean +/- std_dev assumes a normal distribution which production latency violates. IQR pairs well with `p50` (median) as a robust center: the trio `p25 / p50 / p75` describes the body of the distribution without being skewed by tails.};
-my $explain_iqr_compute = q{Derived from already-computed percentiles: `iqr = p75 - p25`. Inherits the data model and precision of the underlying percentile computation -- exact relative to observed samples on surfaces using the raw values data model, or subject to bin-width interpolation on surfaces using the bin counter data model (default ~1.3% relative bin width at 53 buckets per decade; tunable via `-pbpd` or `--percentile-precision`).};
+my $explain_iqr_compute = q{Derived from already-computed percentiles: `iqr = p75 - p25`. Inherits the data model and precision of the underlying percentile computation -- exact relative to observed samples on surfaces using the raw values data model, or subject to bin-width interpolation on surfaces using the bin counter data model (tunable via `--data-model-precision`).};
 
 # --- percentiles (the major topic, covers p1..p99999) ---
 my $explain_percentiles_intuition = q{Percentiles answer the question "what value is faster than (or equal to) N% of all observations?" The N-th percentile pN is the value at which N percent of observed durations fall at or below. p50 is the median; p99 is the value that 99% of requests beat; p999 is the value that 99.9% of requests beat. Where `mean` collapses a distribution to a single average, percentiles describe its *shape* -- by reading off the values at many different points along the cumulative distribution.};
 my $explain_percentiles_operational = q{Percentiles are the primary SRE latency-investigation tool. Each percentile answers a different operational question: `p50` (median) is the "typical" experience; `p90` and `p95` are commonly-used SLO target points; `p99`, `p999`, and higher tail percentiles describe the user-visible worst-case latencies that drive outage and complaint patterns; `p1`, `p5`, `p10` are the lower-body percentiles useful for fast-path analysis (cache effectiveness, what does the system look like when not loaded). The progression of nines -- p99, p999, p9999, p99999 -- describes *how heavy* the tail is: in a benign distribution these values converge quickly; in a pathological one (GC pauses, lock contention, retry storms) they diverge sharply.};
 my $explain_percentiles_table_intro = q{Available percentile slugs and their operational meaning:};
 my $explain_percentiles_sample_size = q{Higher percentiles require larger samples to be statistically meaningful. The general rule: pN needs at least 10/(1-N/100) observations to be informative -- p99 needs ~1000, p999 needs ~10000, p9999 needs ~100000, p99999 needs ~1 million. Below these thresholds the percentile collapses toward `max` and carries no signal independent of `max`. ltl emits every percentile column regardless of sample size, so check the `occurrences` column when interpreting high-nines values.};
-my $explain_percentiles_compute = q{ltl computes percentiles via one of two data models, each using its own algorithm. The raw values data model holds every observation in memory and selects the percentile by nearest-rank from the sorted array (an actually-observed value at the computed rank). The bin counter data model accumulates observations into log-spaced bin counters and computes the percentile by exponential interpolation within the bucket containing the target rank (a synthesised value placed inside the matching bin on a log scale spanning the bin's lower and upper edges); the default 53 buckets per decade gives ~1.3% relative bin width. The two algorithms return different values on the same input, particularly in the tail. Surface defaults: histogram and heatmap use the bin counter data model; per-message-key statistics (summary table / MESSAGES CSV) and per-time-bucket statistics (STATS CSV) use the raw values data model. Override per surface via `--message-stats-data-model`, `--bucket-stats-data-model`, `--histogram-data-model`, `--heatmap-data-model`; pin globally via `--data-model`. Bin resolution is tunable via `-pbpd` (buckets per decade) or `--percentile-precision` (named tiers 1..9).};
+my $explain_percentiles_compute = q{ltl computes percentiles via one of two data models, each using its own algorithm. The raw values data model holds every observation in memory and selects the percentile by nearest-rank from the sorted array (an actually-observed value at the computed rank). The bin counter data model accumulates observations into log-spaced bin counters and computes the percentile by exponential interpolation within the bucket containing the target rank (a synthesised value placed inside the matching bin on a log scale spanning the bin's lower and upper edges); the default 53 buckets per decade gives ~1.3% relative bin width. The two algorithms return different values on the same input, particularly in the tail. Surface defaults: histogram and heatmap use the bin counter data model; per-message-key statistics (summary table / MESSAGES CSV) and per-time-bucket statistics (STATS CSV) use the raw values data model. Override per surface via `--message-stats-data-model`, `--bucket-stats-data-model`, `--histogram-data-model`, `--heatmap-data-model`; pin globally via `--data-model`. On surfaces using the bin counter data model, the resolution is set by `--data-model-precision` (tier 1..9, default 5); higher tiers give finer resolution at higher memory cost.};
 
 # --- skewness (user-supplied content) ---
 my $explain_skewness_intuition = q{Skewness measures the *asymmetry* of a distribution -- how lopsided it is around its mean. Whether the values tend to bunch up on one side with a tail extending toward the other. For latency, skewness answers "is the tail leaning one way?" -- positive skew means the right tail is heavier (most fast, occasionally slow); negative skew means the left tail is heavier (unusual for latency; common when something caps execution at a ceiling).};
@@ -3277,7 +3279,7 @@ my $explain_histogram_layout = q{The histogram has a dual Y-axis: the LEFT axis 
 
 my $explain_histogram_reading = q{The histogram is the chart for answering "what does the distribution actually look like?" Read it as you would any frequency chart, but two ltl-specific patterns deserve special attention. First, log-scale tail interpretation: a small bar at the far right represents a small number of very large values -- those bars are diagnostically valuable even when short, because the X-axis is exponential. Second, percentile-tick alignment: P50 should fall on or near the tallest bar (the mode). When P50 is far from the peak, the distribution is highly skewed and the mean is unreliable. When P95 and P99 are far apart on the X-axis (multiple decades), the tail is fat -- common signature of GC pauses, lock contention, or retry storms. When P99 and P99.9 are visually adjacent, the worst-case is dominated by a small cluster of consistent outliers; when far apart, the worst-case is dominated by one or two extreme events.};
 
-my $explain_histogram_compute = q{The histogram uses log-spaced bins with HDR-histogram-style precision. Default precision (53 buckets per decade, controlled by `-pbpd`) gives ~1.3% resolution. The histogram width (default 95% of terminal) and height (default 8 rows) are tunable via `-hgw` and `-hgh`. Highlight overlays (`-h regex`) render colored sub-bars within each main bar, showing the proportion of highlighted entries at each value range. The percentile tick marks on the baseline are computed from the same observations as the summary-table p99/p999 values, so the visual ticks and the numeric statistics agree by construction.};
+my $explain_histogram_compute = q{The histogram uses log-spaced bins with HDR-histogram-style precision. Bin-counter resolution is controlled by `--data-model-precision` (tier 1..9, default 5); higher tiers give finer resolution. The histogram width (default 95% of terminal) and height (default 8 rows) are tunable via `-hgw` and `-hgh`. Highlight overlays (`-h regex`) render colored sub-bars within each main bar, showing the proportion of highlighted entries at each value range. The percentile tick marks on the baseline are computed from the same observations as the summary-table p99/p999 values, so the visual ticks and the numeric statistics agree by construction.};
 
 # Synthetic histogram example chart. Mirrors the real ltl layout precisely:
 # - Top border (┌─...─┐)
@@ -3439,7 +3441,7 @@ my $explain_histogram_flags = <<'END';
     ltl -hg duration -hgw 50 access.log           # narrow histogram (50% of terminal)
     ltl -hg duration -hgh 16 access.log           # taller histogram (16 rows vs default 8)
     ltl -hg duration -h "/api/v2/" access.log     # overlay highlight of matching entries
-    ltl -hg duration -pp 7 access.log             # tighter percentile precision (slower)
+    ltl -hg duration -dmp 7 access.log            # tighter precision (slower)
 END
 
 my $explain_histogram_notes = q{The X-axis log scale means that visual distance between bars represents an exponential, not linear, gap in actual value. Two bars that look the same width apart on the screen could represent a 10x difference at one part of the chart and a 100x difference at another. When -hg is invoked alongside the bar graph (default), the histogram renders as an additional panel below the timeline. When -hg is invoked with multiple metrics (-hg duration,bytes), each metric gets its own histogram panel stacked vertically. Highlight overlays (-h pattern) draw colored sub-bars within each main bar showing the proportion of matched entries; the highlight percentile legend appears below the main legend in highlight color. Color rendering depends on terminal support: modern Unix terminals and Windows Terminal display the gradient correctly; legacy Windows CMD with `more` shows monochrome bars (the layout and percentile ticks remain readable).};
@@ -3595,11 +3597,11 @@ sub populate_explain_topics {
             { type => 'subheading', text => 'Sample size and meaningfulness' },
             { type => 'paragraph', text => $explain_percentiles_sample_size },
             { type => 'subheading', text => 'Example' },
-            { type => 'pre',       text => "    ltl -so p999 -n 20 access.log         # find APIs with the worst p999 tail latency\n    ltl -so p9999 -n 20 access.log        # tail-of-tail analysis; needs many samples\n    ltl -pp 7 access.log                  # tighten percentile precision on bin-counter surfaces (slower; more memory)\n    ltl -hgdm raw -hg access.log          # pin the histogram surface to exact nearest-rank instead of bin interpolation\n    ltl -mdm bin access.log               # opt the per-message-key surface into bin-counter percentile interpolation (default is raw)\n" },
+            { type => 'pre',       text => "    ltl -so p999 -n 20 access.log         # find APIs with the worst p999 tail latency\n    ltl -so p9999 -n 20 access.log        # tail-of-tail analysis; needs many samples\n    ltl -dmp 7 access.log                 # tighten precision on bin-counter surfaces (slower; more memory)\n    ltl -hgdm raw -hg access.log          # pin the histogram surface to exact nearest-rank instead of bin interpolation\n    ltl -mdm bin access.log               # opt the per-message-key surface into bin-counter percentile interpolation (default is raw)\n" },
             { type => 'subheading', text => 'How ltl computes this' },
             { type => 'paragraph', text => $explain_percentiles_compute },
             { type => 'subheading', text => 'See also' },
-            { type => 'paragraph', text => 'min, max, iqr, skewness, kurtosis, bimodality_coef. Flags: -pbpd, -pp, -dm, -hgdm, -hmdm, -mdm.' },
+            { type => 'paragraph', text => 'min, max, iqr, skewness, kurtosis, bimodality_coef. Flags: -dmp, -dm, -hgdm, -hmdm, -mdm.' },
         ],
 
         # ---- skewness ----
@@ -3716,7 +3718,7 @@ sub populate_explain_topics {
             { type => 'subheading', text => 'How ltl renders this' },
             { type => 'paragraph', text => $explain_histogram_compute },
             { type => 'subheading', text => 'See also' },
-            { type => 'paragraph', text => 'heatmap, percentiles, skewness, kurtosis, bimodality_coef. Flags: -hg, -hgw, -hgh, -pbpd, -pp, -ep.' },
+            { type => 'paragraph', text => 'heatmap, percentiles, skewness, kurtosis, bimodality_coef. Flags: -hg, -hgw, -hgh, -dmp.' },
         ],
     );
     return;
@@ -3823,24 +3825,19 @@ sub print_help {
     $out .= help_opt("-hg,  --histogram [metric]",    "Show an overall distribution histogram after the bar graph (duration, bytes, or count)");
     $out .= help_opt("-hgw, --histogram-width <N>",   "Histogram width as percentage of terminal (default: 95)");
     $out .= help_opt("-hgh, --histogram-height <N>",  "Histogram height in rows (default: 8)");
-    $out .= help_opt("-hgbpd, --histogram-buckets-per-decade <N>", "Histogram buckets per decade (default: 8; 4=~10%, 8=~5%, 16=~2.5%, 32=~1% precision)");
-    $out .= help_opt("-hgb,  --histogram-buckets <N>",             "Override total histogram bucket count (default: 0 = auto-calculate from buckets-per-decade)");
+    $out .= help_opt("-hgb,  --histogram-buckets <N>",             "Override total histogram bucket count (default: 0 = auto-calculate)");
 
-    # Percentile mode (Issue #189)
-    $out .= help_subheading("Percentile mode");
-    $out .= help_opt("-pp,   --percentile-precision <N>",            "Set percentile binning precision tier 1..9 (default: 5 = ~1.3%; 1=~10%, 9=~0.1%). Applies to surfaces using the bin counter data model; see docs/usage.md");
-    $out .= help_opt("-pbpd, --percentile-buckets-per-decade <N>",   "Set percentile buckets-per-decade directly (default: 53; valid 4..616). Overrides --percentile-precision when both supplied");
-    $out .= help_opt("-bsbpd, --bucket-stats-buckets-per-decade <N>", "Set per-time-bucket statistics buckets-per-decade under -bdm bin (default: 53; valid 4..616)");
-
-    # Data-model selectors (Issue #266). Pin which reduction path each
-    # surface uses. No defaults — when unset, the surface's existing
-    # internal logic chooses. Per-surface flag > -dm > internal default.
-    $out .= help_subheading("Data-model selectors");
+    # Data model (Issues #266, #293). The selectors choose WHICH data model
+    # each surface uses (no defaults — when unset, the surface's internal logic
+    # chooses; per-surface flag > -dm > internal default); the precision lever
+    # sets HOW FINELY the bin model resolves.
+    $out .= help_subheading("Data model");
     $out .= help_opt("-dm,   --data-model <raw|bin>",                  "Pin the data model for every surface (overridden by any per-surface flag below)");
     $out .= help_opt("-hgdm, --histogram-data-model <raw|bin>",        "Pin the histogram surface's data model");
     $out .= help_opt("-hmdm, --heatmap-data-model <raw|bin>",          "Pin the heatmap surface's data model");
     $out .= help_opt("-mdm,  --message-stats-data-model <raw|bin>",    "Pin the per-message-key statistics data model (default raw; bin uses HDR-style bin counters with Prometheus-style exponential interpolation)");
     $out .= help_opt("-bdm,  --bucket-stats-data-model <raw|bin>",     "Pin the per-time-bucket statistics data model (default raw; bin uses HDR-style bin counters with Prometheus-style exponential interpolation)");
+    $out .= help_opt("-dmp,  --data-model-precision <N>",              "Precision tier 1..9 (default: 5). Higher tiers give finer resolution on bin-counter surfaces at higher memory cost.");
 
     # User-Defined Metrics
     $out .= help_subheading("User-Defined Metrics");
@@ -6529,10 +6526,7 @@ sub adapt_to_command_line_options {
         'histogram|hg:s' => \&handle_histogram_option,
         'histogram-width|hgw=i' => sub { $histogram_width_percent = $_[1]; $histogram_width_explicit = 1; },
         'histogram-height|hgh=i' => sub { $histogram_height = $_[1]; $histogram_height_explicit = 1; },
-        'hgbpd|histogram-buckets-per-decade=i' => \$histogram_buckets_per_decade,
         'hgb|histogram-buckets=i' => \$histogram_bucket_override,
-        'pbpd|percentile-buckets-per-decade=i' => \$percentile_buckets_per_decade,
-        'bsbpd|bucket-stats-buckets-per-decade=i' => \$bucket_stats_buckets_per_decade,
         'dmp|data-model-precision=i' => \$data_model_precision_level,
         # Issue #266: explicit data-model selectors. Each accepts 'raw' or 'bin';
         # any other value dies at parse time via _validate_dm. The flags have no
@@ -6679,12 +6673,7 @@ sub adapt_to_command_line_options {
     # Histogram option processing (Issue #25)
     # If histogram enabled but no specific metrics requested, default to all available after parsing
     # The handler already sets $histogram_enabled = 1 and populates %histogram_metrics
-    # Validation of buckets_per_decade: must be positive
     if ($histogram_enabled) {
-        if ($histogram_buckets_per_decade < 1) {
-            warn "Invalid buckets-per-decade value: $histogram_buckets_per_decade. Using default (8).\n";
-            $histogram_buckets_per_decade = 8;
-        }
         if ($histogram_bucket_override < 0) {
             warn "Invalid bucket override value: $histogram_bucket_override. Disabling override.\n";
             $histogram_bucket_override = 0;

--- a/ltl
+++ b/ltl
@@ -415,19 +415,37 @@ my $histogram_legend_spacing = 1;             # Vertical gap between histogram a
 my $histogram_buckets_per_decade = 8;         # Default: ~5% precision (4=10%, 8=5%, 16=2.5%, 32=1%)
 my $histogram_bucket_override = 0;            # If > 0, use this exact bucket count instead of calculating
 
-# Percentile-mode bin-counter primitives (Issue #189). Universal
-# buckets-per-decade for the unified percentile contract, distinct from
-# $histogram_buckets_per_decade (above; histogram-only, default 8). The two
-# flags coexist with documented precedence per:
-#   features/189-bin-counter-primitives-implementation-readiness-audit.md § Bucket C § C7 (option 1)
-# Default values are locked at:
-#   features/187-histogram-bin-counter-percentiles.md § Decision 2 (bpd=53)
+# Bin-counter data-model resolution lever (Issue #293). A single tiered
+# precision knob (--data-model-precision, 1..9, default 5) resolves the
+# bins-per-decade for each bin-counter surface through %TIER_BPD below. The
+# tier is the only resolution control; each surface reads its own row, so one
+# dial governs all surfaces at per-surface fidelity. The default (5)
+# reproduces the established per-surface defaults (histogram/heatmap 616,
+# bucket-stats 53, message-stats 53). Tier table locked at:
+#   features/187-histogram-bin-counter-percentiles.md § Decision 2
+#   features/293-precision-lever-unification.md (per-surface tier table)
+# Partition seed span locked at:
 #   features/187-histogram-bin-counter-percentiles.md § Decision 5 (seed_decades=5)
-# Opt-out is the per-surface -dm / -hgdm / -hmdm / -mdm / -bdm selector
-# resolving to 'raw' (per features/266-data-model-selectors.md).
-my $percentile_buckets_per_decade  = 53;      # ~1.3% precision; tier 5 in the locked precision table
-my $percentile_precision_level     = undef;   # 1..9 tier; resolves to a bpd via the locked precision table
-my $percentile_precision_source    = 'default';  # 'default' | '-pbpd N' | '--percentile-precision N' | '-pbpd N; --percentile-precision N overridden'
+# The data model itself (raw vs bin) is chosen by the per-surface
+# -dm / -hgdm / -hmdm / -mdm / -bdm selectors (features/266-data-model-selectors.md);
+# precision applies only on surfaces resolving to 'bin'.
+my %TIER_BPD = (
+    'histogram'     => [53, 80, 115, 256, 616, 616, 616, 616, 616],
+    'heatmap'       => [53, 80, 115, 256, 616, 616, 616, 616, 616],
+    'bucket-stats'  => [16, 32,  53,  53,  53, 115, 616, 616, 616],
+    'message-stats' => [ 4,  8,  16,  32,  53,  80, 115, 256, 616],
+);
+my $data_model_precision_level  = 5;          # 1..9 tier; index into %TIER_BPD
+my $data_model_precision_source = 'default';  # 'default' | '--data-model-precision N'
+
+# Per-surface bins-per-decade, derived from the tier via bpd_for_surface()
+# during option resolution. Initialised to the tier-5 defaults so any reader
+# before resolution sees the documented default.
+my $percentile_buckets_per_decade   = 53;     # message-stats surface
+my $bucket_stats_buckets_per_decade = 53;     # per-time-bucket surface
+my $heatmap_stream_bpd              = 616;    # heatmap surface (display-geometry bound, #201)
+my $histogram_stream_bpd            = 616;    # histogram surface (display-geometry bound, #201)
+
 my $percentile_seed_decades        = 5;       # partition seeds at 5 decades centered on first value
 
 # Issue #268: CSV output precision. $csv_precision is one of 'default', 'full',
@@ -459,21 +477,13 @@ my $heatmap_capture_mode           = undef;   # 'raw' or 'bin' (set before parsi
 my $message_stats_capture_mode     = undef;   # 'raw' or 'bin' (set before parsing loop) — Issue #287
 my $bucket_stats_capture_mode      = undef;   # 'raw' or 'bin' (set before parsing loop) — Issue #289
 
-# Streaming-partition bpd for display-geometry-bound consumers (#201).
-# Higher than the F1 default (53) because F2/F3 partition counts are bounded
-# (~70 total across all heatmap time buckets + histogram metrics) and the
-# end-of-parse re-bin into a coarser display-anchored partition needs streaming
-# bpd this high to keep boundary-mismatch displacement below the ~11% per-row
-# visibility threshold of a 9-char-tall ASCII histogram. Empirically validated
-# by #201 V8 at 1.10% / 5.78% worst-case displacement on canonical datasets.
-my $heatmap_stream_bpd   = 616;
-my $histogram_stream_bpd = 616;
-
-# Issue #289: per-time-bucket statistics bin resolution, the analyst's lever
-# for this surface (mirrors $percentile_buckets_per_decade for the per-message
-# surface). Default 53 (#187 Decision 2 floor); tunable via
-# -bsbpd / --bucket-stats-buckets-per-decade. Valid range 4..616.
-my $bucket_stats_buckets_per_decade = 53;
+# The heatmap and histogram surfaces are display-geometry bound (#201): their
+# bounded partition counts (~70 total) re-bin at end-of-parse into a coarser
+# display-anchored partition, so a high streaming bpd keeps boundary-mismatch
+# displacement below the ~11% per-row visibility threshold of a 9-char-tall
+# ASCII histogram (#201 V8: 1.10% / 5.78% worst-case on canonical datasets).
+# At the default tier 5 both resolve to 616; lower tiers coarsen them
+# (a deliberate trade against shape fidelity — see %TIER_BPD above).
 
 # Histogram data collection (hash-based for dynamic metrics)
 my %histogram_values = (
@@ -953,6 +963,14 @@ sub bin_assign {
     $i = $p->{bin_count} - 1 if $i >= $p->{bin_count};
     $i = 0                   if $i < 0;
     return ('IN', $i);
+}
+
+sub bpd_for_surface {
+    # Resolve a surface's bins-per-decade from the active precision tier
+    # (Issue #293). The tier is validated to 1..9 before any surface reads it,
+    # so the array index is always in range.
+    my ($surface) = @_;
+    return $TIER_BPD{$surface}[$data_model_precision_level - 1];
 }
 
 sub counter_update {
@@ -1506,7 +1524,7 @@ sub _classify_argv_provenance {
                 'hgb|histogram-buckets',
                 'pbpd|percentile-buckets-per-decade',
                 'bsbpd|bucket-stats-buckets-per-decade',
-                'pp|percentile-precision',
+                'dmp|data-model-precision',
                 'dm|data-model',
                 'hgdm|histogram-data-model',
                 'hmdm|heatmap-data-model',
@@ -1619,7 +1637,7 @@ sub emit_runtime_config_verbose {
         'histogram-buckets'                 => $histogram_bucket_override,
         'percentile-buckets-per-decade'     => $percentile_buckets_per_decade,
         'bucket-stats-buckets-per-decade'   => $bucket_stats_buckets_per_decade,
-        'percentile-precision'              => $percentile_precision_level,
+        'data-model-precision'              => $data_model_precision_level,
         # Issue #266: explicit data-model selectors. Emitted only when the
         # user supplied them (per the existing provenance partitioning at
         # the bottom of this sub) — unset flags emit nothing.
@@ -1977,15 +1995,15 @@ sub emit_percentile_algorithm_verbose {
     # and the heatmap/histogram capture-mode resolution at adapt time.
     # The `effective_algorithm` column reports what the code actually
     # ran, not what the resolved data_model implies.
-    # Per-surface bin resolution (buckets_per_decade). Issue #289: 53 is the
-    # global default/floor (#187 Decision 2, OTEP-149 Scale-4 analog); each
-    # surface tunes UP from there by partition cardinality vs memory. The
-    # per-message-key surface (potentially millions of partitions) stays at
-    # the 53 default; the per-time-bucket surface (hundreds of partitions) and
-    # the heatmap/histogram surfaces (bounded partition counts) run finer.
-    # Emitted as `effective_bpd` so the #224 L3 oracle builds its reference
-    # partition at the SAME resolution ltl used (the oracle is parameter-aware
-    # per #280 — it must not hard-code a bpd that diverges from ltl's).
+    # Per-surface bin resolution. Issue #293: each surface's bins-per-decade
+    # is derived from the single precision tier (--data-model-precision) via
+    # %TIER_BPD — one dial, per-surface fidelity. At the default tier 5 the
+    # surfaces resolve to their established defaults (histogram/heatmap 616,
+    # per-time-bucket 53, per-message-key 53). Emitted as `effective_bpd` so
+    # the #224 L3 oracle builds its reference partition at the SAME resolution
+    # ltl used (the oracle is parameter-aware per #280 — it must not hard-code
+    # a bpd that diverges from ltl's). Meaningful only when the surface's data
+    # model is 'bin'; the raw nearest-rank path has no bin resolution.
     my @surfaces = (
         {
             id              => 'histogram',
@@ -2076,43 +2094,13 @@ sub emit_bin_counter_mode_verbose {
 
     push @verbose_output, "=== histogram-bin-counters ===";
 
-    # Two fields, two annotation styles per the locked Decision 8 contract:
-    #
-    # `percentile_precision: <LEVEL> (<source>)` — reports the
-    # --percentile-precision side of the story. When --percentile-precision
-    # was specified (with or without -pbpd), <LEVEL> is the requested level
-    # (1..9) and <source> is "--percentile-precision N" or, when -pbpd also
-    # specified, "--percentile-precision N; overridden". When no
-    # --percentile-precision was specified, <LEVEL> falls back to the tier
-    # corresponding to the active bpd if any matches, or the literal "n/a"
-    # for non-tier bpd values (locked at audit A5).
-    #
-    # `buckets_per_decade: <N> (<source>)` — reports the active resolved bpd
-    # with the full conflict-annotated source ("default" | "-pbpd N" |
-    # "--percentile-precision N" | "-pbpd N; --percentile-precision M overridden").
-    #
-    # The two fields can carry different <source> strings; only the
-    # buckets_per_decade field's annotation tracks $percentile_precision_source
-    # verbatim from option parsing.
-    my %bpd_to_level = (4=>1, 8=>2, 16=>3, 32=>4, 53=>5, 80=>6, 115=>7, 256=>8, 616=>9);
-    my ($level_label, $level_source);
-    if (defined $percentile_precision_level) {
-        # User supplied --percentile-precision. Report it even when overridden.
-        $level_label  = $percentile_precision_level;
-        $level_source = $percentile_precision_source =~ /^-pbpd /
-            ? "--percentile-precision $percentile_precision_level; overridden"
-            : "--percentile-precision $percentile_precision_level";
-    } else {
-        $level_label  = exists $bpd_to_level{$percentile_buckets_per_decade}
-            ? $bpd_to_level{$percentile_buckets_per_decade}
-            : 'n/a';
-        $level_source = $percentile_precision_source;
-    }
-
+    # `data_model_precision: <TIER> (<source>)` — the single precision lever
+    # (Issue #293). <TIER> is the active tier 1..9; <source> is "default" or
+    # "--data-model-precision N". The per-surface bins-per-decade derived from
+    # the tier are reported per surface as `effective_bpd:` in the
+    # percentile-algorithm section, which is authoritative for resolution.
     push @verbose_output,
-        "percentile_precision: $level_label ($level_source)";
-    push @verbose_output,
-        "buckets_per_decade: $percentile_buckets_per_decade ($percentile_precision_source)";
+        "data_model_precision: $data_model_precision_level ($data_model_precision_source)";
 
     my %feature_active = (
         summary_table     => 1,
@@ -6545,7 +6533,7 @@ sub adapt_to_command_line_options {
         'hgb|histogram-buckets=i' => \$histogram_bucket_override,
         'pbpd|percentile-buckets-per-decade=i' => \$percentile_buckets_per_decade,
         'bsbpd|bucket-stats-buckets-per-decade=i' => \$bucket_stats_buckets_per_decade,
-        'pp|percentile-precision=i' => \$percentile_precision_level,
+        'dmp|data-model-precision=i' => \$data_model_precision_level,
         # Issue #266: explicit data-model selectors. Each accepts 'raw' or 'bin';
         # any other value dies at parse time via _validate_dm. The flags have no
         # defaults — when unset, the surface's existing logic applies.
@@ -6711,40 +6699,26 @@ sub adapt_to_command_line_options {
         }
     }
 
-    # Percentile-mode precision resolution (Issue #189). Resolves the bpd to
-    # use for the unified percentile contract from the CLI flags. The flag
-    # interaction (-pbpd wins over --percentile-precision; the level-to-bpd
-    # tier table; the 4..616 range) is locked at:
+    # Data-model precision resolution (Issue #293). The single tiered lever
+    # (--data-model-precision, 1..9, default 5) resolves a per-surface
+    # bins-per-decade through %TIER_BPD. The tier is the only resolution knob;
+    # each surface derives its own bpd. Contract locked at:
     #   features/187-histogram-bin-counter-percentiles.md § Decision 2
-    # Flags are parsed here but not yet consumed — the first consumer
-    # migration is the first reader of these globals.
-    if (defined $percentile_precision_level && $percentile_buckets_per_decade == 53) {
-        my %level_to_bpd = (1=>4, 2=>8, 3=>16, 4=>32, 5=>53, 6=>80, 7=>115, 8=>256, 9=>616);
-        if (!exists $level_to_bpd{$percentile_precision_level}) {
-            warn "Invalid --percentile-precision: $percentile_precision_level (must be 1..9). Using default (5).\n";
-            $percentile_precision_level = 5;
-        }
-        $percentile_buckets_per_decade = $level_to_bpd{$percentile_precision_level};
-        $percentile_precision_source   = "--percentile-precision $percentile_precision_level";
-    } elsif ($percentile_buckets_per_decade != 53) {
-        $percentile_precision_source = defined $percentile_precision_level
-            ? "-pbpd $percentile_buckets_per_decade; --percentile-precision $percentile_precision_level overridden"
-            : "-pbpd $percentile_buckets_per_decade";
-        # Issue #231: surface the override on stderr too — until now it was
-        # only visible inside the -V histogram-bin-counters section.
-        if (defined $percentile_precision_level) {
-            warn "-pbpd $percentile_buckets_per_decade overrides --percentile-precision $percentile_precision_level; using $percentile_buckets_per_decade buckets per decade.\n";
-        }
+    #   features/293-precision-lever-unification.md (per-surface tier table)
+    if (!$option_provenance{'data-model-precision'}) {
+        $data_model_precision_source = 'default';
+    } elsif ($data_model_precision_level < 1 || $data_model_precision_level > 9) {
+        warn "Invalid --data-model-precision: $data_model_precision_level (must be 1..9). Using default (5).\n";
+        $data_model_precision_level  = 5;
+        $data_model_precision_source = 'default';
+    } else {
+        $data_model_precision_source = "--data-model-precision $data_model_precision_level";
     }
-    if ($percentile_buckets_per_decade < 4 || $percentile_buckets_per_decade > 616) {
-        warn "Invalid -pbpd: $percentile_buckets_per_decade (must be 4..616). Using default (53).\n";
-        $percentile_buckets_per_decade = 53;
-        $percentile_precision_source   = 'default';
-    }
-    if ($bucket_stats_buckets_per_decade < 4 || $bucket_stats_buckets_per_decade > 616) {
-        warn "Invalid -bsbpd: $bucket_stats_buckets_per_decade (must be 4..616). Using default (53).\n";
-        $bucket_stats_buckets_per_decade = 53;
-    }
+    # Derive each surface's bpd from the resolved tier.
+    $percentile_buckets_per_decade   = bpd_for_surface('message-stats');
+    $bucket_stats_buckets_per_decade = bpd_for_surface('bucket-stats');
+    $heatmap_stream_bpd              = bpd_for_surface('heatmap');
+    $histogram_stream_bpd            = bpd_for_surface('histogram');
 
     # Duration unit option validation (Issue #17)
     if (defined $duration_unit_override) {

--- a/tests/validate-help-content.sh
+++ b/tests/validate-help-content.sh
@@ -216,11 +216,10 @@ perl -ne '
         $long = $parts[0];
     } else {
         # In every two-token GetOptions name in this codebase, the long
-        # form is the longer string. Verified against all 75 entries —
-        # including the five short-first declarations (hgbpd, hgb,
-        # pbpd, pp, ep) where the *full* spelling is on the right of
-        # the pipe but is still the longer string. length-based pick
-        # is robust where the hyphen heuristic was not (e.g., pause|p,
+        # form is the longer string. This holds for the short-first
+        # declarations (e.g. hgb, dmp, ep) where the *full* spelling is on
+        # the right of the pipe but is still the longer string. length-based
+        # pick is robust where the hyphen heuristic was not (e.g., pause|p,
         # start|st, end|et — long forms with no hyphen and length < 6).
         my @sorted = sort { length($b) <=> length($a) } @parts;
         $long  = $sorted[0];

--- a/tests/validate-help-layout.sh
+++ b/tests/validate-help-layout.sh
@@ -5,9 +5,7 @@
 # Ensures every option row's description starts at the same column and every
 # wrapped-description continuation line aligns at the same column. Catches
 # layout regressions when a new long-form option name exceeds the available
-# option-text column width without bumping $desc_col — exactly the failure
-# mode that shipped silently before PR #189-3 (which added
-# --histogram-buckets-per-decade and --percentile-buckets-per-decade).
+# option-text column width without bumping $desc_col.
 #
 # Project requirement: every CLI option in ltl exposes both a short and a
 # long form. This test guards the help-output column layout so that the
@@ -394,9 +392,7 @@ assert_pair() {
             detail      "no row matched '^[[:space:]]+${short}, +${long}' in stripped --help output"
     fi
 }
-assert_pair "-pp"    "--percentile-precision"
-assert_pair "-pbpd"  "--percentile-buckets-per-decade"
-assert_pair "-hgbpd" "--histogram-buckets-per-decade"
+assert_pair "-dmp"   "--data-model-precision"
 assert_pair "-hgb"   "--histogram-buckets"
 
 # ---------------------------------------------------------------------------

--- a/tests/validate-histogram-bin-counters.sh
+++ b/tests/validate-histogram-bin-counters.sh
@@ -126,7 +126,7 @@ assert_header_present() {
 }
 
 # ---------------------------------------------------------------------------
-# Scenario 1: default run — no percentile-mode flags
+# Scenario 1: default run — no precision flag
 # ---------------------------------------------------------------------------
 scenario_default() {
     current_scenario="default"
@@ -137,128 +137,125 @@ scenario_default() {
     assert_header_present "$out"
 
     assert_line "$out" \
-        pattern     '^percentile_precision: 5 \(default\)$' \
-        asserts     'With no precision flags, percentile_precision reports tier 5 (the default level in the locked tier table) with source annotation `(default)`' \
+        pattern     '^data_model_precision: 5 \(default\)$' \
+        asserts     'With no precision flag, data_model_precision reports tier 5 (the default level in the locked tier table) with source annotation `(default)`' \
         produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block)' \
         contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 2 - tier 5 is the default level; source annotation form is locked'
-
-    assert_line "$out" \
-        pattern     '^buckets_per_decade: 53 \(default\)$' \
-        asserts     'With no precision flags, buckets_per_decade reports the default 53 (the bpd corresponding to tier 5) with source annotation `(default)`' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 + section Decision 2 - tier 5 -> bpd 53 is locked'
 
     rm -f "$out"
 }
 
 # ---------------------------------------------------------------------------
-# Scenario 3: --percentile-precision 7 (tier override)
+# Scenario 3: --data-model-precision 7 (tier override)
 # ---------------------------------------------------------------------------
 scenario_precision_tier() {
     current_scenario="precision-tier"
     echo "[$current_scenario]"
     local out
-    out=$(run_section --percentile-precision 7)
+    out=$(run_section --data-model-precision 7)
 
     assert_header_present "$out"
 
     assert_line "$out" \
-        pattern     '^percentile_precision: 7 \(--percentile-precision 7\)$' \
-        asserts     'When --percentile-precision N is given without -pbpd, percentile_precision reports N with source annotation `(--percentile-precision N)`' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; --percentile-precision branch of source annotation)' \
+        pattern     '^data_model_precision: 7 \(--data-model-precision 7\)$' \
+        asserts     'When --data-model-precision N is given, data_model_precision reports N with source annotation `(--data-model-precision N)`' \
+        produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; supplied-flag branch of source annotation)' \
         contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - source annotation form is locked per branch'
 
-    assert_line "$out" \
-        pattern     '^buckets_per_decade: 115 \(--percentile-precision 7\)$' \
-        asserts     'When --percentile-precision 7 resolves through the tier table, buckets_per_decade reports 115 (the bpd for tier 7) with matching source annotation' \
-        produced_by 'adapt_to_command_line_options() in ltl (tier table %level_to_bpd) + emit_bin_counter_mode_verbose() (source annotation)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - tier 7 -> bpd 115 is locked'
-
     rm -f "$out"
 }
 
 # ---------------------------------------------------------------------------
-# Scenario 4: -pbpd 100 (non-tier value -> literal `n/a` per audit A5)
+# Scenario 4: invalid --data-model-precision warns + falls back to default
 # ---------------------------------------------------------------------------
-scenario_pbpd_non_tier() {
-    current_scenario="pbpd-non-tier"
+scenario_precision_out_of_range() {
+    current_scenario="precision-out-of-range"
     echo "[$current_scenario]"
     local out
-    out=$(run_section -pbpd 100)
+    out=$(run_section --data-model-precision 12)
 
     assert_header_present "$out"
 
     assert_line "$out" \
-        pattern     '^percentile_precision: n/a \(-pbpd 100\)$' \
-        asserts     'When -pbpd resolves to a value with no tier-table match, percentile_precision reports the literal string `n/a` (not an integer) with source annotation reflecting the -pbpd source' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; bpd-without-tier-match branch)' \
-        contract    'features/189-percentile-mode-audit.md section Bucket A section A5 - literal `n/a` rendering for non-tier bpd values is locked'
+        pattern     'Invalid --data-model-precision: 12 \(must be 1\.\.9\)' \
+        asserts     'When --data-model-precision is outside the locked 1..9 range, ltl emits a warning to stderr naming the invalid value' \
+        produced_by 'adapt_to_command_line_options() in ltl (tier range-check branch)' \
+        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - valid tier range is locked at 1..9'
 
     assert_line "$out" \
-        pattern     '^buckets_per_decade: 100 \(-pbpd 100\)$' \
-        asserts     'When -pbpd N is given, buckets_per_decade reports N with source annotation `(-pbpd N)`' \
-        produced_by 'adapt_to_command_line_options() in ltl (-pbpd branch) + emit_bin_counter_mode_verbose() (source annotation)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - source annotation form is locked'
-
-    rm -f "$out"
-}
-
-# ---------------------------------------------------------------------------
-# Scenario 5: -pbpd + --percentile-precision conflict (-pbpd wins)
-# ---------------------------------------------------------------------------
-scenario_flag_conflict() {
-    current_scenario="flag-conflict"
-    echo "[$current_scenario]"
-    local out
-    out=$(run_section -pbpd 100 --percentile-precision 4)
-
-    assert_header_present "$out"
-
-    assert_line "$out" \
-        pattern     '^percentile_precision: 4 \(--percentile-precision 4; overridden\)$' \
-        asserts     'When both -pbpd and --percentile-precision are given, percentile_precision reports the *requested* level from --percentile-precision with `; overridden` suffix indicating -pbpd won' \
-        produced_by 'emit_bin_counter_mode_verbose() in ltl (run-level header block; conflict branch of $level_source)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - conflict annotation form is locked'
-
-    assert_line "$out" \
-        pattern     '^buckets_per_decade: 100 \(-pbpd 100; --percentile-precision 4 overridden\)$' \
-        asserts     'When both flags conflict, buckets_per_decade reports the *active* bpd from -pbpd with full conflict annotation showing both flags and which one was overridden' \
-        produced_by 'adapt_to_command_line_options() in ltl ($percentile_precision_source assembly)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 8 - full conflict annotation is locked'
-
-    rm -f "$out"
-}
-
-# ---------------------------------------------------------------------------
-# Scenario 6: invalid -pbpd value warns + falls back to default
-# ---------------------------------------------------------------------------
-scenario_pbpd_out_of_range() {
-    current_scenario="pbpd-out-of-range"
-    echo "[$current_scenario]"
-    local out
-    out=$(run_section -pbpd 9999)
-
-    assert_header_present "$out"
-
-    assert_line "$out" \
-        pattern     'Invalid -pbpd: 9999' \
-        asserts     'When -pbpd is outside the locked 4..616 range, ltl emits a warning to stderr naming the invalid value' \
-        produced_by 'adapt_to_command_line_options() in ltl (-pbpd range-check branch)' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - valid range is locked at 4..616'
-
-    assert_line "$out" \
-        pattern     '^percentile_precision: 5 \(default\)$' \
-        asserts     'When -pbpd is out of range, percentile_precision falls back to the default tier 5 (not the invalid value)' \
+        pattern     '^data_model_precision: 5 \(default\)$' \
+        asserts     'When the tier is out of range, data_model_precision falls back to the default tier 5 with source annotation reset to `(default)`' \
         produced_by 'adapt_to_command_line_options() in ltl (range-check fallback) + emit_bin_counter_mode_verbose() (source annotation)' \
         contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - fallback to default is locked behavior'
 
-    assert_line "$out" \
-        pattern     '^buckets_per_decade: 53 \(default\)$' \
-        asserts     'When -pbpd is out of range, buckets_per_decade falls back to 53 with source annotation reset to `(default)`' \
-        produced_by 'adapt_to_command_line_options() in ltl (range-check fallback resets $percentile_precision_source to "default")' \
-        contract    'features/187-histogram-bin-counter-percentiles.md section Decision 2 - fallback resets source annotation'
-
     rm -f "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario T: the per-surface tier table (Issue #293). The single precision
+# tier resolves each bin-counter surface's effective_bpd; this asserts the
+# table cells end-to-end via -V percentile-algorithm. message-stats and
+# bucket-stats are pinned to the bin model so their effective_bpd is emitted
+# (the raw nearest-rank path has no bin resolution). Histogram and heatmap are
+# bin by default. Expected cells per surface row:
+#   tier 1 -> histogram 53,  heatmap 53,  bucket-stats 16,  message-stats 4
+#   tier 5 -> histogram 616, heatmap 616, bucket-stats 53,  message-stats 53
+#   tier 7 -> histogram 616, heatmap 616, bucket-stats 616, message-stats 115
+#   tier 9 -> histogram 616, heatmap 616, bucket-stats 616, message-stats 616
+# ---------------------------------------------------------------------------
+run_pa_section() {
+    # Capture -V percentile-algorithm with all four surfaces on the bin model.
+    local outfile
+    outfile=$(mktemp)
+    "$LTL" --disable-progress -V percentile-algorithm -hg -hm \
+        -mdm bin -bdm bin "$@" "$ACCESS_LOG" > "$outfile" 2>&1 || true
+    echo "$outfile"
+}
+
+# Assert one surface's effective_bpd within its percentile-algorithm block.
+assert_surface_bpd() {
+    local outfile="$1" surface="$2" expected="$3"
+    local actual
+    actual=$(sed -nE "/^=== percentile-algorithm \/ ${surface} ===$/,/^=== END percentile-algorithm \/ ${surface} ===$/p" "$outfile" \
+        | sed -nE 's/^effective_bpd: ([0-9]+)$/\1/p' | head -1)
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS  $current_scenario :: ${surface} effective_bpd=$expected"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $current_scenario"
+        echo "        surface:     $surface"
+        echo "        expected:    effective_bpd=$expected"
+        echo "        actual:      effective_bpd=${actual:-<absent>}"
+        echo "        asserts:     The precision tier resolves this surface to its locked per-surface bpd via %TIER_BPD."
+        echo "        produced_by: bpd_for_surface() in ltl -> per-surface globals -> @surfaces array in emit_percentile_algorithm_verbose()"
+        echo "        contract:    features/293-precision-lever-unification.md (per-surface tier table) + features/187 section Decision 2"
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: ${surface} effective_bpd expected=$expected got=${actual:-<absent>}")
+    fi
+}
+
+scenario_tier_table() {
+    current_scenario="tier-table"
+    echo "[$current_scenario]"
+    local out tier cells hg hm bs ms
+    # Each row: "histogram heatmap bucket-stats message-stats" for the tier.
+    for tier in 1 5 7 9; do
+        case "$tier" in
+            1) cells="53 53 16 4" ;;
+            5) cells="616 616 53 53" ;;
+            7) cells="616 616 616 115" ;;
+            9) cells="616 616 616 616" ;;
+        esac
+        read -r hg hm bs ms <<< "$cells"
+        out=$(run_pa_section --data-model-precision "$tier")
+        current_scenario="tier-table[dmp=$tier]"
+        assert_surface_bpd "$out" histogram     "$hg"
+        assert_surface_bpd "$out" heatmap       "$hm"
+        assert_surface_bpd "$out" bucket-stats  "$bs"
+        assert_surface_bpd "$out" message-stats "$ms"
+        rm -f "$out"
+    done
+    current_scenario="tier-table"
 }
 
 # ---------------------------------------------------------------------------
@@ -582,11 +579,9 @@ scenario_default
 echo ""
 scenario_precision_tier
 echo ""
-scenario_pbpd_non_tier
+scenario_precision_out_of_range
 echo ""
-scenario_flag_conflict
-echo ""
-scenario_pbpd_out_of_range
+scenario_tier_table
 echo ""
 scenario_message_stats_bin
 echo ""

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -5,8 +5,8 @@
 #   1. The runtime-config -V section emits command-line and
 #      environment-variable sub-sections per the locked contract.
 #   2. Silent-override warnings fire on the documented sites
-#      (-g non-numeric, -hm non-built-in without UDM, -pbpd overriding
-#      --percentile-precision, --exact-percentiles deprecation).
+#      (-g non-numeric, -hm non-built-in without UDM,
+#      --exact-percentiles deprecation).
 #   3. Hard-error paths (-du / -ru / -so unknown enums; nonexistent
 #      input file) exit non-zero with the documented diagnostic.
 # Usage: ./tests/validate-runtime-config.sh
@@ -158,7 +158,7 @@ scenario_runtime_config_command_line() {
     current_scenario="runtime-config-command-line"
     echo "[$current_scenario]"
 
-    run_ltl "rc-cli" -V runtime-config -bs 60 -pp 7 "$TEST_LOG"
+    run_ltl "rc-cli" -V runtime-config -bs 60 -dmp 7 "$TEST_LOG"
 
     assert_line "$RUN_STDOUT" \
         pattern     '^=== runtime-config ===$' \
@@ -179,7 +179,7 @@ scenario_runtime_config_command_line() {
         contract    'features/225-test-harness-coverage-gaps.md section #231 - value with no annotation means user-supplied, valid, unchanged'
 
     assert_line "$RUN_STDOUT" \
-        pattern     '^percentile-precision: 7$' \
+        pattern     '^data-model-precision: 7$' \
         asserts     'Multi-flag invocation surfaces each supplied flag as its own row in command-line sub-section.' \
         produced_by 'emit_runtime_config_verbose() in ltl' \
         contract    'features/225-test-harness-coverage-gaps.md section #231'
@@ -252,19 +252,6 @@ scenario_warning_hm_non_builtin() {
         pattern     "^-hm value 'bogus_metric' is not a built-in metric \\(duration\\|bytes\\|count\\) and no -udm configs are defined; treating as positional argument and using default metric 'duration'\\.$" \
         asserts     'When -hm is given a value that is neither a built-in metric nor matchable to a -udm config (because no -udm was given), ltl now warns that the value was treated as a positional argument and the default metric was used. Was previously silent.' \
         produced_by 'adapt_to_command_line_options() in ltl (heatmap non-builtin pushback branch)' \
-        contract    'features/225-test-harness-coverage-gaps.md section #231 - silent-override gap closure'
-}
-
-scenario_warning_pbpd_overrides_pp() {
-    current_scenario="warning-pbpd-overrides-pp"
-    echo "[$current_scenario]"
-
-    run_ltl "warn-pbpd" -pbpd 100 -pp 7 "$TEST_LOG"
-
-    assert_line "$RUN_STDERR" \
-        pattern     '^-pbpd 100 overrides --percentile-precision 7; using 100 buckets per decade\.$' \
-        asserts     'When both -pbpd and --percentile-precision are supplied, -pbpd wins. The override is now surfaced on stderr in addition to the -V histogram-bin-counters annotation it already had. Was previously only visible via -V.' \
-        produced_by 'adapt_to_command_line_options() in ltl (percentile-precision resolution; -pbpd-wins branch)' \
         contract    'features/225-test-harness-coverage-gaps.md section #231 - silent-override gap closure'
 }
 
@@ -400,10 +387,10 @@ scenario_no_warning_on_clean_run() {
         produced_by 'normal ltl execution' \
         contract    'baseline'
 
-    # None of the 4 silent-override warnings should fire on a clean run.
+    # None of the silent-override warnings should fire on a clean run.
     assert_no_line "$RUN_STDERR" \
-        pattern     "is not numeric|is not a built-in metric|overrides --percentile-precision|--exact-percentiles is deprecated" \
-        asserts     'A clean run produces none of the four silent-override warnings. This guards against the warnings firing on inputs they were not designed for.' \
+        pattern     "is not numeric|is not a built-in metric|--exact-percentiles is deprecated" \
+        asserts     'A clean run produces none of the silent-override warnings. This guards against the warnings firing on inputs they were not designed for.' \
         produced_by 'adapt_to_command_line_options() in ltl' \
         contract    'features/225-test-harness-coverage-gaps.md section #231 - warnings are gated on specific input shapes'
 }
@@ -419,7 +406,6 @@ scenario_runtime_config_env_only;                      echo ""
 scenario_runtime_config_env_overridden;                echo ""
 scenario_warning_g_non_numeric;                        echo ""
 scenario_warning_hm_non_builtin;                       echo ""
-scenario_warning_pbpd_overrides_pp;                    echo ""
 scenario_error_unknown_exact_percentiles;              echo ""
 scenario_runtime_config_data_model_selectors;          echo ""
 scenario_error_unknown_so;                             echo ""


### PR DESCRIPTION
Closes #293.

Unifies the fragmented statistical-resolution CLI surface into a single tiered precision lever.

## What changed

- **New lever:** `--data-model-precision` / `-dmp` (tier 1..9, default 5) is now the sole resolution knob. It resolves a **per-surface** bins-per-decade through a locked table (`%TIER_BPD`) — one dial governs all four bin-counter surfaces (histogram, heatmap, per-time-bucket, per-message) at per-surface fidelity. Tier 5 reproduces today's defaults, so the default is behavior-neutral.
- **Removed flags:** `-pbpd` / `--percentile-buckets-per-decade`, `-bsbpd` / `--bucket-stats-buckets-per-decade`, and the legacy display-density knob `-hgbpd` / `--histogram-buckets-per-decade`. No deprecation aliases; no precedence/conflict logic remains.
- **Histogram bar density unchanged:** the internal display constant (8 bars/decade) is retained, just no longer user-tunable. Rendering is byte-identical.
- **`-V`:** the run-level `percentile_precision:` key is renamed `data_model_precision:`; the now-ambiguous run-level `buckets_per_decade:` line is dropped (per-surface `effective_bpd:` in the `percentile-algorithm` section is authoritative). The `n/a` and `; overridden` source annotations are dissolved.
- **Contract:** `features/187` Decision 2 and Decision 8 amended to re-lock the single-lever surface, the per-surface tier table, and the `-V` field rename.
- **Docs/help/explain** swept to the single lever; two stale `-ep` references (removed in #287) cleaned from the histogram explain topic and its doc mirror.

## Per-surface tier table

| Surface | 1 | 2 | 3 | 4 | **5** | 6 | 7 | 8 | 9 |
|---|--|--|--|--|--|--|--|--|--|
| Histogram | 53 | 80 | 115 | 256 | **616** | 616 | 616 | 616 | 616 |
| Heatmap | 53 | 80 | 115 | 256 | **616** | 616 | 616 | 616 | 616 |
| Bucket-stats | 16 | 32 | 53 | 53 | **53** | 115 | 616 | 616 | 616 |
| Per-message | 4 | 8 | 16 | 32 | **53** | 80 | 115 | 256 | 616 |

## Verification (all green)

- `validate-histogram-bin-counters.sh` — 63/0 (incl. a new tier-table scenario asserting each surface's `effective_bpd` at tiers 1/5/7/9)
- `validate-runtime-config.sh` — 26/0
- `validate-statistics.sh` — 18/18, 0 T3/T4 across L1/L2/L3
- `validate-help-layout.sh` 6/0, `validate-help-content.sh` 8/0, `validate-explain.sh` 148/0, `validate-doc-examples.sh` 41/0

## Follow-up

`-hgb` / `--histogram-buckets` (render bin-count override) was left intact — it's a display-projection knob, distinct from data-model precision. Flagged on #204 as a removal candidate pending that investigation's results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)