### PR TITLE
Issue #346: measure %log_messages_counters in -mem report

### DIFF
--- a/ltl
+++ b/ltl
@@ -6247,6 +6247,7 @@ sub measure_memory_structures {
         log_occurrences        => Devel::Size::total_size(\%log_occurrences),
         log_analysis           => Devel::Size::total_size(\%log_analysis),
         log_messages           => Devel::Size::total_size(\%log_messages),
+        log_messages_counters  => Devel::Size::total_size(\%log_messages_counters),
         log_stats              => Devel::Size::total_size(\%log_stats),
         log_threadpools        => Devel::Size::total_size(\%log_threadpools),
         log_sessions           => Devel::Size::total_size(\%log_sessions),


### PR DESCRIPTION
Adds `log_messages_counters` to the `-mem` measurement map in `measure_memory_structures()`, alongside the sibling bin-counter stores. Under `-mdm bin` the message-stats counter store was the largest unmeasured structure (~53 MB in the issue's grounding run), silently undercounting the reported total.

Verified against `-V` telemetry: `-mem` reports 7,318,320 bytes vs `counter_memory_bytes: 7318432` on the 2025-05-07 log — the two surfaces agree.

Closes #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)