### PR TITLE
Issue #320: anchor total_occurrences exclusion to the derived rows only

### DIFF
--- a/features/224-validate-statistics-test-harness.md
+++ b/features/224-validate-statistics-test-harness.md
@@ -153,6 +153,10 @@ All invariants below apply within a single row. Failure of any is a T4. Toleranc
 - **Bounded by min/max**: `min ≤ p1` and `p99999 ≤ max`.
 - **IQR derivation**: `iqr == p75 − p25`.
 
+### Level family (STATS rows only)
+
+- **Partition**: `occurrences` equals the sum of all populated level columns, both plain and `-HL` (Issue #320). Highlighted lines are counted only under their `-HL` key, so plain and `-HL` columns partition the bucket's lines; only the derived rate columns and the normalization placeholder sit outside the partition. Skipped when no level column is populated in the row (e.g. under `-ov`, which omits level counts from the CSV while `occurrences` remains full).
+
 Each invariant is documented in the harness with its three self-documenting fields (`asserts`, `produced_by`, `contract`) so a failure surfaces both the arithmetic mismatch and the contract that says the arithmetic must hold.
 
 ## Decision 5 — Column-set scope (all-or-nothing)

--- a/features/312-numeric-criteria-highlight-selection.md
+++ b/features/312-numeric-criteria-highlight-selection.md
@@ -146,6 +146,8 @@ Because numeric highlighting feeds the same `-HL` tag as regex highlighting, it 
 
 Three pre-existing inconsistencies discovered during planning were filed as separate issues: #320 (ineffective `-HL$` exclusion alternative in the `$total_occurrences` accumulation regex), #321 (numeric filters silently drop records lacking the filtered metric entirely), and #322 (silent empty result from an inverted range, e.g. `-dmin 500 -dmax 100`). #322's scope is extended to cover the six highlight options introduced here, so the inverted-range warning lands once for all twelve range options.
 
+Resolution of #320: investigation confirmed the runtime behavior was already correct — plain and `-HL` keys partition each bucket (the highlight tag point replaces the key), so summing both is the documented "total number of log entries matched" (`docs/usage.md` metric-naming section). The dead `-HL$` alternative was removed and the exclusion anchored to exactly the derived rows (`err-rate`, `msg-rate`, `empty`); the partition invariant is now stated in a comment at the accumulation site. No behavior change; verified empirically (STATS CSV `occurrences` equals the sum of all level columns including `-HL` across 174 buckets with highlights active).
+
 ## Lessons Learned
 
 - The gate sweep was exactly the six render sites the plan predicted (plus the declaration, the matcher resolution, and the regex-only runtime-config line). Grep-counting `highlight_regex` before touching anything made the sweep mechanical and verifiable (`grep` after: three intentional survivors).

--- a/ltl
+++ b/ltl
@@ -11286,8 +11286,12 @@ sub print_bar_graph {
                     my $occurrences = $log_occurrences{$bucket}{$category_bucket}{occurrences};
                     my $color = $colors{$category_bucket} // $colors{'NC'};
 
-                    # Always accumulate total occurrences for CSV output, regardless of display options
-                    $total_occurrences += $occurrences if $category_bucket !~ /^(err-rate|msg-rate|empty|-HL$)/;
+                    # Always accumulate total occurrences for CSV output, regardless of display options.
+                    # Highlighted lines are counted only under their '-HL' key (the suffix replaces
+                    # the key at the highlight tag point), so plain and '-HL' keys partition the
+                    # bucket: both must be summed for the total to equal all lines in the bucket.
+                    # Only the derived rate rows and the normalization placeholder are excluded.
+                    $total_occurrences += $occurrences if $category_bucket !~ /^(err-rate|msg-rate|empty)$/;
 
                     next if $omit_values && $category_bucket !~ /^(err-rate|msg-rate)$/;	# we don't want to count data that won't be printed
                     next if $category_bucket =~ /^(err|msg)-rate$/ && $log_occurrences{$bucket}{'err-rate'}{occurrences} == 0 && $log_occurrences{$bucket}{'msg-rate'}{occurrences} == 0;

--- a/tests/csv-output/rules/stats-columns.tsv
+++ b/tests/csv-output/rules/stats-columns.tsv
@@ -1,19 +1,33 @@
 column	position	type	required	max_decimals	family
 timestamp	1	timestamp	yes	n/a	meta
 ERROR	*	int	no	0	level
+ERROR-HL	*	int	no	0	level
 WARN	*	int	no	0	level
+WARN-HL	*	int	no	0	level
 INFO	*	int	no	0	level
+INFO-HL	*	int	no	0	level
 DEBUG	*	int	no	0	level
+DEBUG-HL	*	int	no	0	level
 TRACE	*	int	no	0	level
+TRACE-HL	*	int	no	0	level
 FORCE	*	int	no	0	level
+FORCE-HL	*	int	no	0	level
 DATA	*	int	no	0	level
+DATA-HL	*	int	no	0	level
 5xx	*	int	no	0	level
+5xx-HL	*	int	no	0	level
 4xx	*	int	no	0	level
+4xx-HL	*	int	no	0	level
 3xx	*	int	no	0	level
+3xx-HL	*	int	no	0	level
 2xx	*	int	no	0	level
+2xx-HL	*	int	no	0	level
 1xx	*	int	no	0	level
+1xx-HL	*	int	no	0	level
 Pause Young	*	int	no	0	level
+Pause Young-HL	*	int	no	0	level
 Pause Full	*	int	no	0	level
+Pause Full-HL	*	int	no	0	level
 err-rate_sec	*	float	no	1	level
 err-rate_min	*	float	no	1	level
 err-rate_hr	*	float	no	1	level

--- a/tests/statistics-drift/compare-statistics-drift.pl
+++ b/tests/statistics-drift/compare-statistics-drift.pl
@@ -688,7 +688,16 @@ my %L2_INVARIANTS = (
         produced_by => 'calculate_percentiles_for_bucket() in ltl',
         contract    => 'features/224-validate-statistics-test-harness.md § Decision 4 — IQR derivation',
     },
+    level_partition => {
+        asserts     => 'occurrences equals the sum of all populated level columns (plain and -HL): highlighted and plain keys partition the bucket lines (Issue #320)',
+        produced_by => 'print_bar_graph() in ltl (per-bucket $total_occurrences accumulation)',
+        contract    => 'features/224-validate-statistics-test-harness.md § Decision 4 — level partition',
+    },
 );
+
+# STATS-only level columns (Decision 5), plus their '-HL' highlighted
+# variants, form the partition that level_partition sums over.
+my $LEVEL_COLUMN_RE = qr/^(?:FORCE|ERROR|WARN|INFO|DEBUG|TRACE|DATA|[1-5]xx|Pause Young|Pause Full)(?:-HL)?$/;
 
 my @PERCENTILE_LADDER = qw(p1 p5 p10 p25 p50 p75 p90 p95 p99 p999 p9999 p99999);
 
@@ -924,6 +933,30 @@ sub check_layer2_row {
                 contract => $inv->{contract},
                 rule => 'iqr == p75 - p25 (tolerance 1e-9, float precision)',
             );
+        }
+    }
+
+    # Level partition (STATS rows only): occurrences == sum of populated
+    # level columns. Skipped when no level column is populated (e.g. -ov
+    # omits level counts from the CSV while occurrences remains full).
+    if ($file_kind eq 'stats' && defined $occ && $occ > 0) {
+        my @populated = grep { $_ =~ $LEVEL_COLUMN_RE && defined $row->{$_} && $row->{$_} ne '' } keys %$row;
+        if (@populated) {
+            my $sum = 0;
+            $sum += as_num($row->{$_}) // 0 for @populated;
+            if (abs($sum - $occ) > ORDERING_EPS) {
+                $stats->{T4}++;
+                my $inv = $L2_INVARIANTS{level_partition};
+                emit_l2_failure(
+                    scenario => $scenario, file => $file_kind, key => $k,
+                    invariant => "level_partition ($side)",
+                    observed => sprintf("occurrences=%s level_sum=%s (columns: %s)", $occ, $sum, join(',', sort @populated)),
+                    asserts => $inv->{asserts},
+                    produced_by => $inv->{produced_by},
+                    contract => $inv->{contract},
+                    rule => 'occurrences == sum(level columns, plain + -HL)',
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #320 (dead `-HL$` alternative in the `total_occurrences` exclusion regex).

## What
- Investigation confirmed the runtime behavior was already correct: plain and `-HL` keys partition each bucket's lines (the highlight tag point replaces the key), so summing both is the documented "total number of log entries matched". Excluding `-HL` keys — what the dead alternative appeared to attempt — would have been wrong.
- The exclusion regex now says what it means: anchored to exactly the derived rate rows and the normalization placeholder (`err-rate`, `msg-rate`, `empty`). No behavior change over the fixed `@log_levels` registry.
- The partition invariant is documented at the accumulation site.

## Test coverage added
- New L2 `level_partition` invariant in `tests/statistics-drift/compare-statistics-drift.pl`: STATS-row `occurrences` must equal the sum of all populated level columns (plain + `-HL`). Registered in `features/224-validate-statistics-test-harness.md` § Decision 4. Verified to fire (probe CSV with a broken partition produces a T4 and exit 1).
- `tests/csv-output/rules/stats-columns.tsv` gains the 14 `-HL` level-column rows that were missing from the spec — without them the drift engine's Decision 5 all-or-nothing gate refuses any highlight-bearing STATS CSV.

## Verification
- `CI=1 ./tests/validate-csv-output.sh` — 18/18 pass
- `CI=1 ./tests/validate-statistics.sh` — 18/18 pass
- Empirical: STATS CSV `occurrences` equals sum of level columns (incl. `-HL`) across 174 buckets with 652k highlighted lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLbpvgXyNCZGAYhL57VdrZ