### PR TITLE
Issue #327: preserve case of UDM metric names in -hg option parsing

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -302,7 +302,7 @@ Heatmap mode replaces the per-bucket latency statistics with a color-intensity v
 
 | Option | Description |
 |--------|-------------|
-| `-hm, --heatmap [metric]` | Replace statistics with a color-intensity histogram showing value distribution per time bucket (`duration`, `bytes`, or `count`) |
+| `-hm, --heatmap [metric]` | Replace statistics with a color-intensity histogram showing value distribution per time bucket (`duration`, `bytes`, `count`, or a `-udm` metric name; UDM names are case-sensitive) |
 | `-hmw, --heatmap-width <N>` | Number of columns for the heatmap display (default: 52) |
 
 ```bash
@@ -320,7 +320,7 @@ Histograms show the overall distribution shape of a metric across the entire tim
 
 | Option | Description |
 |--------|-------------|
-| `-hg, --histogram [metric]` | Show an overall distribution histogram after the bar graph (`duration`, `bytes`, or `count`) |
+| `-hg, --histogram [metric]` | Show an overall distribution histogram after the bar graph (`duration`, `bytes`, `count`, or a `-udm` metric name; UDM names are case-sensitive) |
 | `-hgw, --histogram-width <N>` | Histogram width as percentage of terminal (default: 95) |
 | `-hgh, --histogram-height <N>` | Histogram height in rows (default: 8) |
 | `-hgb, --histogram-buckets <N>` | Override total histogram bucket count (default: 0 = auto-calculate) |

--- a/features/histogram-charts.md
+++ b/features/histogram-charts.md
@@ -29,6 +29,8 @@ Add ASCII terminal histogram charts that visualize the value distribution of key
 
 Multiple uses of command line options for -hg should be additive in case the overall environment states displaying -hg duration, and the user adds -hg bytes then both duration and bytes should be included.
 
+Metric-name matching in `-hg` (handled by `handle_histogram_option()`) follows the same contract as `-hm`: the built-in names `duration`/`time`/`bytes`/`count` match case-insensitively, while user-defined metric names are case-sensitive and must be given exactly as declared in `-udm` (Issue #327 — the handler previously lowercased every token, making mixed-case UDM names unselectable).
+
 ### Verbose Output (-V flag)
 
 When the `-V` (verbose) flag is used with histograms enabled, output bucket calculation details for each metric:

--- a/ltl
+++ b/ltl
@@ -4037,12 +4037,12 @@ sub print_help {
 
     # Heatmap
     $out .= help_subheading("Heatmap");
-    $out .= help_opt("-hm,  --heatmap [metric]",      "Replace statistics with a color-intensity histogram showing value distribution per time bucket (duration, bytes, or count)");
+    $out .= help_opt("-hm,  --heatmap [metric]",      "Replace statistics with a color-intensity histogram showing value distribution per time bucket (duration, bytes, count, or a -udm metric name; UDM names are case-sensitive)");
     $out .= help_opt("-hmw, --heatmap-width <N>",     "Number of columns for the heatmap display (default: 52)");
 
     # Histogram
     $out .= help_subheading("Histogram");
-    $out .= help_opt("-hg,  --histogram [metric]",    "Show an overall distribution histogram after the bar graph (duration, bytes, or count)");
+    $out .= help_opt("-hg,  --histogram [metric]",    "Show an overall distribution histogram after the bar graph (duration, bytes, count, or a -udm metric name; UDM names are case-sensitive)");
     $out .= help_opt("-hgw, --histogram-width <N>",   "Histogram width as percentage of terminal (default: 95)");
     $out .= help_opt("-hgh, --histogram-height <N>",  "Histogram height in rows (default: 8)");
     $out .= help_opt("-hgb,  --histogram-buckets <N>",             "Override total histogram bucket count (default: 0 = auto-calculate)");
@@ -6696,12 +6696,15 @@ sub handle_histogram_option {
             return;
         }
 
-        # Parse comma-separated metrics, additive behavior
+        # Parse comma-separated metrics, additive behavior. Built-in metric
+        # names match case-insensitively; UDM names are case-sensitive, so
+        # the original (trimmed) token is preserved for them.
         for my $metric (split /,/, $opt_value) {
-            $metric = lc(trim($metric));
-            if ($metric =~ /^(duration|bytes|count)$/) {
-                $histogram_metrics{$metric} = 1;
-            } elsif ($metric =~ /^time$/) {
+            $metric = trim($metric);
+            my $metric_lc = lc $metric;
+            if ($metric_lc =~ /^(duration|bytes|count)$/) {
+                $histogram_metrics{$metric_lc} = 1;
+            } elsif ($metric_lc eq 'time') {
                 # 'time' is an alias for 'duration' for consistency
                 $histogram_metrics{'duration'} = 1;
             } elsif (@udm_raw_args) {


### PR DESCRIPTION
Fixes #327.

`-hg WS_duration` failed with "unknown metric" while `-hm WS_duration` worked: the histogram option handler lowercased every token before the case-sensitive UDM name validation. Built-ins remain case-insensitive; UDM tokens now keep their original case.

Verified: `-hg WS_duration` renders the distribution; `-hg DURATION` still resolves to the built-in; `-hg ws_duration` (genuinely wrong case) errors listing available metrics. `--help` and `docs/usage.md` now document UDM selection and case sensitivity on both `-hg` and `-hm`; help-content parity harness passes 11/11.

No dedicated regression test added: resolved option state has no `-V` surface yet (reserved `option-resolution` section, #231) and a standalone harness for a two-line parsing fix would be disproportionate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLbpvgXyNCZGAYhL57VdrZ