### PR TITLE
Issue #328: skip CSV rows with unparseable timestamps instead of dying

### DIFF
--- a/features/user-defined-metrics.md
+++ b/features/user-defined-metrics.md
@@ -277,6 +277,7 @@ When a CSV file is processed with `-udm`, ltl auto-detects the CSV format from t
 - All transforms (`delta`, `idelta`) and aggregations (`min`, `max`, `avg`) work with CSV input
 - CSV lines use fixed category `DATA` (no log levels in CSV)
 - Without `-ucm`, all CSV rows group under a single "CSV data" message
+- Rows whose timestamp column is neither epoch nor ISO (`YYYY-MM-DD HH:MM:SS`) are skipped, never fed to the fixed-offset substr/`timegm()` parse: the first such row in a file warns with file, line, and offending value; a per-file total is reported at end of file (Issue #328 — a quoted-timestamp CSV from a previous `ltl -o` run swept into a multi-file glob previously died fatally with `Month '-1' out of range`). Covered by `tests/validate-csv-input.sh`.
 
 **Limitations:**
 - No support for quoted fields with embedded separators (uses simple `split()`)

--- a/ltl
+++ b/ltl
@@ -7592,6 +7592,7 @@ sub read_and_process_logs {
         @csv_udm_col_indices = ();
         @csv_message_col_indices = ();
         my $potential_csv_header;
+        my $csv_skipped_timestamp_rows = 0;
 
         while (<$fh>) {
             s/[\r\n]+$//;                                   # Remove Windows line endings (CRLF) or Unix line endings (LF) if present
@@ -7980,6 +7981,18 @@ sub read_and_process_logs {
                 } elsif ($csv_epoch_timestamp) {
                     # Epoch already parsed above, skip timegm()
                 } elsif( $match_type == 1 || $match_type == 2 || $match_type == 5 || $match_type == 6 || $match_type == 7 || $match_type == 8 || $match_type == 10 || $match_type == 11 || $match_type == 13 ) {
+                    # CSV rows (match_type 13) carry arbitrary column text where the
+                    # regex-matched formats guarantee timestamp shape. A value that is
+                    # neither epoch (handled above) nor ISO would feed garbage into the
+                    # fixed-offset substr extraction and die inside timegm(), so skip
+                    # the row instead (Issue #328).
+                    if ($match_type == 13 && (!defined $timestamp_str || $timestamp_str !~ /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/)) {
+                        $csv_skipped_timestamp_rows++;
+                        if ($csv_skipped_timestamp_rows == 1) {
+                            print STDERR "Warning: $in_file line $line_number: CSV timestamp '" . (defined $timestamp_str ? $timestamp_str : '') . "' is neither epoch nor ISO (YYYY-MM-DD HH:MM:SS) - skipping row (further rows in this file skipped silently)\n";
+                        }
+                        next;
+                    }
                     if (exists $timestamp_cache{$timestamp_str}) {
                         $timestamp = $timestamp_cache{$timestamp_str};
                     } else {
@@ -8720,6 +8733,10 @@ sub read_and_process_logs {
         }
 
         close $fh;
+
+        if ($csv_skipped_timestamp_rows > 1) {
+            print STDERR "Warning: $in_file: skipped $csv_skipped_timestamp_rows CSV rows with unparseable timestamps\n";
+        }
 
         # Index file: finalize per-file counters (Issue #46)
         $index_file_data{$in_file}{line_count} = $line_number;

--- a/tests/validate-csv-input.sh
+++ b/tests/validate-csv-input.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# validate-csv-input.sh — CSV columnar input robustness harness (Issue #328)
+#
+# Validates the -udm CSV columnar input path (features/user-defined-metrics.md
+# § CSV Columnar Input): valid ISO and epoch timestamp CSVs are ingested, and
+# a CSV whose timestamp column is neither epoch nor ISO (e.g. a quoted field
+# from a previous ltl -o run swept into a multi-file glob) is skipped row by
+# row with a warning instead of dying inside timegm().
+#
+# Fixtures are generated inline: their content is the contract under test and
+# has no value as committed files.
+#
+# Usage: ./tests/validate-csv-input.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LTL="$(cd "$SCRIPT_DIR/.." && pwd)/ltl"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass=0
+fail=0
+
+# assert_command: eval a command; PASS if exit code 0. Surfaces the
+# asserts/produced_by/contract triple on failure (HARNESS-DESIGN.md).
+assert_command() {
+    local command="" label="" asserts="" produced_by="" contract=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            command)     command="$2"; shift 2 ;;
+            label)       label="$2"; shift 2 ;;
+            asserts)     asserts="$2"; shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2"; shift 2 ;;
+            *) echo "assert_command: unknown field '$1'" >&2; exit 2 ;;
+        esac
+    done
+    if eval "$command" >/dev/null 2>&1; then
+        echo "  PASS  $label"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $label"
+        echo "        command:     $command"
+        echo "        asserts:     $asserts"
+        echo "        produced_by: $produced_by"
+        echo "        contract:    $contract"
+        fail=$((fail + 1))
+    fi
+}
+
+# --- Fixtures -------------------------------------------------------------
+
+# Valid ISO-timestamp CSV
+printf 'timestamp,latency\n2026-06-01 10:00:05,12\n2026-06-01 10:01:05,34\n2026-06-01 10:02:05,56\n' > "$TMP_DIR/iso.csv"
+
+# Valid epoch-timestamp CSV
+printf 'timestamp,latency\n1771078373,12\n1771078433,34\n' > "$TMP_DIR/epoch.csv"
+
+# Mixed input dir: a ThingWorx-format log next to a CSV whose timestamp
+# column is quoted (the shape of ltl's own -o STATS output) — the #328
+# crash reproduction.
+mkdir "$TMP_DIR/mix"
+printf '%s\n' \
+    '2026-06-01 10:00:00.100+0000 [L: WARN] [O: obj] [I: ] [U: u] [S: ] [P: ] [T: pool-1] message one durationMS=5' \
+    '2026-06-01 10:01:00.100+0000 [L: WARN] [O: obj] [I: ] [U: u] [S: ] [P: ] [T: pool-1] message two durationMS=7' \
+    > "$TMP_DIR/mix/app.log"
+printf 'timestamp,occurrences,bytes\n"2026-06-01 10:00",10,100\n"2026-06-01 12:00",20,200\n"2026-06-01 14:00",30,300\n' > "$TMP_DIR/mix/stats.csv"
+
+# --- Assertions -----------------------------------------------------------
+
+echo "[csv-input]"
+
+# Never toggles errexit itself: callers capture the exit code with
+# `rc=0; run_ltl ... || rc=$?`, which is condition context under set -e.
+run_ltl() {
+    local out="$1"; shift
+    "$LTL" --disable-progress "$@" > "$out" 2>&1
+}
+
+# 1. Valid ISO CSV ingests cleanly.
+iso_rc=0; run_ltl "$TMP_DIR/iso.out" "$TMP_DIR/iso.csv" -udm latency:ms:mean || iso_rc=$?
+assert_command \
+    command     "[[ $iso_rc -eq 0 ]] && grep -aq 'latency' '$TMP_DIR/iso.out' && ! grep -aqE ' at .+ line [0-9]+' '$TMP_DIR/iso.out'" \
+    label       'ISO-timestamp CSV ingests: exit 0, latency column rendered, no runtime warnings' \
+    asserts     'A CSV with ISO YYYY-MM-DD HH:MM:SS timestamps and a -udm column is detected and ingested without Perl runtime warnings' \
+    produced_by 'detect_and_parse_csv_header() + the csv_detected branch of read_and_process_logs() in ltl' \
+    contract    'features/user-defined-metrics.md § CSV Columnar Input'
+
+# 2. Epoch CSV ingests cleanly.
+epoch_rc=0; run_ltl "$TMP_DIR/epoch.out" "$TMP_DIR/epoch.csv" -udm latency:ms:mean || epoch_rc=$?
+assert_command \
+    command     "[[ $epoch_rc -eq 0 ]] && ! grep -aqE ' at .+ line [0-9]+' '$TMP_DIR/epoch.out'" \
+    label       'epoch-timestamp CSV ingests: exit 0, no runtime warnings' \
+    asserts     'A CSV with numeric epoch timestamps is auto-detected on the first data line and ingested' \
+    produced_by 'csv_epoch_timestamp detection in read_and_process_logs() in ltl' \
+    contract    'features/user-defined-metrics.md § CSV Columnar Input (Epoch timestamps, Issue #98)'
+
+# 3. Mixed glob with an unparseable-timestamp CSV: no crash, rows skipped with warning.
+mix_rc=0; run_ltl "$TMP_DIR/mix.out" "$TMP_DIR"/mix/* -udm endpoints::distinct:endpointId || mix_rc=$?
+assert_command \
+    command     "[[ $mix_rc -eq 0 ]]" \
+    label       'mixed glob (log + quoted-timestamp CSV) exits 0 instead of dying in timegm()' \
+    asserts     'A CSV row whose timestamp column is neither epoch nor ISO is skipped, never fed to the fixed-offset substr/timegm parse' \
+    produced_by 'match_type 13 timestamp guard in read_and_process_logs() in ltl' \
+    contract    'features/user-defined-metrics.md § CSV Columnar Input (unparseable-timestamp rows are skipped, Issue #328)'
+
+assert_command \
+    command     "grep -aq 'CSV timestamp' '$TMP_DIR/mix.out' && grep -aq 'skipping row' '$TMP_DIR/mix.out'" \
+    label       'skipped CSV rows are surfaced with a warning naming file, line, and offending value' \
+    asserts     'The first unparseable-timestamp row in a file emits a warning naming the file, line number, and value; the run is not silent about dropping data' \
+    produced_by 'match_type 13 timestamp guard in read_and_process_logs() in ltl' \
+    contract    'features/user-defined-metrics.md § CSV Columnar Input (unparseable-timestamp rows are skipped, Issue #328)'
+
+echo ""
+echo "=== CSV input robustness: $pass pass, $fail fail ==="
+[[ $fail -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Fixes #328.

**Root cause:** the crash needed a CSV file swept into the input glob (e.g. a previous `ltl -o` output next to the logs). It passes two-line CSV detection, the UDM header warning fires legitimately, and then the quoted timestamp field (`"2026-06-08 02:00"`) — quotes kept by the documented simple-split parser — feeds `substr($ts,5,2)` = `-0` into `timegm()`, which dies fatally (`Month '-1' out of range`, exit 25).

**Fix:** CSV rows whose timestamp column is neither epoch nor ISO `YYYY-MM-DD HH:MM:SS` are skipped with a warning (first row: file + line + value; end of file: total skipped). Regex-matched log formats guarantee timestamp shape and are untouched.

**Tests:** new `tests/validate-csv-input.sh` (HARNESS-DESIGN-compliant, inline fixtures): ISO ingestion, epoch ingestion, mixed-glob no-crash, and warning presence. Fails 2/4 against pre-fix ltl, passes 4/4 post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLbpvgXyNCZGAYhL57VdrZ