### PR TITLE
Issue #302: fix calculate_statistics regression (candidate-pool message-key sort)

### DIFF
--- a/ltl
+++ b/ltl
@@ -9265,13 +9265,27 @@ sub calculate_all_statistics {
                 #
                 # Stage 1: sort by the metric ALONE (cheap numeric comparison,
                 # no string scan) to order all keys.
-                # Stage 2: take a generous candidate pool (far larger than N) off
-                # the top and apply the full deterministic tiebreaker only to
-                # that pool. The pool is large enough that the displayed top N is
-                # always within it whenever the top N have a distinguishing
-                # metric; among a block of metric-tied keys beyond the pool the
-                # exact order is immaterial (those keys are interchangeable and
-                # are not displayed).
+                # Stage 2: form a candidate pool of exactly the keys that could
+                # occupy a displayed slot, apply the full deterministic
+                # tiebreaker to that pool, then keep the top N.
+                #
+                # Only the top N keys are displayed. A key can reach a displayed
+                # slot only if its metric value is at least as good as the value
+                # at the display cut (rank N). Any key worse than the cut value
+                # can never be displayed regardless of how the tiebreaker falls,
+                # so it is excluded from the pool. Keys that TIE the cut value all
+                # compete for the remaining displayed slots, so the pool includes
+                # every key at the cut value (the tiebreaker decides among them).
+                #
+                # Anchoring at the display cut — not at some larger fixed pool
+                # size — is what keeps this both correct and fast: when the
+                # displayed top N is distinguished by the metric (the common
+                # case, e.g. high-occurrence messages) the pool is just N-ish keys
+                # and the expensive string tiebreaker runs on a handful; only when
+                # the displayed set itself sits inside a large metric-tie (e.g.
+                # -sa landing on all-occurrences-1 keys) does the pool grow to all
+                # tied keys, which is unavoidable to pick the right rows and was
+                # never fast in any version.
                 my @by_metric = sort {
                     my $occurrences_a = $log_messages{$category}{$a}{$sort_key} // 0;
                     my $occurrences_b = $log_messages{$category}{$b}{$sort_key} // 0;
@@ -9280,9 +9294,17 @@ sub calculate_all_statistics {
                         : ($occurrences_b <=> $occurrences_a);
                 } keys %{$log_messages{$category}};
 
-                my $pool_size = $top_n_messages * 100;
-                $pool_size = 1000 if $pool_size < 1000;
-                my @pool = @by_metric[0 .. min($#by_metric, $pool_size - 1)];
+                # Display cut: the last index that can be shown (rank N), clamped
+                # to the available keys.
+                my $cut = min($#by_metric, $top_n_messages - 1);
+                my $cut_val = $log_messages{$category}{$by_metric[$cut]}{$sort_key} // 0;
+                # Extend the pool past the cut through every key tied with the cut
+                # value on the sort metric — those are the only keys beyond rank N
+                # that could still claim a displayed slot via the tiebreaker.
+                my $pool_end = $cut;
+                $pool_end++ while $pool_end < $#by_metric
+                    && (($log_messages{$category}{$by_metric[$pool_end + 1]}{$sort_key} // 0) == $cut_val);
+                my @pool = @by_metric[0 .. $pool_end];
 
                 @sorted_log_keys = sort {
                     my $occurrences_a = $log_messages{$category}{$a}{$sort_key} // 0;

--- a/ltl
+++ b/ltl
@@ -141,6 +141,10 @@ my %verbose_sections_requested;   # Populated by adapt_to_command_line_options()
 my %verbose_section_buffer;
 # this is where the counts of log entries are tallied across the time buckets
 my ( %log_occurrences, %category_totals, %log_analysis, %log_messages, %log_stats, %log_threadpools, %threadpool_activity, %log_sessions );
+# Per-category message-key display order, computed once in calculate_all_statistics()
+# and reused by print_message_summary() so the same keys are not sorted twice
+# (Issue #302). Keyed by category ('plain'/'highlight').
+my %message_key_order;
 my $max_log_message_length = 0;				    # used to define the maximum key length of the log message bucket counts
 my $mask_uuid;									# temporary command line option to mask UUIDs with HASH characters for grouping purposes (to be replaced by more generic group similar feature)
 my @graph_columns = qw( duration bytes count );
@@ -9250,6 +9254,36 @@ sub calculate_all_statistics {
             my (@sorted_log_keys, @top_keys);
 
             if( $sort_key !~ /^(min|mean|max|std_dev|cv|iqr|skewness|kurtosis|bimodality_coef|p1|p5|p10|p25|p50|p75|p90|p95|p99|p999|p9999|p99999)$/ ) {
+                # Two-stage selection (Issue #302). Only the top N keys are ever
+                # displayed, but a deterministic total order (the metric, then a
+                # tiebreaker) is needed to pick them reproducibly. On a
+                # high-cardinality category (hundreds of thousands of keys, most
+                # tied on the metric), fully sorting every key with the
+                # string-key tiebreaker is the dominant cost — it rescans long,
+                # near-identical message keys on every one of the O(n log n)
+                # comparisons.
+                #
+                # Stage 1: sort by the metric ALONE (cheap numeric comparison,
+                # no string scan) to order all keys.
+                # Stage 2: take a generous candidate pool (far larger than N) off
+                # the top and apply the full deterministic tiebreaker only to
+                # that pool. The pool is large enough that the displayed top N is
+                # always within it whenever the top N have a distinguishing
+                # metric; among a block of metric-tied keys beyond the pool the
+                # exact order is immaterial (those keys are interchangeable and
+                # are not displayed).
+                my @by_metric = sort {
+                    my $occurrences_a = $log_messages{$category}{$a}{$sort_key} // 0;
+                    my $occurrences_b = $log_messages{$category}{$b}{$sort_key} // 0;
+                    $sort_ascending
+                        ? ($occurrences_a <=> $occurrences_b)
+                        : ($occurrences_b <=> $occurrences_a);
+                } keys %{$log_messages{$category}};
+
+                my $pool_size = $top_n_messages * 100;
+                $pool_size = 1000 if $pool_size < 1000;
+                my @pool = @by_metric[0 .. min($#by_metric, $pool_size - 1)];
+
                 @sorted_log_keys = sort {
                     my $occurrences_a = $log_messages{$category}{$a}{$sort_key} // 0;
                     my $occurrences_b = $log_messages{$category}{$b}{$sort_key} // 0;
@@ -9257,7 +9291,10 @@ sub calculate_all_statistics {
                         ? ($occurrences_a <=> $occurrences_b)
                         : ($occurrences_b <=> $occurrences_a))
                     || ($a cmp $b);
-                } keys %{$log_messages{$category}};
+                } @pool;
+                # Reuse this ordering in print_message_summary instead of sorting
+                # the same keys a second time (Issue #302).
+                $message_key_order{$category} = \@sorted_log_keys;
                 # Capture only the top N log keys for calculations if possible
                 @top_keys = @sorted_log_keys[0 .. min($#sorted_log_keys, $top_n_messages - 1)];
             } else {
@@ -12015,6 +12052,17 @@ sub print_message_summary {
     my %sorted_keys = ( 'highlight' => [], 'plain' => [] );
 
     foreach my $grouping ( qw( highlight plain ) ) {
+        # Reuse the ordering already computed in calculate_all_statistics when the
+        # sort metric is an available field (Issue #302): same keys, same
+        # comparator, same result — re-sorting a high-cardinality category here
+        # is redundant. Only the top N are ever displayed, and that ordering
+        # already selected them. The order is absent only when sorting on a
+        # computed statistic (ordered only after the stats exist), so fall back
+        # to a local sort there.
+        if ($message_key_order{$grouping}) {
+            $sorted_keys{$grouping} = $message_key_order{$grouping};
+            next;
+        }
         my @sorted_keys = sort {
             my $occurrences_a = $log_messages{$grouping}{$a}{$sort_key} // 0;
             my $occurrences_b = $log_messages{$grouping}{$b}{$sort_key} // 0;


### PR DESCRIPTION
Fixes the v0.15.0 `calculate_statistics` performance regression surfaced by the v0.14.5→v0.15.0 benchmark comparison.

## Root cause

The per-message-key sort fully ordered **every** key (hundreds of thousands on a high-cardinality category) with a string-key tiebreaker, just to display the top N. The #269 determinism tiebreaker (`$a cmp $b`) made this pathological on event logs whose keys differ only by an embedded UUID: the comparator rescans the long shared prefix on every one of the O(n log n) comparisons. Measured on the unique-errors fixture: `calculate_statistics` 0.28s (v0.14.5) → 2.19s (v0.15.0).

The cost is the **sort**, not the statistics math (probe: sort 2.5s, stats-loop 0s; NYTProf localized it to the comparator over real long keys). It is independent of the data model (`-dm raw` reproduces it).

## Fix

Two-stage selection for the available-value sorts (occurrences/duration/bytes/impact — the metric is already known after parse):

1. **Stage 1:** sort by the metric alone (cheap numeric, no string scan).
2. **Stage 2:** form a candidate pool of exactly the keys that could occupy a displayed slot — anchored at the **display cut (rank N)** plus all keys tied at the cut value — and apply the full deterministic tiebreaker only to that pool.

`print_message_summary` reuses this ordering instead of sorting the same keys a second time.

Anchoring at the display cut (not a fixed pool size) is what makes it both correct and fast: when the top N is metric-distinguished the pool is ~N keys; only when the displayed set sits inside a large metric-tie (e.g. `-sa` on all-occurrences-1 keys) does the pool grow to all tied keys — unavoidable to pick the right rows, and never fast in any version. An earlier fixed-size pool was correct+fast on the descending humongous case but produced wrong output under `-sa`; the display-cut anchor closes that.

## Verification

`calculate_statistics` on the unique-errors fixture: 2.19s → 0.28s (v0.14.5 baseline 0.275s). Output **byte-identical** to release/0.15.0 across: humongous descending + `-sa`, access-log descending + `-sa`. Regression harness 38/0.

The calculated-statistic sort path (`-so p99` etc.) is **not** changed here — its value doesn't exist until stats are computed, so it can't use the pool. That path's benchmark coverage + optimization is tracked in #303.

Closes #302.