### PR TITLE
Issue #309: informational options take precedence; classify option errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ For more on the design philosophy and intended workflow, see [Purpose and Design
 ltl [options] <logfile> [logfile2 ...]
 ```
 
+`--help`, `--explain`, and `--version` print their output and exit immediately, before any file is read or any other option is validated (with `--help` taking precedence over `--explain`, then `--version`). Options must be given by their full long name or a documented short form; unique-prefix abbreviations are not accepted.
+
 ## Documentation
 
 See the [Usage Reference](https://github.com/gregeva/logtimeline/wiki) for the full options reference, feature explanations, and examples.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -427,8 +427,13 @@ Version, help, and diagnostic options.
 | Option | Description |
 |--------|-------------|
 | `-v, --version` | Print the version number and exit |
-| `--help` | Show the help screen and exit |
+| `--help [<topic>]` | Show the help screen and exit; `--help statistics` shows the grouped statistics index |
+| `-ex, --explain [<topic>]` | Show long-form documentation for a statistic; bare `--explain` lists topics |
 | `-mem, --memory-usage` | Display memory consumption statistics after processing completes |
+
+`--help`, `--explain`, and `--version` print their output and exit immediately, before any file is read or any other option is validated. When more than one is given, `--help` takes precedence over `--explain`, which takes precedence over `--version`.
+
+Options must be given by their full long name or a documented short form; unique-prefix abbreviations of long options are not accepted.
 
 ## Alternate Names
 

--- a/ltl
+++ b/ltl
@@ -42,7 +42,7 @@ use POSIX qw(strftime floor);
 use Time::Piece;
 use Time::Local qw(timegm);
 use Term::ReadKey;
-use Getopt::Long qw(:config no_ignore_case);
+use Getopt::Long qw(:config no_ignore_case no_auto_abbrev);
 use Term::ANSIColor;
 use Time::HiRes qw(gettimeofday tv_interval);
 use Devel::Size qw(total_size);
@@ -3974,10 +3974,13 @@ sub print_help {
 
     # INFO
     $out .= help_heading("INFO");
-    $out .= help_opt("-v,   --version",       "Print the version number and exit");
+    $out .= help_opt("-v,   --version",       "Print the version number and exit. Takes precedence over normal processing: prints and exits without reading any file.");
     $out .= help_opt("      --help [<topic>]","Show this help screen and exit. With 'statistics', shows the grouped index of statistics emitted in the summary and CSV.");
     $out .= help_opt("-ex,  --explain [<topic>]", "Show long-form documentation for a statistic. Bare --explain lists available topics. Aliases shared with -so (avg, stddev, p1..p99999).");
     $out .= help_opt("-mem, --memory-usage",  "Display memory consumption statistics after processing completes");
+    $out .= "\n";
+    $out .= help_wrap("--help, --explain, and --version print their output and exit immediately, before any file is read or any other option is validated. When more than one is given, --help wins over --explain, which wins over --version.", indent => 2, first_indent => 2) . "\n";
+    $out .= help_wrap("Options must be given by their full long name or a documented short form; unique-prefix abbreviations of long options are not accepted.", indent => 2, first_indent => 2) . "\n";
 
     $out .= help_heading("EXAMPLES");
     my $ex_desc_col = 68;  # description column for examples (commands are longer than options)
@@ -6566,6 +6569,132 @@ sub handle_histogram_option {
     # If no specific metrics given, will default to all available after parsing
 }
 
+# Informational options (--help, --explain, --version) print their output and
+# exit immediately. They are dispatched from a raw-@ARGV scan BEFORE GetOptions
+# so they take precedence over option parsing and over every downstream
+# validation — a malformed companion option cannot suppress them. When more
+# than one is present the fixed priority is help > explain > version,
+# independent of command-line position; the first match in that order wins and
+# the process exits.
+sub dispatch_informational_options {
+    my ($argv) = @_;
+    my @args = @$argv;   # scan a copy; never mutate the caller's @ARGV
+
+    # The only recognized --help topic keyword; anything else after a bare
+    # --help is a positional (e.g. a logfile), not a topic.
+    my %help_topics = ( statistics => 1 );
+
+    my ($want_help, $help_topic)       = (0, '');
+    my ($want_explain, $explain_topic) = (0, '');
+    my $want_version                   = 0;
+
+    for (my $i = 0; $i < @args; $i++) {
+        my $tok = $args[$i];
+
+        # --help / -help, with optional =topic or a following topic token.
+        if ($tok eq '--help' || $tok eq '-help') {
+            $want_help = 1;
+            # Help has exactly one valid topic keyword (statistics); a bare
+            # following word is consumed as a topic ONLY when it is that
+            # keyword, otherwise it is left as a positional. This is what makes
+            # `--help <logfile>` render full help instead of erroring.
+            my $next = $args[$i + 1];
+            if (defined $next && $next !~ /^-/ && $help_topics{$next}) {
+                $help_topic = $next;
+            }
+        }
+        elsif ($tok =~ /^--help=(.*)$/s) {
+            $want_help  = 1;
+            $help_topic = $1;
+        }
+        # --explain / -ex, with optional =topic or a following topic token.
+        elsif ($tok eq '--explain' || $tok eq '-ex') {
+            $want_explain = 1;
+            # Explain's topic namespace is large (all -so/-explain aliases), so
+            # a bare following non-flag word is treated as a topic candidate and
+            # validated below (unknown -> error), matching existing behavior.
+            my $next = $args[$i + 1];
+            if (defined $next && $next !~ /^-/) {
+                $explain_topic = $next;
+            }
+        }
+        elsif ($tok =~ /^(?:--explain|-ex)=(.*)$/s) {
+            $want_explain  = 1;
+            $explain_topic = $1;
+        }
+        # --version / -v (case-sensitive: -v only, never -V).
+        elsif ($tok eq '--version' || $tok eq '-v') {
+            $want_version = 1;
+        }
+    }
+
+    # Fixed priority: help > explain > version.
+    if ($want_help) {
+        if ($help_topic eq '') {
+            print_help();            # already paginated internally
+        }
+        elsif ($help_topic eq 'statistics') {
+            my $out = print_help_statistics();
+            $out =~ s/^\n+//;
+            pipe_to_pager($out);
+        }
+        else {
+            die print_usage("unknown --help topic '$help_topic' (try: statistics)");
+        }
+        exit 0;
+    }
+    if ($want_explain) {
+        my $out;
+        if ($explain_topic eq '') {
+            $out = print_explain_registry();
+        }
+        else {
+            my $topic = resolve_explain_topic($explain_topic);
+            if (!defined $topic) {
+                die print_usage("unknown --explain topic '$explain_topic' (try: 'ltl --explain' for the list)");
+            }
+            $out = print_explain_topic($topic);
+        }
+        $out =~ s/^\n+//;
+        pipe_to_pager($out);
+        exit 0;
+    }
+    if ($want_version) {
+        print_version();
+        exit 0;
+    }
+
+    return;
+}
+
+# Turn Getopt::Long's captured parse-failure diagnostics into a single,
+# specific, user-facing message that names the offending option/value. Getopt
+# reports the option name without dashes; _dash_prefix restores the form the
+# user typed. The generic "required options not provided" wording survives only
+# as the no-match fallback, so it is no longer shown for the common
+# unknown-option case (where the required options were in fact provided).
+sub _dash_prefix {
+    my ($name) = @_;
+    return (length($name) == 1 ? "-$name" : "--$name");
+}
+
+sub classify_option_error {
+    my ($warnings) = @_;
+    for my $w (@{ $warnings || [] }) {
+        if ($w =~ /^Unknown option:\s+(\S+)/) {
+            return "unknown option '" . _dash_prefix($1) . "'";
+        }
+        if ($w =~ /^Option\s+(\S+)\s+requires an argument/) {
+            return "option '" . _dash_prefix($1) . "' requires a value";
+        }
+        if ($w =~ /^Option\s+(\S+)\s+is ambiguous/) {
+            # Should not fire once no_auto_abbrev is set; kept as a safety net.
+            return "unknown option '" . _dash_prefix($1) . "'";
+        }
+    }
+    return "required options not provided";
+}
+
 sub adapt_to_command_line_options {
     @ORIGINAL_ARGV = @ARGV;
 
@@ -6586,7 +6715,22 @@ sub adapt_to_command_line_options {
 
     @ARGV = map { ($_ eq '-?' || $_ eq '/help' || $_ eq '/?') ? '--help' : $_ } @ARGV;
 
-    GetOptions(
+    # Informational options (--help, --explain, --version) print their output
+    # and exit immediately, taking precedence over option parsing and over any
+    # other validation. Dispatching here — before GetOptions — means a
+    # malformed companion option (e.g. `--version -b 5`) cannot suppress the
+    # informational output. When more than one is present, the fixed priority
+    # is help > explain > version, independent of command-line position.
+    dispatch_informational_options(\@ARGV);
+
+    # Capture Getopt::Long's own diagnostics (which it would otherwise warn
+    # straight to stderr) so a parse failure can be reported as a specific,
+    # named error rather than the misleading generic "required options not
+    # provided". See classify_option_error().
+    my @getopt_warnings;
+    my $getopt_ok = do {
+        local $SIG{__WARN__} = sub { push @getopt_warnings, $_[0]; };
+        GetOptions(
         'bucket-size|bs=i' => \$time_bucket_size,
         'pause|p' => \$pause_output,
         'start|st=s' => \$filter_range_start,
@@ -6671,7 +6815,11 @@ sub adapt_to_command_line_options {
         'validate-layout' => \$validate_layout,                                     # hidden
         'help:s'       => \$show_help,                                              # hidden — special-cased; legacy aliases -?/--help via PreProcessor. Optional arg: '' = full help; 'statistics' = stats index; other = error (Issue #261).
         'explain|ex:s' => \$explain_arg,                                            # Issue #261: optional arg: '' = topic registry; <topic> = long-form explanation. Aliases shared with -so (avg, stddev, p1..p99999).
-    ) or die print_usage( "required options not provided" );
+        );
+    };
+    unless ($getopt_ok) {
+        die print_usage( classify_option_error(\@getopt_warnings) );
+    }
 
     # Issue #226: -V section selectivity. Resolve @verbose_args (raw from
     # GetOptions :s@) into %verbose_sections_requested. See HARNESS-DESIGN.md
@@ -6922,49 +7070,9 @@ sub adapt_to_command_line_options {
     # features/225-test-harness-coverage-gaps.md § #231.
     emit_runtime_config_verbose();
 
-    if( $print_version ) {
-        print_version();
-        exit;
-    }
-
-    # --help dispatch (Issue #261). $show_help is defined when --help was
-    # given (bare = ''; --help statistics = 'statistics'; --help <other> = error).
-    # All help variants pipe through the pager so long output (esp. the
-    # percentiles topic) is browsable. The leading newline emitted by
-    # help_heading is stripped to avoid double-blanks against the banner.
-    if ( defined $show_help ) {
-        if ( $show_help eq '' ) {
-            print_help();         # already paginated internally
-            exit 0;
-        }
-        elsif ( $show_help eq 'statistics' ) {
-            my $out = print_help_statistics();
-            $out =~ s/^\n+//;     # strip leading blank lines (Issue #261)
-            pipe_to_pager($out);
-            exit 0;
-        }
-        else {
-            die print_usage("unknown --help topic '$show_help' (try: statistics)");
-        }
-    }
-
-    # --explain dispatch (Issue #261). $explain_arg is defined when --explain
-    # was given (bare = ''; --explain <topic> = topic name).
-    if ( defined $explain_arg ) {
-        my $out;
-        if ( $explain_arg eq '' ) {
-            $out = print_explain_registry();
-        } else {
-            my $topic = resolve_explain_topic($explain_arg);
-            if ( !defined $topic ) {
-                die print_usage("unknown --explain topic '$explain_arg' (try: 'ltl --explain' for the list)");
-            }
-            $out = print_explain_topic($topic);
-        }
-        $out =~ s/^\n+//;         # strip leading blank lines (Issue #261)
-        pipe_to_pager($out);
-        exit 0;
-    }
+    # --help, --explain, and --version are handled by
+    # dispatch_informational_options() before GetOptions runs; $show_help,
+    # $explain_arg, and $print_version are populated here but no longer read.
 
     foreach my $pattern (@ARGV) {									# do in process file globbing for common experience across environments (Windows doesn't glob in the shell, passes in the parameters)
         push @in_files, glob($pattern);

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -263,14 +263,14 @@ scenario_error_unknown_exact_percentiles() {
 
     assert_exit "$RUN_EXIT" 1 \
         asserts     '--exact-percentiles is not a known flag; ltl rejects it as an unknown option and exits non-zero. The flag is no longer part of the CLI surface; opt-out is via the per-surface data-model selector (-dm raw / -hgdm raw / -hmdm raw / -mdm raw / -bdm raw) per Issue #266.' \
-        produced_by 'Getopt::Long rejecting an unrecognized long option in adapt_to_command_line_options()' \
+        produced_by 'GetOptions parse failure classified by classify_option_error() in adapt_to_command_line_options()' \
         contract    'Issue #266 + Issue #287 - --exact-percentiles was the legacy F2/F3 opt-out; the data-model selectors are the locked replacement.'
 
-    assert_line "$RUN_STDERR" \
-        pattern     '^Unknown option: exact-percentiles' \
-        asserts     'The user-visible error names the unknown option so the user knows which flag was rejected.' \
-        produced_by 'Getopt::Long default error formatter' \
-        contract    'Issue #266 + Issue #287 - flag-removal error surface.'
+    assert_line "$RUN_STDOUT" \
+        pattern     "unknown option '--exact-percentiles'" \
+        asserts     'The user-visible error names the unknown option, using the specific unknown-option message (not the generic "required options not provided"), so the user knows which flag was rejected.' \
+        produced_by 'classify_option_error() in ltl, rendered via print_usage()' \
+        contract    'Issue #309 - option-error classification names each error case; message wording owned by #309, presentation/stream owned by #308.'
 }
 
 # Issue #287: assert that the per-surface data-model selectors surface in
@@ -395,6 +395,57 @@ scenario_no_warning_on_clean_run() {
         contract    'features/225-test-harness-coverage-gaps.md section #231 - warnings are gated on specific input shapes'
 }
 
+scenario_info_version_wins_over_parse_error() {
+    current_scenario="info-version-wins-over-parse-error"
+    echo "[$current_scenario]"
+
+    run_ltl "info-ver" --version -b 5 "$TEST_LOG"
+    assert_exit "$RUN_EXIT" 0 \
+        asserts     'An informational option (--version) short-circuits before GetOptions runs, so an otherwise-fatal malformed companion option (-b, unknown post no_auto_abbrev) never triggers a parse error; the version prints and the process exits 0.' \
+        produced_by 'dispatch_informational_options() in adapt_to_command_line_options() in ltl (pre-parse @ARGV scan)' \
+        contract    'Issue #309 - informational options take precedence over option parsing and validation.'
+
+    assert_line "$RUN_STDOUT" \
+        pattern     '^Version: ' \
+        asserts     'The version line is printed despite the malformed companion option.' \
+        produced_by 'print_version() dispatched from dispatch_informational_options()' \
+        contract    'Issue #309 - informational-option precedence.'
+}
+
+scenario_info_help_beats_version() {
+    current_scenario="info-help-beats-version"
+    echo "[$current_scenario]"
+
+    run_ltl "info-help-ver" --help --version "$TEST_LOG"
+    assert_exit "$RUN_EXIT" 0 \
+        asserts     'When multiple informational options are given, the fixed priority is help > explain > version regardless of command-line position; --help --version prints help and exits 0.' \
+        produced_by 'dispatch_informational_options() in ltl (fixed help>explain>version priority)' \
+        contract    'Issue #309 - informational-option precedence order.'
+
+    assert_line "$RUN_STDOUT" \
+        pattern     'USAGE' \
+        asserts     'The help body (which contains the USAGE heading) is printed, proving help won over version.' \
+        produced_by 'print_help() dispatched from dispatch_informational_options()' \
+        contract    'Issue #309 - informational-option precedence order.'
+}
+
+scenario_error_unknown_short_b() {
+    current_scenario="error-unknown-short-b"
+    echo "[$current_scenario]"
+
+    run_ltl "err-b" -b 5 "$TEST_LOG"
+    assert_exit "$RUN_EXIT" 1 \
+        asserts     'With no_auto_abbrev, -b is no longer a unique-prefix abbreviation of any long option; it is a clean unknown option (not "ambiguous", not silently accepted) and exits 1.' \
+        produced_by 'GetOptions parse failure classified by classify_option_error() in ltl' \
+        contract    'Issue #309 - no_auto_abbrev + option-error classification.'
+
+    assert_line "$RUN_STDOUT" \
+        pattern     "unknown option '-b'" \
+        asserts     'The user-visible error names the specific unknown option (-b), not the generic "required options not provided".' \
+        produced_by 'classify_option_error() in ltl, rendered via print_usage()' \
+        contract    'Issue #309 - option-error classification.'
+}
+
 # ---------- Run -----------------------------------------------------------
 
 echo "Validating runtime-config -V section + CLI validation paths (issue #231)"
@@ -412,6 +463,9 @@ scenario_error_unknown_so;                             echo ""
 scenario_error_unknown_du;                             echo ""
 scenario_error_unknown_ru;                             echo ""
 scenario_error_no_files;                               echo ""
+scenario_info_version_wins_over_parse_error;           echo ""
+scenario_info_help_beats_version;                      echo ""
+scenario_error_unknown_short_b;                        echo ""
 scenario_no_warning_on_clean_run
 
 echo ""


### PR DESCRIPTION
Fixes #309.

## What changed

- **Precedence:** `--help`/`--explain`/`--version` dispatch from a pre-parse `@ARGV` scan before `GetOptions`, so they print and exit before any parsing, validation, or file read. `ltl --version -b 5` now prints the version and exits 0. Fixed priority: **help > explain > version**.
- **`--help <logfile>` bug fixed:** a following non-topic token is no longer swallowed as a help topic.
- **`no_auto_abbrev`:** unique-prefix abbreviations (e.g. `-b`) are now rejected as clean unknown options instead of silently aliasing or reporting "ambiguous". Documented behavior change; existing indexes/tests rely on no abbreviations.
- **Specific error messages:** `classify_option_error()` replaces the generic (and false) "required options not provided" with named cases — `unknown option '-b'`, `option '-X' requires a value` — from Getopt::Long's captured diagnostics.

## Boundary with #308

#309 owns the message *wording* and precedence; #308 (lands next) owns the error-block *presentation* (co-location, bold, STDERR, removing the `Died at` trace). The `Error:` line is still red/STDOUT here by design.

## Testing

- `tests/validate-runtime-config.sh`: 32 passed, 0 failed. Updated the exact-percentiles scenario; added `info-version-wins-over-parse-error`, `info-help-beats-version`, `error-unknown-short-b`.
- Behavioral recipe verified: version-wins-over-parse-error, help-short-circuit, help-beats-version, `-b` unknown-option, `-ru` validator preserved, `-bs` still parses.

## Docs

`print_help()`, `docs/usage.md`, `README.md` note the short-circuit precedence and the no-abbreviation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)