### PR TITLE
Issue #326: skip counting-aggregation UDMs in per-message mean derivation

### DIFF
--- a/features/user-defined-metrics.md
+++ b/features/user-defined-metrics.md
@@ -188,7 +188,10 @@ $log_messages{$cat}{$key}{"udm_${name}_sum"}
 $log_messages{$cat}{$key}{"udm_${name}_occurrences"}
 $log_messages{$cat}{$key}{"udm_${name}_min"}
 $log_messages{$cat}{$key}{"udm_${name}_max"}
+$log_messages{$cat}{$key}{"udm_${name}_mean"}   # numeric aggregations only
 ```
+
+The per-message mean is derived in `calculate_all_statistics()` as `sum / occurrences` and exists only for numeric aggregations. Counting aggregations (`count`, `distinct`, `ratio`, `rate`, `drate`) track `udm_${name}_occurrences` without ever writing `udm_${name}_sum`, so the mean derivation skips `agg_kind eq 'counting'` configs entirely and guards against an undefined sum (Issue #326).
 
 ### Statistics (`%log_stats`)
 ```
@@ -232,6 +235,7 @@ This implementation serves as a proving ground for Issue #23's derived metrics a
 
 ### Resolved
 
+- **Counting aggregations triggered uninitialized-value warnings in the per-message mean loop (Issue #326)**: the per-message mean derivation divided `udm_${name}_sum` by occurrences for every UDM config, but counting aggregations never populate `_sum`, producing one `Use of uninitialized value in division` warning per message key. Fixed by skipping counting configs in the mean loop and guarding on a defined sum. The csv-output harness now fails any scenario whose stderr carries Perl runtime warnings, so this class of unguarded data path can no longer pass silently.
 - **Non-access-log formats silently discarded UDM values**: The UDM storage blocks were inside `if ($is_access_log)` gates. Log formats that don't set `$is_access_log` (e.g., match_type 11 — ThingWorx Edge C SDK trace logs) would capture UDM values but never store them. Fixed by setting `$is_access_log = 1` when `%udm_values` is populated, and making `$print_durations` conditional on actual duration/bytes/count data to avoid empty latency columns.
 
 ## Next Steps

--- a/ltl
+++ b/ltl
@@ -9845,9 +9845,11 @@ sub calculate_all_statistics {
 
                 # Calculate UDM per-message mean (Issue #22)
                 foreach my $config (@udm_configs) {
+                    next if $config->{agg_kind} eq 'counting';    # counting aggregations track occurrences without a numeric sum
                     my $name = $config->{name};
                     my $occ = $log_messages{$category}{$log_key}{"udm_${name}_occurrences"};
-                    $log_messages{$category}{$log_key}{"udm_${name}_mean"} = (defined $occ && $occ > 0) ? $log_messages{$category}{$log_key}{"udm_${name}_sum"} / $occ : undef;
+                    my $sum = $log_messages{$category}{$log_key}{"udm_${name}_sum"};
+                    $log_messages{$category}{$log_key}{"udm_${name}_mean"} = (defined $sum && defined $occ && $occ > 0) ? $sum / $occ : undef;
                 }
 
                 # 2026-01-04 TO DO: free up the memory from the data structure as it is no longer needed (don't think that below logic was actually working as intended)

--- a/tests/validate-csv-output.sh
+++ b/tests/validate-csv-output.sh
@@ -160,6 +160,21 @@ while IFS=$'\t' read -r scenario logfile options families expected_categories; d
         continue
     fi
 
+    # Perl runtime warnings (interpreter-emitted, always suffixed
+    # " at <file> line <N>") are unguarded-data-path bugs, not noise.
+    # Intentional ltl diagnostics printed to stderr never carry that
+    # suffix, so the pattern separates the two cleanly.
+    if grep -qE ' at .+ line [0-9]+' "$v_capture_dir/ltl.stderr"; then
+        echo "FAIL  scenario=$scenario perl-runtime-warnings-on-stderr" >&2
+        grep -E ' at .+ line [0-9]+' "$v_capture_dir/ltl.stderr" | sort | uniq -c | sort -rn | head -5 | sed 's/^/        /' >&2
+        echo "        asserts: a scenario run emits no Perl runtime warnings (uninitialized value, substr outside of string, non-numeric argument, ...) on stderr" >&2
+        echo "        produced_by: whichever ltl code path the warning text names (the warning carries the emitting line)" >&2
+        echo "        contract: ltl must run warning-free on supported inputs; a runtime warning is an unguarded data path (Issue #326)" >&2
+        total_fail=$((total_fail + 1))
+        scenarios_run=$((scenarios_run + 1))
+        continue
+    fi
+
     # Extract -V csv-output / precision sub-section into a file the
     # validator reads. Anchored by the 'precision' sub-section markers
     # so the parent 'csv-output' wrapper is filtered out. (#268)


### PR DESCRIPTION
Fixes #326.

Counting aggregations (count/distinct/ratio/rate/drate) track occurrences without a numeric sum; the per-message UDM mean loop divided the never-set sum by occurrences, emitting one uninitialized-value warning per message key. The loop now skips counting configs and guards on a defined sum.

Also adds a csv-output harness assertion: any Perl runtime warning on a scenario's stderr (distinguished by the ` at <file> line <N>` suffix, which intentional diagnostics never carry) fails the scenario. Proven to fail against the pre-fix ltl (udm-counting scenario, 125 warnings) and to pass post-fix; full suite 19/19 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLbpvgXyNCZGAYhL57VdrZ