### PR TITLE
Issue #308: co-locate command-line errors in one bold block on stderr

### DIFF
--- a/ltl
+++ b/ltl
@@ -2512,11 +2512,21 @@ sub print_title {
 }
 
 sub print_usage {
-    my ( $error_reason ) = @_;
-    print "Usage: ltl [-bs <N>] [-n <N>] [-i <regex>] [-e <regex>] [-h <regex>] [-st <time>] [-et <time>]\n";
-    print "           [-ov] [-or] [-ru <unit>] [-osum] [-so <field>] [-hm [metric]] [-hg [metric]] <logfile> ...\n";
-    print "\n  $colors{'red'}Error: $error_reason$colors{'NC'}\n\n" if defined $error_reason;
-    print "Try 'ltl --help' for more information.\n\n";
+    my ( $error_reason, $parser_text ) = @_;
+    # All command-line diagnostics go to STDERR so both the parser's own
+    # message and ltl's error line appear together as one block, out of any
+    # piped data stream. Layout: usage paragraph, one blank line, the error
+    # block (the raw parser line if any, then ltl's Error line), one blank
+    # line, then the help pointer.
+    print STDERR "Usage: ltl [-bs <N>] [-n <N>] [-i <regex>] [-e <regex>] [-h <regex>] [-st <time>] [-et <time>]\n";
+    print STDERR "           [-ov] [-or] [-ru <unit>] [-osum] [-so <field>] [-hm [metric]] [-hg [metric]] <logfile> ...\n";
+    print STDERR "\n";
+    # The raw parser line is printed verbatim and un-bolded so it stays
+    # escape-free at line start regardless of colour settings.
+    print STDERR $parser_text if defined $parser_text && $parser_text ne '';
+    print STDERR bs_bold("Error: $error_reason") . "\n" if defined $error_reason;
+    print STDERR "\n";
+    print STDERR "Try 'ltl --help' for more information.\n";
     return;
 }
 
@@ -6639,7 +6649,8 @@ sub dispatch_informational_options {
             pipe_to_pager($out);
         }
         else {
-            die print_usage("unknown --help topic '$help_topic' (try: statistics)");
+            print_usage("unknown --help topic '$help_topic' (try: statistics)");
+            exit 1;
         }
         exit 0;
     }
@@ -6651,7 +6662,8 @@ sub dispatch_informational_options {
         else {
             my $topic = resolve_explain_topic($explain_topic);
             if (!defined $topic) {
-                die print_usage("unknown --explain topic '$explain_topic' (try: 'ltl --explain' for the list)");
+                print_usage("unknown --explain topic '$explain_topic' (try: 'ltl --explain' for the list)");
+                exit 1;
             }
             $out = print_explain_topic($topic);
         }
@@ -6818,7 +6830,8 @@ sub adapt_to_command_line_options {
         );
     };
     unless ($getopt_ok) {
-        die print_usage( classify_option_error(\@getopt_warnings) );
+        print_usage( classify_option_error(\@getopt_warnings), join('', @getopt_warnings) );
+        exit 1;
     }
 
     # Issue #226: -V section selectivity. Resolve @verbose_args (raw from
@@ -6988,16 +7001,16 @@ sub adapt_to_command_line_options {
 
     # Duration unit option validation (Issue #17)
     if (defined $duration_unit_override) {
-        die print_usage("Invalid duration unit '$duration_unit_override'. Valid values: ns, us, ms, s")
+        do { print_usage("Invalid duration unit '$duration_unit_override'. Valid values: ns, us, ms, s"); exit 1; }
             unless $duration_unit_override =~ /^(ns|us|ms|s)$/;
     }
 
     # Rate unit option validation (Issue #122)
-    die print_usage("Invalid rate unit '$rate_unit'. Valid values: s, m, h, d")
+    do { print_usage("Invalid rate unit '$rate_unit'. Valid values: s, m, h, d"); exit 1; }
         unless $rate_unit =~ /^(s|m|h|d)$/;
 
     # CSV precision option validation (Issue #268)
-    die print_usage("Invalid --csv-precision value '$csv_precision'. Valid values: default, full, or a non-negative integer.")
+    do { print_usage("Invalid --csv-precision value '$csv_precision'. Valid values: default, full, or a non-negative integer."); exit 1; }
         unless $csv_precision eq 'default' || $csv_precision eq 'full' || $csv_precision =~ /^\d+$/;
 
     # Resolve duration unit for CSV emission (Issue #268). When -du is set,
@@ -7080,8 +7093,8 @@ sub adapt_to_command_line_options {
 
 	@in_files = grep { -f $_ } @in_files;								# only accept files in list to be read (remove anything else in the globbed directory list)
 
-    die print_usage( "unable to open any files" ) unless @in_files;
-    die print_usage( "invalid sort type used" ) unless grep { $_ eq $sort_type } qw(
+    do { print_usage( "unable to open any files" ); exit 2; } unless @in_files;
+    do { print_usage( "invalid sort type used" ); exit 1; } unless grep { $_ eq $sort_type } qw(
         occurrences total duration time bytes size mean_bytes impact cv
         count count_occurrences count_total count_sum count_min count_mean count_avg count_max
         std_dev stddev min mean avg max

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -266,11 +266,11 @@ scenario_error_unknown_exact_percentiles() {
         produced_by 'GetOptions parse failure classified by classify_option_error() in adapt_to_command_line_options()' \
         contract    'Issue #266 + Issue #287 - --exact-percentiles was the legacy F2/F3 opt-out; the data-model selectors are the locked replacement.'
 
-    assert_line "$RUN_STDOUT" \
+    assert_line "$RUN_STDERR" \
         pattern     "unknown option '--exact-percentiles'" \
         asserts     'The user-visible error names the unknown option, using the specific unknown-option message (not the generic "required options not provided"), so the user knows which flag was rejected.' \
-        produced_by 'classify_option_error() in ltl, rendered via print_usage()' \
-        contract    'Issue #309 - option-error classification names each error case; message wording owned by #309, presentation/stream owned by #308.'
+        produced_by 'classify_option_error() in ltl, rendered via print_usage() to stderr' \
+        contract    'Issue #309 - option-error classification names each error case; Issue #308 co-locates the error block on stderr.'
 }
 
 # Issue #287: assert that the per-surface data-model selectors surface in
@@ -312,14 +312,15 @@ scenario_error_unknown_so() {
         produced_by 'adapt_to_command_line_options() in ltl (sort-on enum validation), via print_usage() exit 1' \
         contract    'features/225-test-harness-coverage-gaps.md section #231 - hard-error paths pin current exit code; exit-code policy normalization is deferred to a separate ticket per scoping decision'
 
-    # ltl emits the error banner (including "Error: invalid sort type used") on
-    # stdout via print_usage(); only the bare "Died at ..." Perl trace goes to
-    # stderr. The harness asserts against the user-visible diagnostic, hence stdout.
-    assert_line "$RUN_STDOUT" \
+    # ltl emits the error block (including "Error: invalid sort type used") on
+    # stderr via print_usage(); print_usage exits directly, so there is no
+    # "Died at ..." Perl trace. The harness asserts against the user-visible
+    # diagnostic, hence stderr.
+    assert_line "$RUN_STDERR" \
         pattern     'invalid sort type' \
-        asserts     'The user-visible diagnostic (emitted via print_usage to stdout) identifies the failed validation (sort type).' \
+        asserts     'The user-visible diagnostic (emitted via print_usage to stderr) identifies the failed validation (sort type).' \
         produced_by 'print_usage("invalid sort type used") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md section #231 - pinning current diagnostic surface; new error-format normalization is out of scope'
+        contract    'features/225-test-harness-coverage-gaps.md section #231 - pinning current diagnostic surface; Issue #308 routes the error block to stderr'
 }
 
 scenario_error_unknown_du() {
@@ -332,11 +333,11 @@ scenario_error_unknown_du() {
         produced_by 'adapt_to_command_line_options() in ltl (duration-unit enum validation)' \
         contract    'features/225-test-harness-coverage-gaps.md section #231'
 
-    assert_line "$RUN_STDOUT" \
+    assert_line "$RUN_STDERR" \
         pattern     "Invalid duration unit" \
-        asserts     'The user-visible diagnostic (stdout) identifies the failed validation (duration unit).' \
+        asserts     'The user-visible diagnostic (stderr) identifies the failed validation (duration unit).' \
         produced_by 'print_usage("Invalid duration unit ...") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md section #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231; Issue #308 routes the error block to stderr'
 }
 
 scenario_error_unknown_ru() {
@@ -349,11 +350,11 @@ scenario_error_unknown_ru() {
         produced_by 'adapt_to_command_line_options() in ltl (rate-unit enum validation)' \
         contract    'features/225-test-harness-coverage-gaps.md section #231'
 
-    assert_line "$RUN_STDOUT" \
+    assert_line "$RUN_STDERR" \
         pattern     "Invalid rate unit" \
-        asserts     'The user-visible diagnostic (stdout) identifies the failed validation (rate unit).' \
+        asserts     'The user-visible diagnostic (stderr) identifies the failed validation (rate unit).' \
         produced_by 'print_usage("Invalid rate unit ...") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md section #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231; Issue #308 routes the error block to stderr'
 }
 
 scenario_error_no_files() {
@@ -370,11 +371,11 @@ scenario_error_no_files() {
         produced_by 'adapt_to_command_line_options() in ltl (post-glob @in_files empty check)' \
         contract    'features/225-test-harness-coverage-gaps.md section #231 - exit-code disparity (1 vs 2) intentionally pinned; harmonization deferred to a separate ticket'
 
-    assert_line "$RUN_STDOUT" \
+    assert_line "$RUN_STDERR" \
         pattern     'unable to open any files' \
-        asserts     'The user-visible diagnostic (stdout) surfaces the empty-@in_files condition.' \
+        asserts     'The user-visible diagnostic (stderr) surfaces the empty-@in_files condition.' \
         produced_by 'print_usage("unable to open any files") in adapt_to_command_line_options()' \
-        contract    'features/225-test-harness-coverage-gaps.md section #231'
+        contract    'features/225-test-harness-coverage-gaps.md section #231; Issue #308 routes the error block to stderr'
 }
 
 scenario_no_warning_on_clean_run() {
@@ -439,11 +440,11 @@ scenario_error_unknown_short_b() {
         produced_by 'GetOptions parse failure classified by classify_option_error() in ltl' \
         contract    'Issue #309 - no_auto_abbrev + option-error classification.'
 
-    assert_line "$RUN_STDOUT" \
+    assert_line "$RUN_STDERR" \
         pattern     "unknown option '-b'" \
         asserts     'The user-visible error names the specific unknown option (-b), not the generic "required options not provided".' \
-        produced_by 'classify_option_error() in ltl, rendered via print_usage()' \
-        contract    'Issue #309 - option-error classification.'
+        produced_by 'classify_option_error() in ltl, rendered via print_usage() to stderr' \
+        contract    'Issue #309 - option-error classification; Issue #308 co-locates the error block on stderr.'
 }
 
 # ---------- Run -----------------------------------------------------------


### PR DESCRIPTION
Fixes #308. Builds on #309 (merged) — uses its captured parser text and classified messages.

## What changed

- **Co-located block on stderr:** `print_usage` routes all output to stderr and renders the parser message + ltl's `Error:` line as one paragraph: usage → one blank line → error block → one blank line → `Try 'ltl --help'`. Both messages now appear together instead of on different streams in different places.
- **Bold, not red:** the red colour is dropped; only ltl's `Error:` line is bolded (via `bs_bold` / `help_ansi_enabled()`). The raw parser line is printed verbatim and un-bolded so it stays escape-free at line start.
- **No `Died at` trace:** every command-line-error path now `print_usage(...); exit N` instead of `die`. Exit codes preserved — 1 for option/validation errors, 2 for no-files.

## Anchor safety

Bolding only the `Error:` line (not the parser line) keeps the `^Unknown option:` harness anchor clean even under `FORCE_COLOR=3` (which this environment sets globally and the harness does not scrub).

## Testing

`tests/validate-runtime-config.sh`: **32 passed, 0 failed under both `FORCE_COLOR=3` and a scrubbed environment.** Four option-error scenarios plus the #309 classified-message scenarios moved to assert on stderr; stale comment corrected. Verified layout, one-blank-line spacing, bold-Error-only, escape-free parser line, plain under NO_COLOR, no `Died at`, exit codes 1/1/2.

## Docs

No changes needed — no new flag, and no user-facing doc reproduces the old error layout (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)