### PR TITLE
Issue #311: pass column width to format_duration in the message summary

### DIFF
--- a/ltl
+++ b/ltl
@@ -12367,9 +12367,9 @@ sub print_message_summary {
                     if( $print_durations && !$omit_durations && ( defined $log_messages{$grouping}{$key}{p50} || defined $log_messages{$grouping}{$key}{cv} || defined $log_messages{$grouping}{$key}{total_duration} ) ) {
                         $row .= " " x $table_padding_inner . sprintf( "%-$col_width{1}s", $message ) . " " x $table_padding_inner; 
                         $row .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $occurrences ) . " " x $table_padding_inner; 
-                        $row .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", format_duration( $min ) ) . " " x $table_padding_inner;
-                        $row .= " " x $table_padding_inner . sprintf( "%$col_width{4}s", format_duration( $p50 ) ) . " " x $table_padding_inner;
-                        $row .= " " x $table_padding_inner . sprintf( "%$col_width{5}s", format_duration( $p999 ) ) . " " x $table_padding_inner;
+                        $row .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", format_duration( $min, $col_width{3} ) ) . " " x $table_padding_inner;
+                        $row .= " " x $table_padding_inner . sprintf( "%$col_width{4}s", format_duration( $p50, $col_width{4} ) ) . " " x $table_padding_inner;
+                        $row .= " " x $table_padding_inner . sprintf( "%$col_width{5}s", format_duration( $p999, $col_width{5} ) ) . " " x $table_padding_inner;
                         $row .= " " x $table_padding_inner . sprintf( "%$col_width{6}s", format_cv_display( $cv ) ) . " " x $table_padding_inner; 
                         $row .= " " x $table_padding_inner . sprintf( "%$col_width{7}s", defined $total_duration ? $total_duration : "" ) . " " x $table_padding_inner; 
                     } else {


### PR DESCRIPTION
Fixes #311.

## What changed

The Min/P50/P99.9 duration cells in `print_message_summary` called `format_duration($value)` **without** a width budget, so a value with both integer and fractional parts (e.g. `58.4ms`) rendered at full width and overflowed its cell, breaking table alignment.

The fix passes each cell's own column width — the same `$col_width{N}` the surrounding `sprintf` already uses — as the second argument to `format_duration`, so it sheds the fractional digit to fit. This matches the bar-graph footer, which already passes a budget. Three one-line changes.

## Display-only — CSV unchanged

`format_duration` is used only for terminal display; CSV durations go through `format_csv_value` (a separate path). Verified the MESSAGES and STATS CSV outputs are **byte-identical** before and after the fix.

## Verification

- Isolated `format_duration` test: `format_duration(58.4, 4)` → `58ms` (fits); without a budget → `58.4ms` (6 chars, overflows). Proves the fit engages when the caller passes the width.
- Rendered table at `--terminal-width 140`: Min/P50/P99.9 cells align (constant Duration-column offset across rows).
- No doc changes (internal rendering fix, no new flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)