### PR TITLE
Issue #349: decouple duration statistics from display flags (demand model)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,12 +93,12 @@ ltl -h "/api/v2/orders" -hdmin 5000 access.log
 
 ### Recording & Processing
 
-These options control which metrics logtimeline extracts and computes during processing. By default, it detects and processes everything it finds — durations, byte sizes, and counts. The omit options suppress extraction entirely, so the data is never computed and the corresponding columns do not appear. Use `-ic` to opt in to count tracking, which is off by default.
+These options control which metrics logtimeline extracts and computes during processing. By default, it detects and processes everything it finds — durations, byte sizes, and counts. The omit options suppress extraction entirely, so the data is never computed and the corresponding columns do not appear. The deprecated `-os` is the exception: it only hides the statistics panel (like `-hst, --hide-stats`), and statistics are still computed for any other active consumer — with `-o`, the STATS CSV carries its statistics columns regardless of `-os`/`-hst`. Use `-ic` to opt in to count tracking, which is off by default.
 
 | Option | Description |
 |--------|-------------|
 | `-ov, --omit-values` | Hide the per-bucket numeric values on the bar graph |
-| `-os, --omit-stats` | Hide the statistics columns (min/avg/max/stddev/etc.) |
+| `-os, --omit-stats` | Deprecated: use `-od, --omit-durations` to skip capturing durations, or `-hst, --hide-stats` to hide the statistics panel |
 | `-oe, --omit-empty` | Skip time buckets that contain zero log entries |
 | `-or, --omit-rate` | Hide the error/message rate from the legend |
 | `-od, --omit-durations` | Suppress duration extraction and related columns (significantly reduces memory and processing time on large files) |

--- a/ltl
+++ b/ltl
@@ -25,8 +25,6 @@
 # BUGS
 # - message based sorting and statistics seems to be occurring after the timeline is printed, not during all of the calculation and reading stages
 # - Line printing that heatmap calculation is being processed is not overwritten with a green message stating that it is complete like the other stages (it dissappears)
-# - durations_observed=0 initiated by --omit-stats should not impeed statistical calculation of statistics for CSV output file
-# BUG 2026-01-04 : stats calculations and output need to be decoupled from what is printed to the console.  Here, specifying to not print duration stats will not output them either.
 
 # NOT PRIORITY BACKLOG
 # - refactor thread pool summary and message summary views to use common code base for printing tables
@@ -81,7 +79,7 @@ my @verbose_output;           # Accumulated verbose output lines (Issue #56)
 # Perl hash iteration is unordered.
 my %verbose_section_registry = (
     'runtime-config' => {
-        description => 'Effective runtime configuration: LTL_CONFIG and merged include/exclude/highlight/threadpool-activity regexes.',
+        description => 'Effective runtime configuration: LTL_CONFIG, merged include/exclude/highlight/threadpool-activity regexes, resolved duration-statistics demand.',
     },
     'index-read-back' => {
         description => 'Index pre-seed lookups, freshness checks, aggregated bounds, drift detection (Issue #179).',
@@ -529,6 +527,15 @@ my $histogram_capture_mode         = undef;   # 'raw' or 'bin' (set before parsi
 my $heatmap_capture_mode           = undef;   # 'raw' or 'bin' (set before parsing loop)
 my $message_stats_capture_mode     = undef;   # 'raw' or 'bin' (set before parsing loop) — Issue #287
 my $bucket_stats_capture_mode      = undef;   # 'raw' or 'bin' (set before parsing loop) — Issue #289
+
+# Duration-statistics demand: the data model stores only what will be output,
+# so statistics capture and computation run only when at least one output
+# surface will consume them. Resolved once from the effective options in
+# adapt_to_command_line_options(); producers still require an observed
+# duration value ($durations_observed / per-sample observation) — demand is
+# the consumer half of that conjunction. One boolean per statistics store.
+my $bucket_duration_stats_demand   = 0;       # per-time-bucket statistics (%log_analysis): timeline latency column, STATS CSV
+my $message_duration_stats_demand  = 0;       # per-message-key statistics (%log_messages): messages-table statistics variant, MESSAGES CSV
 
 # The heatmap and histogram surfaces are display-geometry bound (#201): their
 # bounded partition counts (~70 total) re-bin at end-of-parse into a coarser
@@ -1697,6 +1704,12 @@ sub emit_runtime_config_verbose {
     push @verbose_output, "highlight (merged): "  . (defined $highlight_regex ? $highlight_regex : "(not set)");
     push @verbose_output, "threadpool-activity (merged): " . (defined $threadpool_activity_regex ? $threadpool_activity_regex : "(not set)");
 
+    # Resolved duration-statistics demand — computed, not user-supplied:
+    # whether each statistics store has at least one active output surface
+    # (see the demand resolution in adapt_to_command_line_options).
+    push @verbose_output, "bucket-duration-stats-demand: $bucket_duration_stats_demand";
+    push @verbose_output, "message-duration-stats-demand: $message_duration_stats_demand";
+
     # Per-flag current values (Issue #231) — collected from the snapshot
     # taken at the top of adapt_to_command_line_options() vs the
     # post-resolution values now held in their respective globals. The
@@ -2321,8 +2334,7 @@ sub emit_bin_counter_mode_verbose {
     my %feature_active = (
         summary_table     => 1,
         csv_output        => $write_messages_to_csv ? 1 : 0,
-        time_bucket_stats => ($durations_observed && !$omit_durations && !$omit_stats
-                              && (!$heatmap_enabled || $write_messages_to_csv)) ? 1 : 0,
+        time_bucket_stats => ($durations_observed && $bucket_duration_stats_demand) ? 1 : 0,
         heatmap_markers   => $heatmap_enabled ? 1 : 0,
         heatmap_cells     => $heatmap_enabled ? 1 : 0,
         histogram_view    => $histogram_enabled ? 1 : 0,
@@ -4006,7 +4018,7 @@ sub print_help {
     # Recording & Processing
     $out .= help_subheading("Recording & Processing");
     $out .= help_opt("-ov,  --omit-values",           "Hide the per-bucket numeric values on the bar graph");
-    $out .= help_opt("-os,  --omit-stats",            "Hide the statistics columns (min/avg/max/stddev/etc.)");
+    $out .= help_opt("-os,  --omit-stats",            "Deprecated: use -od, --omit-durations to skip capturing durations, or -hst, --hide-stats to hide the statistics panel");
     $out .= help_opt("-oe,  --omit-empty",            "Skip time buckets that contain zero log entries");
     $out .= help_opt("-or,  --omit-rate",             "Hide the error/message rate from the legend");
     $out .= help_opt("-od,  --omit-durations",        "Suppress duration extraction and related columns (significantly reduces memory and processing time on large files)");
@@ -7320,12 +7332,6 @@ sub adapt_to_command_line_options {
         }
     }
 
-    # Verbose output: runtime-config section (Issues #19, #21, #56, #226, #231).
-    # Extended in #231 to surface per-flag resolution under three sub-sections
-    # (command-line, environment-variable, defaults) per the locked decision in
-    # features/225-test-harness-coverage-gaps.md § #231.
-    emit_runtime_config_verbose();
-
     # --help, --explain, and --version are handled by
     # dispatch_informational_options() before GetOptions runs; $show_help,
     # $explain_arg, and $print_version are populated here but no longer read.
@@ -7428,6 +7434,40 @@ sub adapt_to_command_line_options {
             # Colors resolved from @column_layout in normalize_data_for_output()
         }
     }
+
+    # -os/--omit-stats is deprecated: it folds into the consumer-side display
+    # toggle. -od/--omit-durations is the producer-side control (durations not
+    # captured at all); -hst/--hide-stats is the consumer-side control (the
+    # statistics panel is not displayed). Statistics capture/computation is
+    # governed by the demand resolution below, not by this flag.
+    if ($omit_stats) {
+        print STDERR "Warning: -os/--omit-stats is deprecated: use -od/--omit-durations to keep durations from being captured, or -hst/--hide-stats to keep the statistics panel from being displayed\n";
+        $hide_stats = 1;
+    }
+
+    # Duration-statistics demand resolution: each statistics store is captured
+    # and computed only when at least one of its output surfaces is active.
+    # Duration-based sort keys (-so min/mean/p50/...) order the messages table
+    # and MESSAGES CSV rows, so they are subsumed by those surfaces' terms.
+    # Heatmap and histogram consume durations through their own dedicated
+    # stores and gates and create no demand here; -V sections report resolved
+    # state truthfully whether or not statistics ran, so they create none either.
+    $bucket_duration_stats_demand = ( !$omit_durations && (
+           (!$hide_stats && !$heatmap_enabled)   # timeline latency-statistics column (heatmap replaces it)
+        || $write_messages_to_csv                # STATS CSV statistics columns
+    ) ) ? 1 : 0;
+    $message_duration_stats_demand = ( !$omit_durations && (
+           $top_n_messages > 0                   # messages-table statistics variant
+        || $write_messages_to_csv                # MESSAGES CSV statistics columns
+    ) ) ? 1 : 0;
+
+    # Verbose output: runtime-config section (Issues #19, #21, #56, #226, #231).
+    # Extended in #231 to surface per-flag resolution under three sub-sections
+    # (command-line, environment-variable, defaults) per the locked decision in
+    # features/225-test-harness-coverage-gaps.md § #231. Emitted after every
+    # option is resolved (heatmap/histogram validation, -os deprecation fold,
+    # duration-statistics demand) so the section reports post-resolution values.
+    emit_runtime_config_verbose();
 
     # Under --profile the calendar date is folded away: day/workday render
     # time-of-day only (%H:%M), week/workweek prefix the weekday (%a %H:%M).
@@ -8396,79 +8436,85 @@ sub read_and_process_logs {
                             $log_messages{$category}{$log_key}{total_duration} += $duration;
                             $log_messages{$category}{$log_key}{total_duration_num} += $duration;
 
-                            # Accumulate the sum of squares for variance calculation
-                            $log_messages{$category}{$log_key}{sum_of_squares} += $duration ** 2;
-                            # Issue #287 Commit 5: skip the durations[] push under -mdm bin —
-                            # this is the dominant memory consumer at high (category, log_key)
-                            # cardinality. The bin-counter store and Welford-Pébay sidecars
-                            # below carry equivalent information for the consumer.
-                            push @{$log_messages{$category}{$log_key}{durations}}, $duration
-                                unless $message_stats_capture_mode eq 'bin';
-
-                            # Issue #287: under -mdm bin, additionally feed the per-key bin-counter
-                            # store and update the Welford-Pébay online central-moment accumulators
-                            # plus the running min/max sidecars. Validated end-to-end through
-                            # Commit 4; this commit eliminates the durations[] safety net.
-                            #
-                            # The counter_update call is gated on $duration > 0 because log-spaced
-                            # partitions cannot represent zero (mirrors the heatmap pattern at
-                            # ltl:7671). The sidecar/Welford-Pébay updates are NOT gated — they
-                            # must include 0-duration samples so the bin-path exact-value statistics
-                            # (min, mean, std_dev, moments) match raw byte-for-byte per #224
-                            # Layer 4 T1 expectation. Zero-duration samples are therefore visible
-                            # to the sidecar-derived statistics but missing from the percentile
-                            # ladder; the cross-model envelope at tests/statistics-drift/cross-model-
-                            # tolerances.tsv (R9.2 of features/287-*.md) absorbs that divergence,
-                            # populated in Commit 6 once Layer 4 measurement is available.
-                            if ($message_stats_capture_mode eq 'bin') {
-                                my $entry = $log_messages{$category}{$log_key};
-
-                                # Percentile-ladder source (the bin partition). Skip zero-valued
-                                # samples — partition's log-spaced geometry cannot bin them.
-                                if ($duration > 0) {
-                                    counter_update(\%log_messages_counters,
-                                                   "$category\x1f$log_key",
-                                                   $duration);
+                            # Statistics machinery (sum of squares, raw samples or bin
+                            # counters + moment sidecars) is captured only when a surface
+                            # will consume the per-key statistics; the totals and impact
+                            # accumulate regardless.
+                            if( $message_duration_stats_demand ) {
+                                # Accumulate the sum of squares for variance calculation
+                                $log_messages{$category}{$log_key}{sum_of_squares} += $duration ** 2;
+                                # Issue #287 Commit 5: skip the durations[] push under -mdm bin —
+                                # this is the dominant memory consumer at high (category, log_key)
+                                # cardinality. The bin-counter store and Welford-Pébay sidecars
+                                # below carry equivalent information for the consumer.
+                                push @{$log_messages{$category}{$log_key}{durations}}, $duration
+                                    unless $message_stats_capture_mode eq 'bin';
+    
+                                # Issue #287: under -mdm bin, additionally feed the per-key bin-counter
+                                # store and update the Welford-Pébay online central-moment accumulators
+                                # plus the running min/max sidecars. Validated end-to-end through
+                                # Commit 4; this commit eliminates the durations[] safety net.
+                                #
+                                # The counter_update call is gated on $duration > 0 because log-spaced
+                                # partitions cannot represent zero (mirrors the heatmap pattern at
+                                # ltl:7671). The sidecar/Welford-Pébay updates are NOT gated — they
+                                # must include 0-duration samples so the bin-path exact-value statistics
+                                # (min, mean, std_dev, moments) match raw byte-for-byte per #224
+                                # Layer 4 T1 expectation. Zero-duration samples are therefore visible
+                                # to the sidecar-derived statistics but missing from the percentile
+                                # ladder; the cross-model envelope at tests/statistics-drift/cross-model-
+                                # tolerances.tsv (R9.2 of features/287-*.md) absorbs that divergence,
+                                # populated in Commit 6 once Layer 4 measurement is available.
+                                if ($message_stats_capture_mode eq 'bin') {
+                                    my $entry = $log_messages{$category}{$log_key};
+    
+                                    # Percentile-ladder source (the bin partition). Skip zero-valued
+                                    # samples — partition's log-spaced geometry cannot bin them.
+                                    if ($duration > 0) {
+                                        counter_update(\%log_messages_counters,
+                                                       "$category\x1f$log_key",
+                                                       $duration);
+                                    }
+    
+                                    # Sidecar accumulators (R2.2 of features/287-*.md) — fed on every
+                                    # sample including 0, so calculate_statistics_bin can derive min,
+                                    # mean, std_dev, skewness, kurtosis, bimodality_coef byte-identical
+                                    # to the raw path.
+                                    $entry->{min} = $duration
+                                        if !defined $entry->{min} || $duration < $entry->{min};
+                                    $entry->{max} = $duration
+                                        if !defined $entry->{max} || $duration > $entry->{max};
+    
+                                    # Welford-Pébay online M2/M3/M4 update (Pébay 2008,
+                                    # SAND2008-6212). The order matters: M4 reads the old M2 and M3,
+                                    # M3 reads the old M2, M2 is updated last. duration_count tracks
+                                    # samples that contributed to the moment accumulators; it is
+                                    # distinct from {occurrences}, which counts all matched lines
+                                    # for this (category, log_key) regardless of duration presence,
+                                    # and matches the raw path's `scalar @{$bucket_data->{durations}}`.
+                                    my $n_old = $entry->{duration_count};
+                                    my $n     = $n_old + 1;
+                                    if ($n_old == 0) {
+                                        $entry->{_running_mean} = $duration;
+                                    } else {
+                                        my $mean     = $entry->{_running_mean};
+                                        my $delta    = $duration - $mean;
+                                        my $delta_n  = $delta / $n;
+                                        my $delta_n2 = $delta_n * $delta_n;
+                                        my $term1    = $delta * $delta_n * $n_old;
+                                        $entry->{_running_mean} = $mean + $delta_n;
+                                        $entry->{m4_sum} +=
+                                              $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
+                                            + 6 * $delta_n2 * $entry->{m2_sum}
+                                            - 4 * $delta_n  * $entry->{m3_sum};
+                                        $entry->{m3_sum} +=
+                                              $term1 * $delta_n * ($n - 2)
+                                            - 3 * $delta_n * $entry->{m2_sum};
+                                        $entry->{m2_sum} += $term1;
+                                    }
+                                    $entry->{duration_count} = $n;
                                 }
-
-                                # Sidecar accumulators (R2.2 of features/287-*.md) — fed on every
-                                # sample including 0, so calculate_statistics_bin can derive min,
-                                # mean, std_dev, skewness, kurtosis, bimodality_coef byte-identical
-                                # to the raw path.
-                                $entry->{min} = $duration
-                                    if !defined $entry->{min} || $duration < $entry->{min};
-                                $entry->{max} = $duration
-                                    if !defined $entry->{max} || $duration > $entry->{max};
-
-                                # Welford-Pébay online M2/M3/M4 update (Pébay 2008,
-                                # SAND2008-6212). The order matters: M4 reads the old M2 and M3,
-                                # M3 reads the old M2, M2 is updated last. duration_count tracks
-                                # samples that contributed to the moment accumulators; it is
-                                # distinct from {occurrences}, which counts all matched lines
-                                # for this (category, log_key) regardless of duration presence,
-                                # and matches the raw path's `scalar @{$bucket_data->{durations}}`.
-                                my $n_old = $entry->{duration_count};
-                                my $n     = $n_old + 1;
-                                if ($n_old == 0) {
-                                    $entry->{_running_mean} = $duration;
-                                } else {
-                                    my $mean     = $entry->{_running_mean};
-                                    my $delta    = $duration - $mean;
-                                    my $delta_n  = $delta / $n;
-                                    my $delta_n2 = $delta_n * $delta_n;
-                                    my $term1    = $delta * $delta_n * $n_old;
-                                    $entry->{_running_mean} = $mean + $delta_n;
-                                    $entry->{m4_sum} +=
-                                          $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
-                                        + 6 * $delta_n2 * $entry->{m2_sum}
-                                        - 4 * $delta_n  * $entry->{m3_sum};
-                                    $entry->{m3_sum} +=
-                                          $term1 * $delta_n * ($n - 2)
-                                        - 3 * $delta_n * $entry->{m2_sum};
-                                    $entry->{m2_sum} += $term1;
-                                }
-                                $entry->{duration_count} = $n;
-                            }
+                            }  # end: if ($message_duration_stats_demand)
 
                             # by calculating impact as the numbers build, it will be ready to use for sorting without having to go through the whole dataset
                             if( $duration > 0 ) {
@@ -8485,7 +8531,7 @@ sub read_and_process_logs {
                 ## CAPTURE TIME-WINDOWS BASED STATISTICS DATA ##
                 if( $is_access_log  ) {
                     # Latency-statistics surfaces (timeline latency column, stats CSV
-                    # columns, messages-table latency variant) activate only when a
+                    # columns, messages-table statistics variant) activate only when a
                     # duration value was actually observed in the data. A source that
                     # carries bytes or counts but no durations (e.g. common access log
                     # format) must not present duration statistics.
@@ -8539,57 +8585,58 @@ sub read_and_process_logs {
                         $log_analysis{$bucket}{total_duration} += $duration;
 
                         $log_analysis{$bucket}{'total_duration-HL'} += $duration if $category_bucket =~ /-HL$/;
-                        $log_analysis{$bucket}{sum_of_squares} += $duration ** 2;
-                        # Skip collecting individual durations for percentiles when heatmap is enabled (memory optimization) —
-                        # the terminal bar-graph replaces the per-time-bucket statistics row with the heatmap row.
-                        # Issue #289: but the STATS CSV is a SEPARATE render surface, so when -o is requested the
-                        # per-time-bucket statistics must still be captured and computed even under heatmap. Skip the
-                        # push only when heatmap is active AND no CSV is being written. Also skip under -bdm bin — the
-                        # bin-counter partition + sidecars below carry equivalent information for the consumer.
-                        push @{$log_analysis{$bucket}{durations}}, $duration
-                            unless ($heatmap_enabled && !$write_messages_to_csv)
-                                || $bucket_stats_capture_mode eq 'bin';
+                        # Statistics machinery (sum of squares, raw samples or bin
+                        # counters + moment sidecars) is captured only when a surface
+                        # will consume the per-bucket statistics; totals above feed
+                        # the duration bar and impact regardless.
+                        if( $bucket_duration_stats_demand ) {
+                            $log_analysis{$bucket}{sum_of_squares} += $duration ** 2;
+                            # Raw samples feed the percentile computation; under -bdm bin the
+                            # bin-counter partition + sidecars below carry equivalent information.
+                            push @{$log_analysis{$bucket}{durations}}, $duration
+                                unless $bucket_stats_capture_mode eq 'bin';
 
-                        # Issue #289: under -bdm bin, feed the per-bucket bin-counter store and the
-                        # Welford-Pébay online central-moment sidecars (mirrors the per-message-key
-                        # producer at the -mdm bin site). The counter_update is gated on $duration > 0
-                        # because log-spaced partitions cannot represent zero; the sidecars are fed on
-                        # every sample including 0 (inside the existing $duration >= 0 gate) so
-                        # duration_count exactly equals the raw path's `scalar @{durations}` denominator
-                        # and the exact-value statistics (min/mean/std_dev/moments) match raw byte-for-byte.
-                        if ($bucket_stats_capture_mode eq 'bin') {
-                            my $entry = $log_analysis{$bucket};
+                            # Issue #289: under -bdm bin, feed the per-bucket bin-counter store and the
+                            # Welford-Pébay online central-moment sidecars (mirrors the per-message-key
+                            # producer at the -mdm bin site). The counter_update is gated on $duration > 0
+                            # because log-spaced partitions cannot represent zero; the sidecars are fed on
+                            # every sample including 0 (inside the existing $duration >= 0 gate) so
+                            # duration_count exactly equals the raw path's `scalar @{durations}` denominator
+                            # and the exact-value statistics (min/mean/std_dev/moments) match raw byte-for-byte.
+                            if ($bucket_stats_capture_mode eq 'bin') {
+                                my $entry = $log_analysis{$bucket};
 
-                            counter_update(\%bucket_stats_counters, $bucket, $duration, $bucket_stats_buckets_per_decade) if $duration > 0;
-                            counter_update(\%bucket_stats_counters_hl, $bucket, $duration, $bucket_stats_buckets_per_decade)
-                                if $duration > 0 && $category_bucket =~ /-HL$/;   # store parity only
+                                counter_update(\%bucket_stats_counters, $bucket, $duration, $bucket_stats_buckets_per_decade) if $duration > 0;
+                                counter_update(\%bucket_stats_counters_hl, $bucket, $duration, $bucket_stats_buckets_per_decade)
+                                    if $duration > 0 && $category_bucket =~ /-HL$/;   # store parity only
 
-                            $entry->{min} = $duration if !defined $entry->{min} || $duration < $entry->{min};
-                            $entry->{max} = $duration if !defined $entry->{max} || $duration > $entry->{max};
+                                $entry->{min} = $duration if !defined $entry->{min} || $duration < $entry->{min};
+                                $entry->{max} = $duration if !defined $entry->{max} || $duration > $entry->{max};
 
-                            # Welford-Pébay online M2/M3/M4 update (Pébay 2008, SAND2008-6212).
-                            # Order matters: M4 reads the old M2 and M3, M3 reads the old M2, M2 last.
-                            my $n_old = $entry->{duration_count};
-                            my $n     = $n_old + 1;
-                            if ($n_old == 0) {
-                                $entry->{_running_mean} = $duration;
-                            } else {
-                                my $mean     = $entry->{_running_mean};
-                                my $delta    = $duration - $mean;
-                                my $delta_n  = $delta / $n;
-                                my $delta_n2 = $delta_n * $delta_n;
-                                my $term1    = $delta * $delta_n * $n_old;
-                                $entry->{_running_mean} = $mean + $delta_n;
-                                $entry->{m4_sum} +=
-                                      $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
-                                    + 6 * $delta_n2 * $entry->{m2_sum}
-                                    - 4 * $delta_n  * $entry->{m3_sum};
-                                $entry->{m3_sum} +=
-                                      $term1 * $delta_n * ($n - 2)
-                                    - 3 * $delta_n * $entry->{m2_sum};
-                                $entry->{m2_sum} += $term1;
+                                # Welford-Pébay online M2/M3/M4 update (Pébay 2008, SAND2008-6212).
+                                # Order matters: M4 reads the old M2 and M3, M3 reads the old M2, M2 last.
+                                my $n_old = $entry->{duration_count};
+                                my $n     = $n_old + 1;
+                                if ($n_old == 0) {
+                                    $entry->{_running_mean} = $duration;
+                                } else {
+                                    my $mean     = $entry->{_running_mean};
+                                    my $delta    = $duration - $mean;
+                                    my $delta_n  = $delta / $n;
+                                    my $delta_n2 = $delta_n * $delta_n;
+                                    my $term1    = $delta * $delta_n * $n_old;
+                                    $entry->{_running_mean} = $mean + $delta_n;
+                                    $entry->{m4_sum} +=
+                                          $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
+                                        + 6 * $delta_n2 * $entry->{m2_sum}
+                                        - 4 * $delta_n  * $entry->{m3_sum};
+                                    $entry->{m3_sum} +=
+                                          $term1 * $delta_n * ($n - 2)
+                                        - 3 * $delta_n * $entry->{m2_sum};
+                                    $entry->{m2_sum} += $term1;
+                                }
+                                $entry->{duration_count} = $n;
                             }
-                            $entry->{duration_count} = $n;
                         }
                     }
 
@@ -9582,8 +9629,10 @@ sub calculate_all_statistics {
         undef $log_analysis{$bucket}{durations};
         delete $log_analysis{$bucket}{durations};
     
-        # The duration based statistics won't catch the counts if there are no durations (see else condition below)
-        if( $durations_observed && !$omit_durations ) {
+        # The duration based statistics won't catch the counts if there are no durations (see else condition below).
+        # Demand (≥1 active consumer of per-bucket statistics) and observation
+        # (≥1 duration value seen in the data) must both hold.
+        if( $bucket_duration_stats_demand && $durations_observed ) {
             # Issue #266/#289: caller-side data-model dispatch. Surface 4
             # (per-time-bucket statistics). Under 'bin' the statistics are
             # derived from the per-bucket bin-counter partition plus the
@@ -9845,7 +9894,7 @@ sub calculate_all_statistics {
                     : ( scalar @{ $log_messages{$category}{$log_key}{durations} // [] } > 0 );
                 $duration_observed ||= ( ($log_messages{$category}{$log_key}{total_duration} // 0) > 0 );
 
-                if( $duration_observed && !$omit_durations ) {
+                if( $duration_observed && $message_duration_stats_demand ) {
                     $aggregated_data->{total_duration} += $log_messages{$category}{$log_key}{total_duration};
                     $aggregated_data->{sum_of_squares} += $log_messages{$category}{$log_key}{sum_of_squares};
                     # Issue #287 Commit 5: under -mdm bin the per-key durations[] no
@@ -9856,16 +9905,18 @@ sub calculate_all_statistics {
                     # would auto-vivify it as an empty arrayref. Skip the push.
                     push @{$aggregated_data->{durations}}, @{$log_messages{$category}{$log_key}{durations}}
                         unless $message_stats_capture_mode eq 'bin';
-                } elsif ( !$omit_durations ) {
+                } elsif ( !$duration_observed && !$omit_durations ) {
                     # No duration was ever observed for this key: clear the
                     # 0-initialized accumulator so duration-total consumers
                     # (summary table, MESSAGES CSV duration/duration_nice)
                     # emit blank rather than a zero indistinguishable from a
-                    # measured total of zero (Issue #330).
+                    # measured total of zero (Issue #330). A key with real
+                    # observations keeps its total even when no statistics
+                    # surface is active.
                     delete $log_messages{$category}{$log_key}{total_duration};
                 }
 
-                if( defined $aggregated_data->{total_duration} && !$omit_durations ) {
+                if( defined $aggregated_data->{total_duration} && $message_duration_stats_demand ) {
                     # Issue #266 dispatch shell, now wired for #287 surface 3.
                     # Under 'raw' (and at default), the existing sort-and-index
                     # primitive runs unchanged. Under 'bin', the new sibling
@@ -10270,7 +10321,7 @@ sub initialize_empty_time_windows {
 # Returns an ordered array of column definition hashes.
 sub build_column_layout {
     my $show_legend  = !($omit_values && $omit_rate);
-    my $show_latency = $durations_observed && !$omit_durations && !$omit_stats && !$heatmap_enabled;
+    my $show_latency = $durations_observed && !$omit_durations && !$hide_stats && !$heatmap_enabled;
     my $show_heatmap = $heatmap_enabled;
     my $timestamp_w  = length(strftime($output_timestamp_format, gmtime(0))) + ($print_milliseconds ? 4 : 0);
     my $latency_w    = $show_heatmap ? $heatmap_width : 52;
@@ -10643,6 +10694,17 @@ sub cumulative_round_widths {
     return @widths;
 }
 
+# Single source of truth for whether the STATS CSV carries the duration-
+# statistics columns. The header push (normalize_data_for_output) and the
+# per-bucket row push (print_bar_graph) MUST both call this so rows always
+# match the header. The CSV is its own render surface: display toggles
+# (-hst, heatmap replacing the terminal statistics row, width auto-hiding)
+# do not affect it — only the CSV being active, durations being extracted,
+# and a duration having been observed in the data.
+sub stats_csv_duration_columns_active {
+    return ($write_messages_to_csv && !$omit_durations && $durations_observed) ? 1 : 0;
+}
+
 # Key function used to normalize data for output, graphing, and data scaling.
 sub normalize_data_for_output {
 
@@ -10854,12 +10916,9 @@ sub normalize_data_for_output {
     my $ts_col = (grep { $_->{id} eq 'timestamp' } @column_layout)[0];
     $timestamp_length = $ts_col->{width} + $ts_col->{spacing_before} + $ts_col->{spacing_after};
 
-    # Add CSV output columns for latency stats. Issue #289: under heatmap the
-    # terminal bar-graph replaces the per-time-bucket statistics row, but the
-    # STATS CSV is a separate render surface — so when -o is requested the stat
-    # columns are still emitted (the data was captured at parse time). @output_columns
-    # drives the CSV header/data only here; the terminal render uses @column_layout.
-    if ($durations_observed && !$omit_durations && !$omit_stats && (!$heatmap_enabled || $write_messages_to_csv)) {
+    # Add CSV output columns for latency stats. @output_columns drives the CSV
+    # header/data only here; the terminal render uses @column_layout.
+    if (stats_csv_duration_columns_active()) {
         push @output_columns, qw( min mean max std_dev p1 p5 p10 p25 p50 p75 iqr p90 p95 p99 p999 p9999 p99999 cv skewness kurtosis bimodality_coef );
     }
 
@@ -11665,13 +11724,11 @@ sub print_bar_graph {
             }
 
             # Append latency stats to CSV data. The header lists these columns
-            # when $durations_observed && !$omit_durations && !$omit_stats &&
-            # (!$heatmap_enabled || $write_messages_to_csv) (see
-            # normalize_data_for_output). The push must use the SAME gate so
-            # rows always match the header regardless of whether the latency
+            # under the same shared predicate (see normalize_data_for_output),
+            # so rows always match the header regardless of whether the latency
             # *display column* was auto-hidden by terminal width (Issue #263)
             # or replaced by the heatmap row on the terminal surface (Issue #289).
-            if( $durations_observed && !$omit_durations && !$omit_stats && (!$heatmap_enabled || $write_messages_to_csv) ) {
+            if( stats_csv_duration_columns_active() ) {
                 foreach my $stat ( qw( min mean max std_dev p1 p5 p10 p25 p50 p75 iqr p90 p95 p99 p999 p9999 p99999 cv skewness kurtosis bimodality_coef ) ) {
                     push @csv_data, format_csv_value( $log_stats{$bucket}{$stat}, $stat );
                 }
@@ -12540,12 +12597,18 @@ sub print_summary_table {
 }
 
 sub print_message_summary {
+    # Table variant: the statistics variant appends the Min/P50/P99.9/CV %/
+    # Duration columns to the occurrences column; the basic variant carries
+    # occurrences only. A statistics table needs both an active consumer of
+    # per-key statistics (demand) and at least one observed duration.
+    my $statistics_variant = ( $message_duration_stats_demand && $durations_observed ) ? 1 : 0;
+
     # Define the relative size of each column as a percentage
     my %col_relative_size;
 
     print "\n";
 
-    if( $durations_observed && !$omit_durations ) {
+    if( $statistics_variant ) {
         %col_relative_size = (
             1 => 65,
             2 => 6,
@@ -12677,30 +12740,26 @@ sub print_message_summary {
             if( $grouping eq "highlight" ) {
                 $header_title = " " x $table_padding_outer . "$colors{'bright-yellow-HL'}" . " " x $table_padding_inner . sprintf( "%-$col_width{1}s", $header_title_text[0] ) . " " x $table_padding_inner;
 
-                if( $durations_observed && !$omit_durations ) {
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $col_names{'occurrences'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", $col_names{'min'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{4}s", $col_names{'p50'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{5}s", $col_names{'p999'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{6}s", $col_names{'cv'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{7}s", $col_names{'time'} ) . " " x $table_padding_inner; 
-                } else {
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $col_names{'occurrences'} ) . " " x $table_padding_inner; 
+                $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $col_names{'occurrences'} ) . " " x $table_padding_inner;
+                if( $statistics_variant ) {
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", $col_names{'min'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{4}s", $col_names{'p50'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{5}s", $col_names{'p999'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{6}s", $col_names{'cv'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{7}s", $col_names{'time'} ) . " " x $table_padding_inner;
                 }
 
                 $header_title .= "$colors{'NC'}$colors{'bright-yellow'}";
             } elsif( $grouping eq "plain" ) {
                 $header_title = " " x $table_padding_outer . "$colors{'bright-cyan-HL'}" . " " x $table_padding_inner . sprintf( "%-$col_width{1}s", $header_title_text[1] ) . " " x $table_padding_inner;
 
-                if( $durations_observed && !$omit_durations ) {
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $col_names{'occurrences'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", $col_names{'min'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{4}s", $col_names{'p50'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{5}s", $col_names{'p999'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{6}s", $col_names{'cv'} ) . " " x $table_padding_inner; 
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{7}s", $col_names{'time'} ) . " " x $table_padding_inner; 
-                } else {
-                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $col_names{'occurrences'} ) . " " x $table_padding_inner; 
+                $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $col_names{'occurrences'} ) . " " x $table_padding_inner;
+                if( $statistics_variant ) {
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", $col_names{'min'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{4}s", $col_names{'p50'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{5}s", $col_names{'p999'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{6}s", $col_names{'cv'} ) . " " x $table_padding_inner;
+                    $header_title .= " " x $table_padding_inner . sprintf( "%$col_width{7}s", $col_names{'time'} ) . " " x $table_padding_inner;
                 }
 
                 $header_title .= "$colors{'NC'}$colors{'bright-cyan'}";
@@ -12753,7 +12812,7 @@ sub print_message_summary {
                     my $total_duration_num = $log_messages{$grouping}{$key}{total_duration_num};
                     my $total_duration = $log_messages{$grouping}{$key}{total_duration};
 
-                    if( $durations_observed && !$omit_durations && ( defined $log_messages{$grouping}{$key}{p50} || defined $log_messages{$grouping}{$key}{cv} || defined $log_messages{$grouping}{$key}{total_duration} ) ) {
+                    if( $statistics_variant && ( defined $log_messages{$grouping}{$key}{p50} || defined $log_messages{$grouping}{$key}{cv} || defined $log_messages{$grouping}{$key}{total_duration} ) ) {
                         $row .= " " x $table_padding_inner . sprintf( "%-$col_width{1}s", $message ) . " " x $table_padding_inner; 
                         $row .= " " x $table_padding_inner . sprintf( "%$col_width{2}s", $occurrences ) . " " x $table_padding_inner; 
                         $row .= " " x $table_padding_inner . sprintf( "%$col_width{3}s", format_duration( $min, $col_width{3} ) ) . " " x $table_padding_inner;

--- a/releases/v0.16.0.md
+++ b/releases/v0.16.0.md
@@ -4,6 +4,9 @@
 
 - User-defined metrics gain counting aggregations — `count`, `distinct`, `ratio`, `rate`, `drate` — with full string-token support, plus a token-key spec field that separates the extraction token from the column label; the canonical UDM average keyword is now `mean` (`avg` still accepted), so duplicate-name collision headers and CSV columns read `x:mean` instead of `x:avg` (#313)
 - Numeric criteria can now highlight instead of filter: `-hdmin`/`-hdmax`, `-hbmin`/`-hbmax`, `-hcmin`/`-hcmax` mark entries inside an inclusive duration/bytes/count band across every highlight surface while keeping the full population in view, composing with the hard filters and with `-h` (AND) (#312)
+
+## Bug Fixes
+
 - `-dmin`/`-dmax` boundaries are now inclusive, matching `-bmin`/`-bmax`/`-cmin`/`-cmax`: entries exactly at the threshold are kept where they were previously dropped (#312)
 - The STATS CSV `occurrences` total is confirmed as all lines in the bucket (plain plus highlighted) and is now locked by a test invariant; a dead exclusion alternative in its accumulation regex that contradicted this was removed (#320)
 - Numeric filters now report how many lines they excluded solely for carrying no value for the filtered metric, instead of silently shrinking the analyzed population; the metric-carrying requirement is documented in `--help` and the usage guide (#321)

--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -96,7 +96,7 @@ End markers are required. They exist so harnesses can use range extraction (`sed
 This list prevents collisions across parallel work. Update it when adding a new section.
 
 **Implemented:**
-- `runtime-config` — effective runtime configuration: LTL_CONFIG, merged include/exclude/highlight/threadpool regexes, and per-flag resolved values (including the numeric highlight criteria, Issue #312)
+- `runtime-config` — effective runtime configuration: LTL_CONFIG, merged include/exclude/highlight/threadpool regexes, resolved duration-statistics demand booleans (Issue #349), and per-flag resolved values (including the numeric highlight criteria, Issue #312)
 - `index-read-back` — index pre-seed lookups, freshness, aggregated bounds, drift detection (Issue #179); `heatmap_preseed_min`/`heatmap_preseed_max` expose the live post-preseed heatmap bounds when a heatmap is active (Issue #310)
 - `histogram-array` — raw-array histogram dimensions; active when a surface resolves to the raw values data model
 - `histogram-bin-counters` — HDR-style bin-counter histogram state and finalized histogram dimensions (Issue #187)

--- a/tests/csv-output/scenarios.tsv
+++ b/tests/csv-output/scenarios.tsv
@@ -18,3 +18,4 @@ numeric-highlight-regex-and-numeric	tests/fixtures/numeric-highlight-boundary.tx
 numeric-highlight-regex-only	tests/fixtures/numeric-highlight-boundary.txt	-bs 240 -n 25 -h BD-bytes-	duration,percentile,dispersion,shape,bytes,count,level	expected/numeric-highlight-regex-only.tsv
 numeric-filter-boundary-inclusive	tests/fixtures/numeric-highlight-boundary.txt	-bs 240 -n 25 -dmin 100 -dmax 200	duration,percentile,dispersion,shape,bytes,count,level	expected/numeric-filter-boundary-inclusive.tsv
 numeric-highlight-count-absent-format	logs/Codebeamber/codebeamer_access_log.2025-10-29.txt	-bs 240 -n 25 -ic -hcmin 1	bytes,duration,percentile,dispersion,shape,level	expected/numeric-highlight-count-absent-format.tsv
+omit-stats-csv-decoupling	logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log	-bs 240 -n 25 -os	bytes,duration,percentile,dispersion,shape,level


### PR DESCRIPTION
Fixes #349.

- Per-store demand booleans (bucket/message duration statistics) resolved at option-resolution time; statistics capture and computation gate on demand, each output surface gates on its own activation plus surface-local data presence.
- `-os`/`--omit-stats` deprecated: display-only alias of `-hst`/`--hide-stats` with a one-line stderr notice pointing at `-od` (producer side) and `-hst` (consumer side); help and docs/usage.md updated in the same commit.
- STATS CSV header/row emission share one predicate: `-o -os` / `-o -hst` now emit the full statistics columns (the reported bug).
- Messages-table variant selection is an explicit statistics-variant boolean; duplicated occurrences-header emission collapsed.
- Demand booleans exposed in `-V runtime-config`, emitted after full option resolution.
- New `validate-csv-output.sh` scenario `omit-stats-csv-decoupling` pins the `-o -os` contract (proven FAIL pre-fix, PASS post-fix).

Verification: validate-csv-output 20/20, validate-statistics 18/18 (no T3/T4), histogram-bin-counters, regression, help-content, help-layout, doc-examples, runtime-config all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)