### PR TITLE
Issue #310: fix index read-back so a filtered run is never served a whole-file max

### DIFF
--- a/features/179-index-read-back.md
+++ b/features/179-index-read-back.md
@@ -127,9 +127,13 @@ The section content must be sufficient for an external test to assert that read-
 === INDEX READ-BACK ===
 index_used: yes|no
 index_filter_signature: <serialized filters or "-">
+heatmap_preseed_min: <value or "-">    (only when a heatmap is active)
+heatmap_preseed_max: <value or "-">    (only when a heatmap is active)
 ```
 
 `index_filter_signature` is the run's filter signature. Always emitted. Lets tests confirm the run was identified with the expected filter context.
+
+`heatmap_preseed_min` / `heatmap_preseed_max` are the live heatmap bounds after any index pre-seed, emitted only when a heatmap is active. They are the values that scale the heatmap axis, and let tests confirm that a filtered run is never seeded with a whole-file (Tier-2) maximum.
 
 #### Layer 2 — Per-file lookup result
 
@@ -210,7 +214,9 @@ Each input file is checked independently for tier matching and freshness. Pre-se
 
 Filters are the *primary* reason this feature has tiered lookup. A filtered run looks for a Tier 1 selection entry matching `(file_path, filter_signature)`. This is the most-specific match and the most accurate pre-seed.
 
-Filter signature comparison is exact-string against the value produced by the existing serialization. Different filter values → different signatures → different selection entries. The signature is alphabetically sorted and URL-encoded by the existing write side; read-back reproduces the same signature for the current run and compares as exact strings.
+Filter signature comparison is exact-string against the value produced by the existing serialization. Different filter values → different signatures → different selection entries. The signature is alphabetically sorted and URL-encoded by the existing write side; read-back reproduces the same signature for the current run and compares as exact strings. Repeated multi-value filter flags are canonicalized by sorting the values within each flag, so the same logical selection produces one identical signature regardless of the order the values were given on the command line (e.g. `-e A -e B` and `-e B -e A` match the same selection entry).
+
+A filtered run that does not find a matching selection entry falls back to the file entry (Tier 2). The file entry's bounds describe the *whole file*, which over-states a filtered population, so a filtered Tier-2 run is **not** pre-seeded from the file entry's bounds for heatmap scaling — the live pass discovers the filtered bounds directly, exactly as an un-indexed run would. (An unfiltered run's file bounds equal its filtered bounds, so unfiltered Tier-2 pre-seeding is retained.)
 
 ### With unfiltered runs
 
@@ -225,6 +231,7 @@ An unfiltered run has filter signature `-`. Per the multi-file rule, an unfilter
 | `ltl-index.csv` present but malformed (CSV parse error / truncated) | Warn to stderr; no pre-seed; do not crash. End-of-run write proceeds as today (the existing write logic handles the corrupt case by overwriting). |
 | Index entry missing one or more bound columns (`-` placeholder) | Treat the missing column as "no pre-seed for that bound"; pre-seed any other columns that are present. |
 | Filter signature differs by encoding-equivalent strings (e.g., legacy non-encoded entry) | Treat as no Tier 1 match — fall through to Tier 2. The on-disk entry will be replaced on next write. |
+| Selection entry written before intra-flag value canonicalization (its `filters` key used the pre-canonicalization value order) | No longer matches the canonical signature — falls through to Tier 2 (which is now safe for filtered runs) and is rebuilt in canonical form on the next end-of-run write. Self-healing; no migration needed. |
 | File mtime changes between startup read and end-of-run write | The on-disk file changed mid-run. Today's write side captures live `file_mtime` at write time, so the index reflects actual file state. Drift detection unaffected (it compares pre-seed vs live, not against on-disk mtime). |
 | Extremely fast run where mtime resolution doesn't change | Freshness passes correctly because `file_size` is also compared. |
 | User deletes `ltl-index.csv` during the run | End-of-run write recreates it as today. No special handling needed. |

--- a/ltl
+++ b/ltl
@@ -1145,11 +1145,15 @@ sub serialize_filters {
     push @parts, "-cmin=$filter_count_min"        if defined $filter_count_min;
     push @parts, "-dmax=$filter_duration_max"    if defined $filter_duration_max;
     push @parts, "-dmin=$filter_duration_min"     if defined $filter_duration_min;
-    push @parts, "-e=" . $url_encode->(join(',', @exclude_args))   if @exclude_args;
-    push @parts, "-ef=" . $url_encode->(join(',', @exclude_files)) if @exclude_files;
-    push @parts, "-et=" . $url_encode->($filter_range_end)         if $filter_range_end ne "";
-    push @parts, "-i=" . $url_encode->(join(',', @include_args))   if @include_args;
-    push @parts, "-if=" . $url_encode->(join(',', @include_files)) if @include_files;
+    # Sort the values within each repeated flag so the same logical selection
+    # always produces one identical signature regardless of the order the
+    # values were given on the command line (Issue #310). Cross-flag order is
+    # already fixed by the push order above.
+    push @parts, "-e=" . $url_encode->(join(',', sort @exclude_args))   if @exclude_args;
+    push @parts, "-ef=" . $url_encode->(join(',', sort @exclude_files)) if @exclude_files;
+    push @parts, "-et=" . $url_encode->($filter_range_end)              if $filter_range_end ne "";
+    push @parts, "-i=" . $url_encode->(join(',', sort @include_args))   if @include_args;
+    push @parts, "-if=" . $url_encode->(join(',', sort @include_files)) if @include_files;
     push @parts, "-st=" . $url_encode->($filter_range_start)       if $filter_range_start ne "";
     return join(';', @parts);
 }
@@ -1352,7 +1356,19 @@ sub read_index_file {
         elsif ($heatmap_metric eq 'count')    { $hm_metric_col = 'count';    }
         # UDM heatmap metrics are not in the index schema; skip.
     }
-    if ($hm_metric_col
+    # Only pre-seed the live heatmap bounds when the served bounds are
+    # population-correct for THIS run (Issue #310). The selection tier stores
+    # bounds over the filtered population; an unfiltered run's file bounds
+    # equal its filtered bounds. A FILTERED run that fell back to the file
+    # (Tier-2) row would otherwise be seeded with the whole-file max, which
+    # over-states the filtered population — and because the parse pass only
+    # grows the max, that inflated value would survive onto the heatmap axis.
+    # In that case skip the copy and let the live pass discover the filtered
+    # max cold (identical to a no-index run).
+    my $preseed_bounds_population_correct =
+        ($active_tier eq 'tier_1_selection') || ($index_filter_sig eq '-');
+    if ($preseed_bounds_population_correct
+        && $hm_metric_col
         && defined $index_aggregated{"${hm_metric_col}_min"}
         && defined $index_aggregated{"${hm_metric_col}_max"}) {
         $heatmap_min = $index_aggregated{"${hm_metric_col}_min"}{value} + 0;
@@ -1790,6 +1806,15 @@ sub emit_index_readback_verbose {
     push @verbose_output, "=== index-read-back ===";
     push @verbose_output, "index_used: " . ($index_used ? "yes" : "no");
     push @verbose_output, "index_filter_signature: $index_filter_sig";
+
+    # Issue #310: the live heatmap bounds after any index pre-seed. This is the
+    # value that scales the heatmap axis; exposing it lets a harness assert that
+    # a filtered run is never seeded with a whole-file (Tier-2) maximum. Emitted
+    # only when the heatmap is active (otherwise these globals are unused).
+    if ($heatmap_enabled) {
+        push @verbose_output, "heatmap_preseed_min: " . (defined $heatmap_min ? $heatmap_min : '-');
+        push @verbose_output, "heatmap_preseed_max: " . (defined $heatmap_max ? $heatmap_max : '-');
+    }
 
     # Per-file lookup blocks (always emitted under -V, in input order).
     for my $file (@in_files) {

--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -97,7 +97,7 @@ This list prevents collisions across parallel work. Update it when adding a new 
 
 **Implemented:**
 - `runtime-config` — effective runtime configuration: LTL_CONFIG and merged include/exclude/highlight/threadpool regexes
-- `index-read-back` — index pre-seed lookups, freshness, aggregated bounds, drift detection (Issue #179)
+- `index-read-back` — index pre-seed lookups, freshness, aggregated bounds, drift detection (Issue #179); `heatmap_preseed_min`/`heatmap_preseed_max` expose the live post-preseed heatmap bounds when a heatmap is active (Issue #310)
 - `histogram-array` — raw-array histogram dimensions; active when a surface resolves to the raw values data model
 - `histogram-bin-counters` — HDR-style bin-counter histogram state and finalized histogram dimensions (Issue #187)
 - `message-grouping` — fuzzy message consolidation (Issue #96)

--- a/tests/validate-index-read-back.sh
+++ b/tests/validate-index-read-back.sh
@@ -965,6 +965,90 @@ scenario_expired_selection_entry() {
         contract    'features/179-index-read-back.md section Interactions with existing features section "With write side (#46)" - expiration semantics delegated to #46; section Behavior - read-back does not expire'
 }
 
+scenario_signature_canonicalization() {
+    current_scenario="signature-canonicalization"
+    echo "[$current_scenario]"
+
+    # The same logical selection expressed with the values of a repeated flag
+    # in a different order must produce one identical filter signature, so the
+    # selection row written by the first run re-matches (Tier 1) on the second.
+    # Use exclude values that actually match rows in the log so a selection row
+    # is written and can be re-matched.
+    local outA outB sigA sigB
+    outA=$(PERL_PERTURB_KEYS=1 run_ltl $COMMON -V index-read-back -e GET -e POST "$ACCESS_LOG")
+    sigA=$(extract_v_value "$outA" 'index_filter_signature')
+
+    outB=$(PERL_PERTURB_KEYS=1 run_ltl $COMMON -V index-read-back -e POST -e GET "$ACCESS_LOG")
+    sigB=$(extract_v_value "$outB" 'index_filter_signature')
+
+    assert_command \
+        command     "[ \"$sigA\" = \"$sigB\" ]" \
+        label       "permuted intra-flag order yields identical signature ($sigA)" \
+        asserts     'serialize_filters() sorts the values within each repeated flag, so the same logical selection produces one byte-identical filter signature regardless of the order the values were given on the command line' \
+        produced_by 'serialize_filters() in ltl (intra-flag value sort), surfaced as index_filter_signature by emit_index_readback_verbose()' \
+        contract    'features/179-index-read-back.md section "With filtered runs" - signature is canonical and compared as exact strings; Issue #310 Fix B'
+
+    assert_line "$outB" \
+        pattern     '^  lookup: tier_1_selection$' \
+        asserts     'The second run, with the same selection in a different value order, re-matches the selection row written by the first run (Tier 1) rather than falling through to the file row' \
+        produced_by 'read_index_file() in ltl (selection-row match on canonical signature)' \
+        contract    'features/179-index-read-back.md section "With filtered runs"; Issue #310 Fix B'
+}
+
+scenario_filtered_tier2_no_leak() {
+    current_scenario="filtered-tier2-no-leak"
+    echo "[$current_scenario]"
+
+    # A filtered run that falls back to Tier 2 (file row) must NOT be pre-seeded
+    # with the whole-file maximum. Force Tier 2 by removing the -dmin=50
+    # selection row, then inflate the file row's duration_max far above the
+    # filtered population's true max. The served heatmap max must be the
+    # filtered max, not the inflated file-row value, and must be deterministic.
+    seed_from_fixture
+
+    # The true filtered max for -dmin=50 is stored on the -dmin=50 selection
+    # row (1297 in the fixture). Read it BEFORE deleting that row, using the
+    # harness's CSV reader helper.
+    local filtered_max
+    filtered_max=$(read_index_column duration_max "entry_type=selection AND filters=-dmin=50 AND file_path=$ACCESS_LOG")
+
+    delete_index_rows "entry_type=selection AND filters=-dmin=50"
+    edit_index_row "entry_type=file AND file_path=$ACCESS_LOG" "duration_max=999999999"
+
+    # Both runs must fall back to Tier 2. Because each run's end-of-run write
+    # would append a -dmin=50 selection row (making the next run hit Tier 1),
+    # re-delete that selection row and re-inflate the file row before the
+    # second run so it exercises the same Tier-2 path.
+    local out1 out2 max1 max2
+    out1=$(PERL_PERTURB_KEYS=1 run_ltl $COMMON -V index-read-back -hm duration -dmin 50 "$ACCESS_LOG")
+    max1=$(extract_v_value "$out1" 'heatmap_preseed_max')
+
+    delete_index_rows "entry_type=selection AND filters=-dmin=50"
+    edit_index_row "entry_type=file AND file_path=$ACCESS_LOG" "duration_max=999999999"
+    out2=$(PERL_PERTURB_KEYS=1 run_ltl $COMMON -V index-read-back -hm duration -dmin 50 "$ACCESS_LOG")
+    max2=$(extract_v_value "$out2" 'heatmap_preseed_max')
+
+    assert_line "$out1" \
+        pattern     '^  lookup: tier_2_file$' \
+        asserts     'The filtered run genuinely falls back to the file row (Tier 2), so this scenario exercises the leak path - the fix suppresses the leak without changing the tier' \
+        produced_by 'read_index_file() in ltl (Tier 2 fallback when no matching selection row)' \
+        contract    'features/179-index-read-back.md section Behavior - Pre-seeded values (Tier 2 fallback)'
+
+    assert_command \
+        command     "[ \"$max1\" = \"$filtered_max\" ]" \
+        label       "filtered Tier-2 heatmap max is the filtered max ($max1), not the inflated file-row value" \
+        asserts     'A filtered run that falls back to Tier 2 is NOT pre-seeded with the whole-file maximum; the live pass discovers the filtered max cold, so the served heatmap max equals the filtered population max even when the file row holds a much larger (unfiltered or stale) value' \
+        produced_by 'read_index_file() in ltl (tier-gated heatmap pre-seed) + emit_index_readback_verbose() (heatmap_preseed_max)' \
+        contract    'features/179-index-read-back.md section Motivation - file-entry bounds over-state a filtered run; Issue #310 Fix A'
+
+    assert_command \
+        command     "[ \"$max1\" = \"$max2\" ]" \
+        label       "served heatmap max is deterministic across runs ($max1)" \
+        asserts     'The served heatmap max is identical across repeated invocations under hash-order perturbation, so the same filtered command reproduces the same auto-scaled maximum every run' \
+        produced_by 'read_index_file() in ltl (tier-gated pre-seed) + live parse pass' \
+        contract    'Issue #310 - the heatmap auto-scaled maximum must be deterministic for identical input'
+}
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -995,6 +1079,8 @@ for s in \
     scenario_malformed_index \
     scenario_missing_bound_column \
     scenario_expired_selection_entry \
+    scenario_signature_canonicalization \
+    scenario_filtered_tier2_no_leak \
     ; do
     echo ""
     in_scenario_dir "$s"


### PR DESCRIPTION
Fixes #310.

## Root cause

The non-deterministic, sometimes grossly-inflated heatmap auto-scaled maximum is an **index read-back bug that manifests in the heatmap**, not a heatmap bug. Two violations of the selection-entry contract funnel into one leak:

- **A (primary leak):** a *filtered* run that falls back to the file (Tier-2) row was pre-seeded with the *whole-file* maximum. The file row stores unfiltered bounds; the parse pass only ever *grows* the max, so an inflated value survived onto the heatmap axis.
- **B (non-determinism):** `serialize_filters()` didn't sort the values *within* a repeated flag, so `-e A -e B` and `-e B -e A` produced different signatures — a selection missed its own row and fell through to the leaking Tier-2 path. This is the run-to-run variation.

## Fixes (single atomic commit — interdependent)

- **A:** pre-seed the live heatmap bounds only for a selection-tier match or an unfiltered run. A filtered Tier-2 run discovers its bounds cold (identical to an un-indexed run).
- **B:** sort intra-flag values so one logical selection → one canonical signature. Old-format rows self-heal on next write; no migration.

They ship together because B's old-row invalidation is only harmless once A makes the Tier-2 fallback safe.

## Observability + tests

- New `heatmap_preseed_min`/`heatmap_preseed_max` in the `index-read-back` `-V` section (only when a heatmap is active), exposing the live post-preseed bounds.
- Two new harness scenarios in `tests/validate-index-read-back.sh`: `signature-canonicalization` and `filtered-tier2-no-leak`. **58 passed, 0 failed.**

Verified end-to-end against the reproduction: filtered `-e HUGE` now shows `2s` (was `15.3h`); unfiltered still correctly shows `15.3h`; permuted flag order re-matches Tier-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)