### PR TITLE
Issue #305: statistics-group demand registry — gate shape-moment/extended-percentile capture, compute, and storage on consumer demand

### DIFF
--- a/features/189-histogram-bin-counter-primitives.md
+++ b/features/189-histogram-bin-counter-primitives.md
@@ -20,6 +20,8 @@ The primitives serve every consumer catalogued in #187 R12:
 
 The primitives support **independent partitions per consumer** (heatmap, histogram, per-message, per-time-bucket all hold their own partitions) while sharing partition-computation, bin-assignment, counter-update, and percentile-interpolation logic. The contract is what's the same; the keying and rendering are what consumers choose.
 
+Consumer-side statistics demand: which statistic groups the message-stats and bucket-stats consumers actually compute and store — including whether the Welford-Pébay moment sidecars are maintained at all — is governed by the statistics-group demand registry; see `features/305-shape-moment-extended-percentile-demand.md`.
+
 ## GitHub Issue
 
 [#189](https://github.com/gregeva/logtimeline/issues/189)

--- a/features/305-shape-moment-extended-percentile-demand.md
+++ b/features/305-shape-moment-extended-percentile-demand.md
@@ -1,0 +1,224 @@
+# Statistics-group demand registry (#305)
+
+## Overview
+
+The duration-statistics ladder (min through bimodality_coef) is computed by
+`calculate_statistics` (raw data model) / `calculate_statistics_bin` (bin data
+model) for two statistics stores: per-time-bucket (`%log_analysis` →
+`%log_stats`) and per-message-key (`%log_messages`). Before #305, every
+invocation computed and stored the full ladder regardless of whether any
+output surface consumed the values. Two costs followed:
+
+- **Compute**: the shape-moment derivation (m2/m3/m4 → skewness, kurtosis,
+  bimodality_coef) is an O(n) pass over the sorted samples per key/bucket —
+  the dominant per-key cost of `calculate_statistics` and the residual
+  +15–27% `calculate_statistics` regression vs v0.14.5 identified in #305.
+- **Memory**: every computed statistic is stored as a field on the per-key /
+  per-bucket entry. At high key cardinality (hundreds of thousands of
+  distinct messages) each unconsumed field is dead weight multiplied by the
+  population — measured in the #323 investigation at ~2.3 KB/entry across
+  600k+ keys.
+
+#305 introduces a **declarative statistics-group demand registry** that gates
+capture, compute, and storage on actual consumer demand. Memory and compute
+are equal goals.
+
+## GitHub Issue
+
+https://github.com/gregeva/logtimeline/issues/305
+
+## The demand contract
+
+**A statistic is captured, computed, and stored only when a producer is
+active AND at least one output surface consumes it.**
+
+This extends the store-level demand contract introduced by #349 (commit
+`eb86f84`), which this document also records since #349 has no feature doc:
+
+### Store-level demand (#349, pre-existing)
+
+One boolean per statistics store, resolved once in
+`adapt_to_command_line_options()` after all options (including the `-os`
+deprecation fold) are settled:
+
+- `$bucket_duration_stats_demand` — per-time-bucket statistics. Raised by:
+  the timeline latency-statistics column (`!$hide_stats && !$heatmap_enabled`
+  — the heatmap replaces the column) OR the STATS CSV (`-o`).
+- `$message_duration_stats_demand` — per-message-key statistics. Raised by:
+  the messages-table statistics variant (`$top_n_messages > 0`) OR the
+  MESSAGES CSV (`-o`).
+
+Both require the producer (`!$omit_durations`). Demand is the consumer half
+of a conjunction: compute additionally requires observation
+(`$durations_observed` / per-sample observation). `-hst/--hide-stats` is
+display-only and does NOT suppress capture; `-od/--omit-durations`
+suppresses production. Heatmap/histogram consume durations through their own
+stores and create no demand here. `-V` sections report resolved state
+truthfully whether or not statistics ran, so **-V creates no demand** —
+locked decision, inherited by the group level below.
+
+### Statistics-group demand (#305)
+
+The ladder is partitioned into four groups (`%STAT_GROUP_FIELDS` in `ltl`):
+
+| group | fields | rationale |
+|---|---|---|
+| `terminal_core` | min p50 p95 p99 p999 cv | every ladder field any terminal surface reads: timeline latency column (p50/p95/p99/p999/cv), messages table (min/p50/p999/cv). Demanded whenever the store is, by construction. |
+| `csv_body` | mean max p1 p75 p90 std_dev | body statistics consumed only by the CSVs and `-so` sort keys |
+| `extended_percentiles` | p5 p10 p25 p9999 p99999 iqr | the #222 extended set; CSV/`-so` only |
+| `shape_moments` | skewness kurtosis bimodality_coef | the #222 shape set; CSV/`-so` only; owns the O(n) pass |
+
+Consumer surfaces declare the groups they read (`@STAT_CONSUMERS` in `ltl`):
+
+| consumer | store | active when | groups |
+|---|---|---|---|
+| timeline-latency-column | bucket | `!$hide_stats && !$heatmap_enabled` | terminal_core |
+| stats-csv | bucket | `$write_messages_to_csv` | all four |
+| messages-table | message | `$top_n_messages > 0` | terminal_core |
+| messages-csv | message | `$write_messages_to_csv` | all four |
+| sort-on | message | `$sort_key` is a ladder field | the group containing `$sort_key` |
+
+`resolve_statistics_group_demand()` derives per-store per-group demand from
+the declarations (a consumer contributes only when it is active AND its
+store's #349 boolean is true), records provenance (`consumers=` in the -V
+section; the sort consumer as `sort-on:<field>`), and caches six hot-path
+booleans (`$bucket_stats_demand_{csv_body,extended,shape}` and the message
+equivalents). `-so` thereby becomes an **explicit demand contributor**:
+sorting on a statistic guarantees that statistic's group is computed and
+stored for every sorted key.
+
+## The three gate classes
+
+Demand gates three distinct cost sites; all three matter:
+
+1. **Capture (read loop)** — accumulators are only maintained when a
+   demanding group needs them. Raw-path capture was already fully
+   store-gated by #349 (sum_of_squares feeds cv = terminal_core; the
+   durations array feeds every percentile). The bin path's Welford-Pébay
+   moment accumulators (`m2_sum`/`m3_sum`/`m4_sum`: the lazy-init literal
+   fields, the per-sample update, and the `merge_bin_state` moment-merge
+   arithmetic) run only under shape-group demand. `duration_count` and
+   `_running_mean` stay unconditional — core derivation and the parallel
+   merge consume them.
+2. **Compute (finalize)** — `calculate_statistics` /
+   `calculate_statistics_bin` take a demand descriptor
+   `{ csv_body => 0|1, extended => 0|1, shape => 0|1 }` (terminal_core is
+   always computed). The raw O(n) shape pass, the extended percentile index
+   reads / `percentile()` calls, and the shape derivation are skipped when
+   ungated. Cheap scalars other demanded statistics derive from (mean,
+   std_dev, p75 for iqr) are computed regardless of their own group's
+   demand — intermediates are free; the gates target the O(n) pass and the
+   stored fields.
+3. **Storage (the memory lever)** — both primitives return a **hashref of
+   only-computed fields** (the positional 22-tuple is gone). The store sites
+   merge that hashref into the entry (`%$stats` in the `%log_stats{$bucket}`
+   literal; a hash-slice write onto `%log_messages{...}`), so undemanded
+   statistic fields are **never written**. Absent fields read as undef —
+   identical downstream semantics to the old present-with-undef contract
+   under `defined`/`//` guards.
+
+## Output-compatibility invariants
+
+- **Demand OFF (terminal-only runs)**: rendered output is byte-identical to
+  pre-#305 — no terminal surface reads a gated field. Verified by direct
+  diff and `validate-regression.sh`.
+- **Demand ON (any `-o` run; `-so <statistic>`)**: CSV bytes are identical to
+  pre-#305 — a CSV being active is precisely what raises full demand, so the
+  columns always populate. The CSV column *set* never changes.
+- Fields whose value is legitimately undefined under demand (std_dev at n<2,
+  shape moments at n<4 or degenerate m2) remain present-with-undef.
+
+## -V statistics-demand section contract
+
+Registered section `statistics-demand` (registry + `@verbose_section_order`,
+after `percentile-algorithm`), emitted by `emit_statistics_demand_verbose()`
+after finalize so counters are final. Harness:
+`tests/validate-statistics-demand.sh` (5 scenarios; self-documenting
+assertions per HARNESS-DESIGN.md). Locked line shapes:
+
+```
+=== statistics-demand ===
+store: <bucket|message>
+  store_demand: <0|1>
+  group <name>: demanded=<0|1> consumers=<comma-joined|->
+  moment_source: <second_pass|sidecar|none>
+shape_pass: executed=<N> skipped=<N>
+=== END statistics-demand ===
+```
+
+- Group order fixed: terminal_core, csv_body, extended_percentiles,
+  shape_moments. Store order fixed: bucket, message.
+- `moment_source` — how the store's shape moments are produced when
+  demanded: `second_pass` (raw path O(n) pass), `sidecar` (bin path
+  Welford-Pébay derivation; the raw path also becomes `sidecar` when #306
+  lands), `none` (shape undemanded or store inactive). Derived from resolved
+  configuration in the emitter.
+- `shape_pass` counters count **only the raw path's O(n) second pass**:
+  `executed` = invocations that ran it; `skipped` = invocations with n≥4
+  whose shape group was undemanded. The bin path's O(1) derivation is
+  deliberately not counted — its story is `moment_source: sidecar`. These
+  counters are the observable proof that demand gating skips work.
+- Additions are non-breaking; renames/removals are breaking per
+  HARNESS-DESIGN.md's stability contract.
+
+## Sorting and the top-N landscape (context for demand's compute impact)
+
+- **Non-statistic sorts** (default `occurrences`, etc.): the #302/#304
+  two-stage candidate-pool selection already limits per-message statistics
+  to the top-N pool — demand gating changes little for the message store on
+  such runs (but fully gates the bucket store, which `-n` never limits).
+- **Statistic sorts** (`-so p99`, `-so skewness`, …): `@top_keys` is every
+  key — the full ladder is computed and stored for the entire population,
+  then sorted. The demand registry bounds this to the demanded groups (the
+  4-group split saves the csv_body/extended/shape fields per key when only
+  the sort statistic's group is needed), but the population-wide compute
+  remains **#303's territory**: a two-pass approach (pass 1 computes only
+  the sort statistic's group for all keys, pass 2 full demand for the top
+  N). The demand descriptor is per-call precisely so #303 can pass different
+  descriptors per pass without reworking this registry.
+
+## How future statistics-surface reduction plugs in
+
+The registry is the single declaration of which surface consumes which
+statistics. Reducing a surface's statistic set (e.g. dropping columns from a
+CSV) becomes an edit to that surface's `groups` declaration (or a group's
+field list) — capture, compute, and storage follow automatically. Note the
+inverse implication: with gating in place, unconsumed statistics cost
+nothing, so any future reduction decision is purely about user-facing
+surface complexity, not performance.
+
+## Relationship to other issues
+
+- **#349** — the store-level demand contract this extends (recorded above).
+- **#222** — introduced the shape moments and extended percentiles; #305
+  gates their cost on demand without regressing the feature.
+- **#302/#304** — the two-stage candidate-pool selection (fewer keys); #305
+  is less work per key.
+- **#303** — population-wide compute on statistic sorts; enabled by the
+  per-call demand descriptor, not solved here.
+- **#306** — replaces the raw path's O(n) shape pass with incremental
+  Welford-Pébay sidecars when shape IS demanded; shape-group demand gates
+  that capture (the #305/#306 interlock). See
+  features/189-histogram-bin-counter-primitives.md for the sidecar/merge
+  machinery.
+- **#323/#354** — the memory investigations that established per-key field
+  cost at scale; the storage gate is this design's contribution to that
+  reduction line.
+
+## Validation
+
+- `tests/validate-statistics-demand.sh` — the section contract (5 scenarios:
+  terminal-only, `-o` full demand, `-so skewness`, heatmap bucket-store
+  suppression, runtime-config cross-check), with a prove-can-fail sabotage
+  demonstration recorded in the #305 PR.
+- Demand-OFF byte-identity: terminal output diff vs branch point +
+  `validate-regression.sh`.
+- Demand-ON byte-identity: `validate-csv-output.sh`,
+  `validate-statistics.sh` (L1/L2/L3 — all scenarios use `-o`, so full
+  demand: unchanged), `validate-distribution-shape.sh`.
+- Memory: `-mem` per-structure HWMs before/after on a large node file
+  (terminal-only and `-so p99` variants).
+- Performance: `benchmark-data` TIMING `calculate_statistics` vs
+  `tests/baseline/results/v0.14.5.tsv` via
+  `tests/baseline/compare-results.sh` (±5% acceptance on
+  month-many-servers-standard per the #305 verification criteria).

--- a/ltl
+++ b/ltl
@@ -105,6 +105,9 @@ my %verbose_section_registry = (
     'percentile-algorithm' => {
         description => 'Per-surface effective percentile algorithm: resolved data model and algorithm name for histogram, heatmap, message-stats, and bucket-stats (Issue #280).',
     },
+    'statistics-demand' => {
+        description => 'Per-store resolved statistics-group demand with raising consumers, shape-moment pass execution counters, and per-store moment source (Issue #305).',
+    },
     'profile' => {
         description => 'Timeline folding (--profile): resolved mode, fold period, included weekdays, and included vs dropped sample counts (Issue #256).',
     },
@@ -125,6 +128,7 @@ my @verbose_section_order = qw(
     heatmap-palette
     csv-output
     percentile-algorithm
+    statistics-demand
     profile
     udm-counting
     benchmark-data
@@ -536,6 +540,71 @@ my $bucket_stats_capture_mode      = undef;   # 'raw' or 'bin' (set before parsi
 # the consumer half of that conjunction. One boolean per statistics store.
 my $bucket_duration_stats_demand   = 0;       # per-time-bucket statistics (%log_analysis): timeline latency column, STATS CSV
 my $message_duration_stats_demand  = 0;       # per-message-key statistics (%log_messages): messages-table statistics variant, MESSAGES CSV
+
+# Statistics-group demand registry (#305): extends the store-level demand
+# above to statistic-group granularity. The 22-statistic duration ladder is
+# partitioned into four groups; each consumer surface declares the groups it
+# reads; resolve_statistics_group_demand() derives per-store per-group demand
+# from the active surfaces. Demand gates capture (read-loop accumulators),
+# compute (the derivation blocks in calculate_statistics /
+# calculate_statistics_bin), and storage (undemanded statistic fields are
+# never written to %log_messages / %log_stats) — the storage gate is the
+# memory lever at high key cardinality.
+my %STAT_GROUP_FIELDS = (
+    # terminal_core: every ladder field any terminal surface reads — the
+    # timeline latency column (p50/p95/p99/p999/cv) and the messages-table
+    # statistics variant (min/p50/p999/cv). Demanded whenever the store is.
+    terminal_core        => [qw(min p50 p95 p99 p999 cv)],
+    # csv_body: body statistics consumed only by the STATS/MESSAGES CSVs
+    # (and -so sort keys).
+    csv_body             => [qw(mean max p1 p75 p90 std_dev)],
+    extended_percentiles => [qw(p5 p10 p25 p9999 p99999 iqr)],
+    shape_moments        => [qw(skewness kurtosis bimodality_coef)],
+);
+my %STAT_FIELD_GROUP;   # field name -> group name; built by the resolver.
+
+# Resolved demand with provenance: {store}{group} = [consumer names].
+# Only consulted for -V reporting; the hot paths read the cached booleans.
+my %stats_group_demand;
+# Cached per-store group-demand booleans (terminal_core needs no boolean:
+# every store-activating consumer declares it, so terminal_core demand is
+# identical to the store-level demand flag above by construction).
+my ($bucket_stats_demand_csv_body, $bucket_stats_demand_extended, $bucket_stats_demand_shape)    = (0, 0, 0);
+my ($message_stats_demand_csv_body, $message_stats_demand_extended, $message_stats_demand_shape) = (0, 0, 0);
+# Telemetry for the -V statistics-demand section: how often the raw path's
+# O(n) shape-moment pass ran vs was skipped by demand. (The section's
+# moment_source line is derived from resolved config in the emitter, not
+# tracked here.)
+my %stats_demand_telemetry = (
+    shape_pass_executed => 0,
+    shape_pass_skipped  => 0,
+);
+
+# Consumer declarations: which statistics store a surface reads from, when it
+# is active, and which statistic groups it consumes. 'active' closures read
+# post-resolution option state, so the resolver must run after every option
+# (including the -os deprecation fold) is settled. 'groups' is a static list,
+# or a closure for consumers whose group set depends on an option value
+# (-so). The 'sort-on' consumer makes duration-statistic sort keys an
+# explicit demand contributor: sorting on a statistic requires that
+# statistic's group to be computed and stored for every sorted key.
+my @STAT_CONSUMERS = (
+    { name => 'timeline-latency-column', store => 'bucket',
+      active => sub { !$hide_stats && !$heatmap_enabled },
+      groups => ['terminal_core'] },
+    { name => 'stats-csv', store => 'bucket',
+      active => sub { $write_messages_to_csv },
+      groups => [qw(terminal_core csv_body extended_percentiles shape_moments)] },
+    { name => 'messages-table', store => 'message',
+      active => sub { $top_n_messages > 0 },
+      groups => ['terminal_core'] },
+    { name => 'messages-csv', store => 'message',
+      active => sub { $write_messages_to_csv },
+      groups => [qw(terminal_core csv_body extended_percentiles shape_moments)] },
+    { name => 'sort-on', store => 'message',
+      active => sub { defined $sort_key && exists $STAT_FIELD_GROUP{$sort_key} },
+      groups => sub { [ $STAT_FIELD_GROUP{$sort_key} ] } },
+);
 
 # The heatmap and histogram surfaces are display-geometry bound (#201): their
 # bounded partition counts (~70 total) re-bin at end-of-parse into a coarser
@@ -1575,6 +1644,49 @@ sub choose_data_model {
     return resolve_data_model($surface);
 }
 
+# Issue #305: derive per-store per-group statistics demand from the consumer
+# declarations in @STAT_CONSUMERS. Runs once from
+# adapt_to_command_line_options(), after the store-level duration-statistics
+# demand resolution (whose booleans it layers on top of, never re-derives)
+# and after every option those consumers' 'active' closures read is settled.
+# -V sections report resolved state truthfully whether or not statistics ran,
+# so they create no demand here (same rule as the store-level resolution).
+sub resolve_statistics_group_demand {
+    # Field -> group reverse index (also consulted by the sort-on consumer's
+    # 'active' closure and by callers needing "is this field a statistic").
+    %STAT_FIELD_GROUP = ();
+    for my $group (keys %STAT_GROUP_FIELDS) {
+        $STAT_FIELD_GROUP{$_} = $group for @{ $STAT_GROUP_FIELDS{$group} };
+    }
+
+    %stats_group_demand = ();
+    my %store_demand = (
+        bucket  => $bucket_duration_stats_demand,
+        message => $message_duration_stats_demand,
+    );
+    if (!$omit_durations) {
+        for my $consumer (@STAT_CONSUMERS) {
+            next unless $store_demand{ $consumer->{store} };
+            next unless $consumer->{active}->();
+            my $groups = ref $consumer->{groups} eq 'CODE'
+                ? $consumer->{groups}->()
+                : $consumer->{groups};
+            my $label = $consumer->{name} eq 'sort-on'
+                ? "sort-on:$sort_key"
+                : $consumer->{name};
+            push @{ $stats_group_demand{ $consumer->{store} }{$_} }, $label
+                for @$groups;
+        }
+    }
+
+    $bucket_stats_demand_csv_body   = $stats_group_demand{bucket}{csv_body}              ? 1 : 0;
+    $bucket_stats_demand_extended   = $stats_group_demand{bucket}{extended_percentiles}  ? 1 : 0;
+    $bucket_stats_demand_shape      = $stats_group_demand{bucket}{shape_moments}         ? 1 : 0;
+    $message_stats_demand_csv_body  = $stats_group_demand{message}{csv_body}             ? 1 : 0;
+    $message_stats_demand_extended  = $stats_group_demand{message}{extended_percentiles} ? 1 : 0;
+    $message_stats_demand_shape     = $stats_group_demand{message}{shape_moments}        ? 1 : 0;
+}
+
 # Issue #231: classify each known long-flag-name as having been supplied
 # via the command line, the LTL_CONFIG env-var splice, both, or neither.
 # Returns a hash mapping flag-name => list of sources ('command-line',
@@ -2221,6 +2333,67 @@ sub emit_percentile_algorithm_verbose {
     }
 
     push @verbose_output, "=== END percentile-algorithm ===";
+}
+
+# Issue #305: statistics-group demand observability. Reports, per statistics
+# store (bucket, message): the store-level demand boolean, each statistic
+# group's resolved demand with the consumer surfaces that raised it, and the
+# moment source the store's shape statistics would use. A trailing
+# shape_pass line carries the raw-path second-pass execution counters — the
+# observable proof that demand gating skips the O(n) moment pass. The bin
+# path's O(1) sidecar derivation is intentionally NOT counted there; it is
+# reported through moment_source.
+#
+# Locked surface: section name 'statistics-demand'; line shapes
+#   `store: <bucket|message>`
+#   `  store_demand: <0|1>`
+#   `  group <name>: demanded=<0|1> consumers=<comma-joined|->`
+#   `  moment_source: <second_pass|sidecar|none>`
+#   `shape_pass: executed=<N> skipped=<N>`
+# Group order is fixed: terminal_core, csv_body, extended_percentiles,
+# shape_moments. The sort-on consumer is labeled `sort-on:<field>`.
+sub emit_statistics_demand_verbose {
+    return unless section_requested('statistics-demand');
+
+    push @verbose_output, "=== statistics-demand ===";
+
+    my %store_demand = (
+        bucket  => $bucket_duration_stats_demand,
+        message => $message_duration_stats_demand,
+    );
+    my %store_shape_demand = (
+        bucket  => $bucket_stats_demand_shape,
+        message => $message_stats_demand_shape,
+    );
+    my %store_surface = ( bucket => 'bucket-stats', message => 'message-stats' );
+
+    for my $store (qw( bucket message )) {
+        push @verbose_output, "store: $store";
+        push @verbose_output, "  store_demand: " . ($store_demand{$store} ? 1 : 0);
+        for my $group (qw( terminal_core csv_body extended_percentiles shape_moments )) {
+            my $consumers = $stats_group_demand{$store}{$group};
+            my $demanded  = ($consumers && @$consumers) ? 1 : 0;
+            my $names     = $demanded ? join(',', @$consumers) : '-';
+            push @verbose_output, "  group $group: demanded=$demanded consumers=$names";
+        }
+        # Moment source: which mechanism produces this store's shape moments.
+        # Derivable from resolved state: none when shape is undemanded (or the
+        # store inactive); otherwise the store's effective data model decides
+        # between the raw path's O(n) second pass and the bin path's
+        # Welford-Pébay sidecar derivation.
+        my $source = 'none';
+        if ($store_demand{$store} && $store_shape_demand{$store}) {
+            my $dm = choose_data_model($store_surface{$store}) // 'raw';
+            $source = $dm eq 'bin' ? 'sidecar' : 'second_pass';
+        }
+        push @verbose_output, "  moment_source: $source";
+    }
+
+    push @verbose_output, "shape_pass: "
+        . "executed=$stats_demand_telemetry{shape_pass_executed} "
+        . "skipped=$stats_demand_telemetry{shape_pass_skipped}";
+
+    push @verbose_output, "=== END statistics-demand ===";
 }
 
 # Issue #256: timeline-folding observability. Reports the resolved --profile
@@ -5437,42 +5610,49 @@ sub merge_bin_state {
     return if $n_b == 0;
 
     if ($n_a == 0) {
-        # Target empty — adopt source sidecars wholesale.
+        # Target empty — adopt source sidecars wholesale. The moment sidecars
+        # exist on entries only under shape-group demand (#305): the capture
+        # sites never update them otherwise, so the merge skips them
+        # symmetrically rather than writing zero-valued fields.
         $target->{duration_count} = $n_b;
         $target->{_running_mean}  = $source->{_running_mean};
-        $target->{m2_sum}         = $source->{m2_sum} // 0;
-        $target->{m3_sum}         = $source->{m3_sum} // 0;
-        $target->{m4_sum}         = $source->{m4_sum} // 0;
+        if ($message_stats_demand_shape) {
+            $target->{m2_sum}         = $source->{m2_sum} // 0;
+            $target->{m3_sum}         = $source->{m3_sum} // 0;
+            $target->{m4_sum}         = $source->{m4_sum} // 0;
+        }
     } else {
         my $n_ab    = $n_a + $n_b;
         my $mean_a  = $target->{_running_mean};
         my $mean_b  = $source->{_running_mean};
         my $delta   = $mean_b - $mean_a;
-        my $M2_a    = $target->{m2_sum} // 0;
-        my $M2_b    = $source->{m2_sum} // 0;
-        my $M3_a    = $target->{m3_sum} // 0;
-        my $M3_b    = $source->{m3_sum} // 0;
-        my $M4_a    = $target->{m4_sum} // 0;
-        my $M4_b    = $source->{m4_sum} // 0;
-        my $d2      = $delta * $delta;
-        my $d3      = $d2 * $delta;
-        my $d4      = $d2 * $d2;
-        # Order: M4 (reads M2 and M3), M3 (reads M2), M2, mean. All read OLD
-        # state before any field is overwritten.
-        my $M4_ab = $M4_a + $M4_b
-                  + $d4 * $n_a * $n_b * ($n_a*$n_a - $n_a*$n_b + $n_b*$n_b) / ($n_ab * $n_ab * $n_ab)
-                  + 6 * $d2 * ($n_a*$n_a * $M2_b + $n_b*$n_b * $M2_a) / ($n_ab * $n_ab)
-                  + 4 * $delta * ($n_a * $M3_b - $n_b * $M3_a) / $n_ab;
-        my $M3_ab = $M3_a + $M3_b
-                  + $d3 * $n_a * $n_b * ($n_a - $n_b) / ($n_ab * $n_ab)
-                  + 3 * $delta * ($n_a * $M2_b - $n_b * $M2_a) / $n_ab;
-        my $M2_ab = $M2_a + $M2_b + $d2 * $n_a * $n_b / $n_ab;
+        if ($message_stats_demand_shape) {
+            my $M2_a    = $target->{m2_sum} // 0;
+            my $M2_b    = $source->{m2_sum} // 0;
+            my $M3_a    = $target->{m3_sum} // 0;
+            my $M3_b    = $source->{m3_sum} // 0;
+            my $M4_a    = $target->{m4_sum} // 0;
+            my $M4_b    = $source->{m4_sum} // 0;
+            my $d2      = $delta * $delta;
+            my $d3      = $d2 * $delta;
+            my $d4      = $d2 * $d2;
+            # Order: M4 (reads M2 and M3), M3 (reads M2), M2, mean. All read OLD
+            # state before any field is overwritten.
+            my $M4_ab = $M4_a + $M4_b
+                      + $d4 * $n_a * $n_b * ($n_a*$n_a - $n_a*$n_b + $n_b*$n_b) / ($n_ab * $n_ab * $n_ab)
+                      + 6 * $d2 * ($n_a*$n_a * $M2_b + $n_b*$n_b * $M2_a) / ($n_ab * $n_ab)
+                      + 4 * $delta * ($n_a * $M3_b - $n_b * $M3_a) / $n_ab;
+            my $M3_ab = $M3_a + $M3_b
+                      + $d3 * $n_a * $n_b * ($n_a - $n_b) / ($n_ab * $n_ab)
+                      + 3 * $delta * ($n_a * $M2_b - $n_b * $M2_a) / $n_ab;
+            my $M2_ab = $M2_a + $M2_b + $d2 * $n_a * $n_b / $n_ab;
+            $target->{m2_sum}         = $M2_ab;
+            $target->{m3_sum}         = $M3_ab;
+            $target->{m4_sum}         = $M4_ab;
+        }
         my $mean_ab = $mean_a + $delta * $n_b / $n_ab;
         $target->{duration_count} = $n_ab;
         $target->{_running_mean}  = $mean_ab;
-        $target->{m2_sum}         = $M2_ab;
-        $target->{m3_sum}         = $M3_ab;
-        $target->{m4_sum}         = $M4_ab;
     }
 
     # Bin-counter entry merge (only meaningful when source observed at least
@@ -7461,6 +7641,12 @@ sub adapt_to_command_line_options {
         || $write_messages_to_csv                # MESSAGES CSV statistics columns
     ) ) ? 1 : 0;
 
+    # Statistics-group demand (#305): layer per-group demand on top of the
+    # store-level booleans above, from the consumer declarations in
+    # @STAT_CONSUMERS. Must run after the -os deprecation fold and the
+    # store-level resolution, before the runtime-config emission below.
+    resolve_statistics_group_demand();
+
     # Verbose output: runtime-config section (Issues #19, #21, #56, #226, #231).
     # Extended in #231 to surface per-flag resolution under three sub-sections
     # (command-line, environment-variable, defaults) per the locked decision in
@@ -8390,9 +8576,9 @@ sub read_and_process_logs {
                             min            => undef,
                             max            => undef,
                             _running_mean  => 0,
-                            m2_sum         => 0,
-                            m3_sum         => 0,
-                            m4_sum         => 0,
+                            # Moment sidecars only under shape-group demand (#305):
+                            # three per-key numeric fields that nothing reads otherwise.
+                            ($message_stats_demand_shape ? (m2_sum => 0, m3_sum => 0, m4_sum => 0) : ()),
                         } : {
                             occurrences    => 0,
                             total_bytes    => 0,
@@ -8492,6 +8678,10 @@ sub read_and_process_logs {
                                     # distinct from {occurrences}, which counts all matched lines
                                     # for this (category, log_key) regardless of duration presence,
                                     # and matches the raw path's `scalar @{$bucket_data->{durations}}`.
+                                    # duration_count and _running_mean stay unconditional (consumed
+                                    # by core derivation and merge_bin_state); the M2/M3/M4 moment
+                                    # accumulation runs only under shape-group demand (#305) — the
+                                    # moments feed nothing else.
                                     my $n_old = $entry->{duration_count};
                                     my $n     = $n_old + 1;
                                     if ($n_old == 0) {
@@ -8500,17 +8690,19 @@ sub read_and_process_logs {
                                         my $mean     = $entry->{_running_mean};
                                         my $delta    = $duration - $mean;
                                         my $delta_n  = $delta / $n;
-                                        my $delta_n2 = $delta_n * $delta_n;
-                                        my $term1    = $delta * $delta_n * $n_old;
                                         $entry->{_running_mean} = $mean + $delta_n;
-                                        $entry->{m4_sum} +=
-                                              $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
-                                            + 6 * $delta_n2 * $entry->{m2_sum}
-                                            - 4 * $delta_n  * $entry->{m3_sum};
-                                        $entry->{m3_sum} +=
-                                              $term1 * $delta_n * ($n - 2)
-                                            - 3 * $delta_n * $entry->{m2_sum};
-                                        $entry->{m2_sum} += $term1;
+                                        if ($message_stats_demand_shape) {
+                                            my $delta_n2 = $delta_n * $delta_n;
+                                            my $term1    = $delta * $delta_n * $n_old;
+                                            $entry->{m4_sum} +=
+                                                  $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
+                                                + 6 * $delta_n2 * $entry->{m2_sum}
+                                                - 4 * $delta_n  * $entry->{m3_sum};
+                                            $entry->{m3_sum} +=
+                                                  $term1 * $delta_n * ($n - 2)
+                                                - 3 * $delta_n * $entry->{m2_sum};
+                                            $entry->{m2_sum} += $term1;
+                                        }
                                     }
                                     $entry->{duration_count} = $n;
                                 }
@@ -8561,9 +8753,8 @@ sub read_and_process_logs {
                         min            => undef,
                         max            => undef,
                         _running_mean  => 0,
-                        m2_sum         => 0,
-                        m3_sum         => 0,
-                        m4_sum         => 0,
+                        # Moment sidecars only under shape-group demand (#305).
+                        ($bucket_stats_demand_shape ? (m2_sum => 0, m3_sum => 0, m4_sum => 0) : ()),
                     } : {
                         occurrences => 0,
                         total_bytes => 0,
@@ -8615,6 +8806,9 @@ sub read_and_process_logs {
 
                                 # Welford-Pébay online M2/M3/M4 update (Pébay 2008, SAND2008-6212).
                                 # Order matters: M4 reads the old M2 and M3, M3 reads the old M2, M2 last.
+                                # duration_count and _running_mean stay unconditional (core
+                                # derivation consumes them); the M2/M3/M4 accumulation runs only
+                                # under shape-group demand (#305).
                                 my $n_old = $entry->{duration_count};
                                 my $n     = $n_old + 1;
                                 if ($n_old == 0) {
@@ -8623,17 +8817,19 @@ sub read_and_process_logs {
                                     my $mean     = $entry->{_running_mean};
                                     my $delta    = $duration - $mean;
                                     my $delta_n  = $delta / $n;
-                                    my $delta_n2 = $delta_n * $delta_n;
-                                    my $term1    = $delta * $delta_n * $n_old;
                                     $entry->{_running_mean} = $mean + $delta_n;
-                                    $entry->{m4_sum} +=
-                                          $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
-                                        + 6 * $delta_n2 * $entry->{m2_sum}
-                                        - 4 * $delta_n  * $entry->{m3_sum};
-                                    $entry->{m3_sum} +=
-                                          $term1 * $delta_n * ($n - 2)
-                                        - 3 * $delta_n * $entry->{m2_sum};
-                                    $entry->{m2_sum} += $term1;
+                                    if ($bucket_stats_demand_shape) {
+                                        my $delta_n2 = $delta_n * $delta_n;
+                                        my $term1    = $delta * $delta_n * $n_old;
+                                        $entry->{m4_sum} +=
+                                              $term1 * $delta_n2 * ($n*$n - 3*$n + 3)
+                                            + 6 * $delta_n2 * $entry->{m2_sum}
+                                            - 4 * $delta_n  * $entry->{m3_sum};
+                                        $entry->{m3_sum} +=
+                                              $term1 * $delta_n * ($n - 2)
+                                            - 3 * $delta_n * $entry->{m2_sum};
+                                        $entry->{m2_sum} += $term1;
+                                    }
                                 }
                                 $entry->{duration_count} = $n;
                             }
@@ -9637,31 +9833,31 @@ sub calculate_all_statistics {
             # (per-time-bucket statistics). Under 'bin' the statistics are
             # derived from the per-bucket bin-counter partition plus the
             # Welford-Pébay sidecars held on $log_analysis{$bucket} (shared
-            # 22-tuple derivation with the per-message-key surface via
+            # derivation with the per-message-key surface via
             # calculate_statistics_bin); under 'raw' the nearest-rank
-            # primitive runs unchanged. The %log_stats{$bucket} build below is
-            # identical for both paths.
+            # primitive runs unchanged. Both return a hashref carrying only
+            # the demanded statistics groups' fields (#305) — merging it into
+            # the %log_stats{$bucket} literal below is the storage gate:
+            # undemanded statistic fields are never written.
             my $dm = choose_data_model('bucket-stats') // 'raw';
-            my ($min, $mean, $max,
-                $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-                $std_dev, $cv,
-                $skewness, $kurtosis, $bimodality_coef);
+            my $bucket_demand = {
+                csv_body => $bucket_stats_demand_csv_body,
+                extended => $bucket_stats_demand_extended,
+                shape    => $bucket_stats_demand_shape,
+            };
+            my $stats;
             if ($dm eq 'bin') {
-                ($min, $mean, $max,
-                 $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-                 $std_dev, $cv,
-                 $skewness, $kurtosis, $bimodality_coef) = calculate_statistics_bin(
+                $stats = calculate_statistics_bin(
                     $log_analysis{$bucket},              # sidecar entry (min/max/duration_count/m*_sum/total_duration/sum_of_squares/occurrences)
                     $bucket_stats_counters{$bucket},     # counter entry (undef when every duration was 0)
                     $aggregated_data,
+                    $bucket_demand,                      # statistics-group demand (#305)
                     \%bucket_stats_audit,                # per-time-bucket audit aggregation (kept separate from message-stats)
                 );
             } else {
-                ($min, $mean, $max,
-                 $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-                 $std_dev, $cv,
-                 $skewness, $kurtosis, $bimodality_coef) = calculate_statistics($aggregated_data);
+                $stats = calculate_statistics($aggregated_data, $bucket_demand);
             }
+            $stats //= {};
 
             $log_stats{$bucket} = {
                 occurrences   => $aggregated_data->{occurrences},
@@ -9676,27 +9872,7 @@ sub calculate_all_statistics {
                 count_max     => $log_analysis{$bucket}{count_max},
                 count_mean    => ( defined $log_analysis{$bucket}{count_sum} && defined $log_analysis{$bucket}{count_occurrences} && $log_analysis{$bucket}{count_occurrences} > 0 ) ? ($log_analysis{$bucket}{count_sum} / $log_analysis{$bucket}{count_occurrences}) : undef,
                 count_sum     => $log_analysis{$bucket}{count_sum},
-                min           => $min,
-                mean          => $mean,
-                max           => $max,
-                p1            => $p1,
-                p5            => $p5,
-                p10           => $p10,
-                p25           => $p25,
-                p50           => $p50,
-                p75           => $p75,
-                iqr           => $iqr,
-                p90           => $p90,
-                p95           => $p95,
-                p99           => $p99,
-                p999          => $p999,
-                p9999         => $p9999,
-                p99999        => $p99999,
-                std_dev       => $std_dev,
-                cv            => $cv,
-                skewness      => $skewness,
-                kurtosis      => $kurtosis,
-                bimodality_coef => $bimodality_coef,
+                %$stats,
             };
 
         } else {
@@ -9919,54 +10095,35 @@ sub calculate_all_statistics {
                 if( defined $aggregated_data->{total_duration} && $message_duration_stats_demand ) {
                     # Issue #266 dispatch shell, now wired for #287 surface 3.
                     # Under 'raw' (and at default), the existing sort-and-index
-                    # primitive runs unchanged. Under 'bin', the new sibling
+                    # primitive runs unchanged. Under 'bin', the sibling
                     # primitive calculate_statistics_bin() runs against the
                     # per-key sidecar entry (%log_messages{...}) and the
                     # corresponding counter-store entry (%log_messages_counters).
-                    # Commit 1 of #287 ships the stub forwarder; Commit 2 lands
-                    # the real sidecar-and-percentile derivation.
+                    # Both return a hashref carrying only the demanded
+                    # statistics groups' fields (#305); the hash-slice write
+                    # below is the storage gate — undemanded statistic fields
+                    # are never written onto the per-key entry, which is the
+                    # memory lever at high key cardinality.
                     my $dm = choose_data_model('message-stats') // 'raw';
-                    my ($min, $mean, $max,
-                        $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-                        $std_dev, $cv,
-                        $skewness, $kurtosis, $bimodality_coef);
+                    my $message_demand = {
+                        csv_body => $message_stats_demand_csv_body,
+                        extended => $message_stats_demand_extended,
+                        shape    => $message_stats_demand_shape,
+                    };
+                    my $stats;
                     if ($dm eq 'bin') {
-                        ($min, $mean, $max,
-                         $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-                         $std_dev, $cv,
-                         $skewness, $kurtosis, $bimodality_coef) = calculate_statistics_bin(
+                        $stats = calculate_statistics_bin(
                             $log_messages{$category}{$log_key},
                             $log_messages_counters{"$category\x1f$log_key"},
                             $aggregated_data,
+                            $message_demand,             # statistics-group demand (#305)
                         );
                     } else {
-                        ($min, $mean, $max,
-                         $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-                         $std_dev, $cv,
-                         $skewness, $kurtosis, $bimodality_coef) = calculate_statistics($aggregated_data);
+                        $stats = calculate_statistics($aggregated_data, $message_demand);
                     }
-
-                    $log_messages{$category}{$log_key}{min} = $min;
-                    $log_messages{$category}{$log_key}{mean} = $mean;
-                    $log_messages{$category}{$log_key}{max} = $max;
-                    $log_messages{$category}{$log_key}{std_dev} = $std_dev;
-                    $log_messages{$category}{$log_key}{p1} = $p1;
-                    $log_messages{$category}{$log_key}{p5} = $p5;
-                    $log_messages{$category}{$log_key}{p10} = $p10;
-                    $log_messages{$category}{$log_key}{p25} = $p25;
-                    $log_messages{$category}{$log_key}{p50} = $p50;
-                    $log_messages{$category}{$log_key}{p75} = $p75;
-                    $log_messages{$category}{$log_key}{iqr} = $iqr;
-                    $log_messages{$category}{$log_key}{p90} = $p90;
-                    $log_messages{$category}{$log_key}{p95} = $p95;
-                    $log_messages{$category}{$log_key}{p99} = $p99;
-                    $log_messages{$category}{$log_key}{p999} = $p999;
-                    $log_messages{$category}{$log_key}{p9999} = $p9999;
-                    $log_messages{$category}{$log_key}{p99999} = $p99999;
-                    $log_messages{$category}{$log_key}{cv} = $cv;
-                    $log_messages{$category}{$log_key}{skewness} = $skewness;
-                    $log_messages{$category}{$log_key}{kurtosis} = $kurtosis;
-                    $log_messages{$category}{$log_key}{bimodality_coef} = $bimodality_coef;
+                    if ($stats && %$stats) {
+                        @{ $log_messages{$category}{$log_key} }{ keys %$stats } = values %$stats;
+                    }
                     $log_messages{$category}{$log_key}{total_duration_num} = $aggregated_data->{total_duration} if defined $aggregated_data->{total_duration};
                     $log_messages{$category}{$log_key}{total_duration} = format_time( $aggregated_data->{total_duration}, 'ms', 'medium', 'space' ) if defined $aggregated_data->{total_duration};
                 }
@@ -10068,9 +10225,19 @@ sub log_bucket {
     return $value > 0 ? floor(log($value) / log($base)) : 0;
 }
 
-# Function to calculate statistical metrics
+# Function to calculate statistical metrics for the raw data model.
+# $demand is the #305 statistics-group demand descriptor for the calling
+# store: { csv_body => 0|1, extended => 0|1, shape => 0|1 }. terminal_core
+# statistics are always computed (they are demanded whenever the store is).
+# Cheap scalars that other demanded statistics derive from (mean, std_dev,
+# p75) are computed regardless of their own group's demand; the gates control
+# the O(n) shape-moment pass, the extended percentile reads, and — via the
+# returned hashref, which carries ONLY the demanded groups' fields — which
+# statistic fields the caller stores. Fields whose value is legitimately
+# undefined under demand (std_dev at n<2, shape moments at n<4 or degenerate
+# m2) are present-with-undef, matching the pre-#305 contract.
 sub calculate_statistics {
-    my ($bucket_data) = @_;
+    my ($bucket_data, $demand) = @_;
     my $occurrences = $bucket_data->{occurrences};
     return unless $occurrences > 0;
 
@@ -10096,56 +10263,72 @@ sub calculate_statistics {
     # Percentile calculations must use duration_count, not occurrences
     # to correctly index into the sorted durations array
     my $p1    = $sorted[int($duration_count * 0.01)];
-    my $p5    = $sorted[int($duration_count * 0.05)];
-    my $p10   = $sorted[int($duration_count * 0.10)];
-    my $p25   = $sorted[int($duration_count * 0.25)];
     my $p50   = $sorted[int($duration_count * 0.5)];
     my $p75   = $sorted[int($duration_count * 0.75)];
     my $p90   = $sorted[int($duration_count * 0.9)];
     my $p95   = $sorted[int($duration_count * 0.95)];
     my $p99   = $sorted[int($duration_count * 0.99)];
     my $p999  = $sorted[int($duration_count * 0.999)];
-    my $p9999 = $sorted[int($duration_count * 0.9999)] // $sorted[-1];
-    my $p99999 = $sorted[int($duration_count * 0.99999)] // $sorted[-1];
-    my $iqr   = $p75 - $p25;
+
+    my %stats = (
+        min => $min, p50 => $p50, p95 => $p95, p99 => $p99, p999 => $p999, cv => $cv,
+    );
+    if ($demand->{csv_body}) {
+        @stats{qw(mean max p1 p75 p90 std_dev)} = ($mean, $max, $p1, $p75, $p90, $std_dev);
+    }
+    if ($demand->{extended}) {
+        my $p5    = $sorted[int($duration_count * 0.05)];
+        my $p10   = $sorted[int($duration_count * 0.10)];
+        my $p25   = $sorted[int($duration_count * 0.25)];
+        my $p9999 = $sorted[int($duration_count * 0.9999)] // $sorted[-1];
+        my $p99999 = $sorted[int($duration_count * 0.99999)] // $sorted[-1];
+        my $iqr   = $p75 - $p25;
+        @stats{qw(p5 p10 p25 p9999 p99999 iqr)} = ($p5, $p10, $p25, $p9999, $p99999, $iqr);
+    }
 
     # Distribution-shape moments — sample-corrected skewness and excess kurtosis,
     # plus Sarle's bimodality coefficient screening. Sarle BC > 5/9 (~0.555) flags
     # suspect multimodal; threshold is the canonical cutoff from the bimodality
     # literature. Requires n >= 4 (denominator of BC has (n-2)(n-3) factor) and a
-    # non-degenerate distribution (positive second moment).
-    my ($skewness, $kurtosis, $bimodality_coef) = (undef, undef, undef);
-    if ($duration_count >= 4) {
-        my ($m2_sum, $m3_sum, $m4_sum) = (0, 0, 0);
-        for my $x (@sorted) {
-            my $d = $x - $mean;
-            my $d2 = $d * $d;
-            $m2_sum += $d2;
-            $m3_sum += $d2 * $d;
-            $m4_sum += $d2 * $d2;
+    # non-degenerate distribution (positive second moment). The O(n) moment pass
+    # is the dominant per-key cost of this function and runs only under
+    # shape-group demand (#305).
+    if ($demand->{shape}) {
+        my ($skewness, $kurtosis, $bimodality_coef) = (undef, undef, undef);
+        if ($duration_count >= 4) {
+            $stats_demand_telemetry{shape_pass_executed}++;
+            my ($m2_sum, $m3_sum, $m4_sum) = (0, 0, 0);
+            for my $x (@sorted) {
+                my $d = $x - $mean;
+                my $d2 = $d * $d;
+                $m2_sum += $d2;
+                $m3_sum += $d2 * $d;
+                $m4_sum += $d2 * $d2;
+            }
+            my $n  = $duration_count;
+            my $m2 = $m2_sum / $n;
+            my $m3 = $m3_sum / $n;
+            my $m4 = $m4_sum / $n;
+            if ($m2 > 0) {
+                my $g1 = $m3 / ($m2 ** 1.5);
+                my $g2 = $m4 / ($m2 ** 2) - 3;
+                $skewness = sqrt($n * ($n - 1)) / ($n - 2) * $g1;
+                $kurtosis = ($n - 1) / (($n - 2) * ($n - 3)) * (($n + 1) * $g2 + 6);
+                my $bc_denom = $kurtosis + 3 * (($n - 1) ** 2) / (($n - 2) * ($n - 3));
+                $bimodality_coef = ($skewness * $skewness + 1) / $bc_denom if $bc_denom > 0;
+            }
         }
-        my $n  = $duration_count;
-        my $m2 = $m2_sum / $n;
-        my $m3 = $m3_sum / $n;
-        my $m4 = $m4_sum / $n;
-        if ($m2 > 0) {
-            my $g1 = $m3 / ($m2 ** 1.5);
-            my $g2 = $m4 / ($m2 ** 2) - 3;
-            $skewness = sqrt($n * ($n - 1)) / ($n - 2) * $g1;
-            $kurtosis = ($n - 1) / (($n - 2) * ($n - 3)) * (($n + 1) * $g2 + 6);
-            my $bc_denom = $kurtosis + 3 * (($n - 1) ** 2) / (($n - 2) * ($n - 3));
-            $bimodality_coef = ($skewness * $skewness + 1) / $bc_denom if $bc_denom > 0;
-        }
+        @stats{qw(skewness kurtosis bimodality_coef)} = ($skewness, $kurtosis, $bimodality_coef);
+    } elsif ($duration_count >= 4) {
+        $stats_demand_telemetry{shape_pass_skipped}++;
     }
 
-    return ($min, $mean, $max,
-            $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-            $std_dev, $cv,
-            $skewness, $kurtosis, $bimodality_coef);
+    return \%stats;
 }
 
 # Issue #287: per-message-key bin-counter consumer. Sibling of
-# calculate_statistics() — same 22-tuple return shape, different derivation:
+# calculate_statistics() — same hashref return shape and #305 demand
+# semantics, different derivation:
 #   min/max  — running sidecar (R2.2 of features/287-*.md).
 #   mean     — total_duration / duration_count (matches raw path's denominator).
 #   std_dev, cv — from sum_of_squares accumulator (matches raw path).
@@ -10159,9 +10342,10 @@ sub calculate_statistics {
 # observable output remains byte-identical to -mdm raw. Commit 2 replaces
 # the body with the real sidecar-and-percentile derivation.
 sub calculate_statistics_bin {
-    # Issue #287 Commit 2: real per-statistic derivation. Returns the same
-    # 22-tuple as calculate_statistics(), with derivation per the R3.2 table
-    # in features/287-message-stats-bin-counter-data-model.md:
+    # Issue #287 Commit 2: real per-statistic derivation. Returns a hashref
+    # of computed statistic fields with the same field names and demand
+    # semantics as calculate_statistics() (#305), with derivation per the
+    # R3.2 table in features/287-message-stats-bin-counter-data-model.md:
     #   min/max:                 sidecar (R2.2; populated unconditionally per
     #                            sample so 0-duration samples are captured).
     #   mean:                    total_duration / duration_count (matches the
@@ -10185,7 +10369,15 @@ sub calculate_statistics_bin {
     # #287 per-message-key callers are unchanged; the per-time-bucket caller
     # passes \%bucket_stats_audit so the two surfaces' -V telemetry stay
     # separate when both run bin (e.g. under -dm bin).
-    my ($sidecar_entry, $counter_entry, $aggregated_data, $audit_ref) = @_;
+    # Issue #305: $demand is the statistics-group demand descriptor
+    # { csv_body => 0|1, extended => 0|1, shape => 0|1 }. Undemanded groups'
+    # percentile() calls and the shape derivation are skipped, and the
+    # returned hashref carries only the demanded groups' fields (undemanded
+    # quantiles also make no out_of_range_bounded audit contribution). The
+    # shape_pass telemetry counters are NOT touched here — they count the raw
+    # path's O(n) second pass; this path's O(1) sidecar derivation is
+    # reported via moment_source instead.
+    my ($sidecar_entry, $counter_entry, $aggregated_data, $demand, $audit_ref) = @_;
     $audit_ref //= \%message_stats_audit;
     return unless $sidecar_entry && ($sidecar_entry->{occurrences} // 0) > 0;
     my $n = $sidecar_entry->{duration_count} // 0;
@@ -10204,6 +10396,18 @@ sub calculate_statistics_bin {
         $cv = $mean != 0 ? $std_dev / $mean : undef;
     }
 
+    # Quantiles to derive, by demand: terminal_core always; csv_body and
+    # extended_percentiles when demanded. p75 is additionally needed as an
+    # intermediate whenever extended is demanded (iqr = p75 - p25), even if
+    # csv_body (p75's own group) is not. Explicit [field, quantile] pairs —
+    # deriving field names from $q*100 would risk float stringification
+    # artifacts.
+    my @quantiles = ( [p50 => 0.50], [p95 => 0.95], [p99 => 0.99], [p999 => 0.999] );
+    push @quantiles, ( [p1 => 0.01], [p90 => 0.90] ) if $demand->{csv_body};
+    push @quantiles, [p75 => 0.75] if $demand->{csv_body} || $demand->{extended};
+    push @quantiles, ( [p5 => 0.05], [p10 => 0.10], [p25 => 0.25],
+                       [p9999 => 0.9999], [p99999 => 0.99999] ) if $demand->{extended};
+
     # Percentile ladder. When $counter_entry is undef (the rare case of every
     # observed duration being 0, so counter_update was never called for this
     # key), all percentiles collapse to 0 — matches the raw path's behavior
@@ -10211,21 +10415,13 @@ sub calculate_statistics_bin {
     # into the caller-selected $audit_ref for the -V out_of_range_bounded
     # report; the matching finalize_*_unified() drains the aggregation into
     # the per-consumer telemetry hash.
-    my ($p1, $p5, $p10, $p25, $p50, $p75, $p90, $p95, $p99, $p999, $p9999, $p99999);
+    my %pct;   # percentile field name (e.g. 'p999') -> value
     if ($counter_entry) {
         my %a;
-        ($p1,     $a{p1})     = percentile($counter_entry, 0.01);
-        ($p5,     $a{p5})     = percentile($counter_entry, 0.05);
-        ($p10,    $a{p10})    = percentile($counter_entry, 0.10);
-        ($p25,    $a{p25})    = percentile($counter_entry, 0.25);
-        ($p50,    $a{p50})    = percentile($counter_entry, 0.50);
-        ($p75,    $a{p75})    = percentile($counter_entry, 0.75);
-        ($p90,    $a{p90})    = percentile($counter_entry, 0.90);
-        ($p95,    $a{p95})    = percentile($counter_entry, 0.95);
-        ($p99,    $a{p99})    = percentile($counter_entry, 0.99);
-        ($p999,   $a{p999})   = percentile($counter_entry, 0.999);
-        ($p9999,  $a{p9999})  = percentile($counter_entry, 0.9999);
-        ($p99999, $a{p99999}) = percentile($counter_entry, 0.99999);
+        for my $pair (@quantiles) {
+            my ($key, $q) = @$pair;
+            ($pct{$key}, $a{$key}) = percentile($counter_entry, $q);
+        }
         # Aggregate: 'high' wins over 'low' wins over 'none'.
         for my $q (keys %a) {
             my $new = $a{$q};
@@ -10243,7 +10439,7 @@ sub calculate_statistics_bin {
         # clamping here preserves #224 Decision 4's "min <= p1 ... p99999
         # <= max" Layer 2 invariant while still using bin-counter precision
         # for everything inside the observed range.
-        for ($p1, $p5, $p10, $p25, $p50, $p75, $p90, $p95, $p99, $p999, $p9999, $p99999) {
+        for (values %pct) {
             next unless defined;
             $_ = $min if defined $min && $_ < $min;
             $_ = $max if defined $max && $_ > $max;
@@ -10251,32 +10447,46 @@ sub calculate_statistics_bin {
     } else {
         # All-zero degenerate case: every percentile equals min (which is 0
         # here because durations are non-negative and we observed only zeros).
-        $p1 = $p5 = $p10 = $p25 = $p50 = $p75 = $p90 = $p95 = $p99 = $p999 = $p9999 = $p99999 = ($min // 0);
+        $pct{ $_->[0] } = ($min // 0) for @quantiles;
     }
-    my $iqr = (defined $p75 && defined $p25) ? $p75 - $p25 : undef;
 
-    # Distribution-shape moments — same downstream formulas as calculate_statistics
-    # at ltl:~8895, with m2/m3/m4 sourced from the Welford-Pébay sidecar
-    # accumulators (M_k_sum / n = m_k central moment).
-    my ($skewness, $kurtosis, $bimodality_coef) = (undef, undef, undef);
-    if ($n >= 4) {
-        my $m2 = $sidecar_entry->{m2_sum} / $n;
-        my $m3 = $sidecar_entry->{m3_sum} / $n;
-        my $m4 = $sidecar_entry->{m4_sum} / $n;
-        if ($m2 > 0) {
-            my $g1 = $m3 / ($m2 ** 1.5);
-            my $g2 = $m4 / ($m2 ** 2) - 3;
-            $skewness = sqrt($n * ($n - 1)) / ($n - 2) * $g1;
-            $kurtosis = ($n - 1) / (($n - 2) * ($n - 3)) * (($n + 1) * $g2 + 6);
-            my $bc_denom = $kurtosis + 3 * (($n - 1) ** 2) / (($n - 2) * ($n - 3));
-            $bimodality_coef = ($skewness * $skewness + 1) / $bc_denom if $bc_denom > 0;
+    my %stats = (
+        min => $min, p50 => $pct{p50}, p95 => $pct{p95}, p99 => $pct{p99},
+        p999 => $pct{p999}, cv => $cv,
+    );
+    if ($demand->{csv_body}) {
+        @stats{qw(mean max p1 p75 p90 std_dev)} =
+            ($mean, $max, $pct{p1}, $pct{p75}, $pct{p90}, $std_dev);
+    }
+    if ($demand->{extended}) {
+        my $iqr = (defined $pct{p75} && defined $pct{p25}) ? $pct{p75} - $pct{p25} : undef;
+        @stats{qw(p5 p10 p25 p9999 p99999 iqr)} =
+            (@pct{qw(p5 p10 p25 p9999 p99999)}, $iqr);
+    }
+
+    # Distribution-shape moments — same downstream formulas as calculate_statistics,
+    # with m2/m3/m4 sourced from the Welford-Pébay sidecar accumulators
+    # (M_k_sum / n = m_k central moment). O(1) here; gated on demand so the
+    # fields are neither derived nor stored when no consumer reads them.
+    if ($demand->{shape}) {
+        my ($skewness, $kurtosis, $bimodality_coef) = (undef, undef, undef);
+        if ($n >= 4) {
+            my $m2 = $sidecar_entry->{m2_sum} / $n;
+            my $m3 = $sidecar_entry->{m3_sum} / $n;
+            my $m4 = $sidecar_entry->{m4_sum} / $n;
+            if ($m2 > 0) {
+                my $g1 = $m3 / ($m2 ** 1.5);
+                my $g2 = $m4 / ($m2 ** 2) - 3;
+                $skewness = sqrt($n * ($n - 1)) / ($n - 2) * $g1;
+                $kurtosis = ($n - 1) / (($n - 2) * ($n - 3)) * (($n + 1) * $g2 + 6);
+                my $bc_denom = $kurtosis + 3 * (($n - 1) ** 2) / (($n - 2) * ($n - 3));
+                $bimodality_coef = ($skewness * $skewness + 1) / $bc_denom if $bc_denom > 0;
+            }
         }
+        @stats{qw(skewness kurtosis bimodality_coef)} = ($skewness, $kurtosis, $bimodality_coef);
     }
 
-    return ($min, $mean, $max,
-            $p1, $p5, $p10, $p25, $p50, $p75, $iqr, $p90, $p95, $p99, $p999, $p9999, $p99999,
-            $std_dev, $cv,
-            $skewness, $kurtosis, $bimodality_coef);
+    return \%stats;
 }
 
 sub initialize_empty_time_windows {
@@ -13297,6 +13507,8 @@ emit_heatmap_palette_verbose();
 emit_csv_output_verbose();
 
 emit_percentile_algorithm_verbose();
+
+emit_statistics_demand_verbose();
 
 emit_profile_verbose();
 

--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -104,6 +104,7 @@ This list prevents collisions across parallel work. Update it when adding a new 
 - `heatmap-palette` — heatmap color palette resolution: active metric, light/dark selection, source of selection, gradient arrays (Issue #250)
 - `profile` — timeline folding (--profile): resolved mode, fold period, included weekdays, included vs dropped sample counts (Issue #256)
 - `udm-counting` — per-bucket counting-aggregation UDM state: occurrences, distinct cardinality, display and highlight values, plus sessions oracle reference (Issue #313)
+- `statistics-demand` — per-store resolved statistics-group demand with raising consumers, shape-moment pass execution counters, and per-store moment source (Issue #305)
 - `benchmark-data` — machine-parseable TSV: version, files, line counts, timings, memory, structure counts
 
 **Reserved by sub-issues, not yet implemented:**

--- a/tests/baseline/results/305-post.tsv
+++ b/tests/baseline/results/305-post.tsv
@@ -1,0 +1,414 @@
+test_name	options	metric_type	metric_name	value
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	version	0.15.2
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	lines_read	7749167
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	lines_included	7749167
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	read_files	276.712
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	group_similar	72.372
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	calculate_statistics	2.865
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	heatmap_statistics	0.061
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	histogram_statistics	0.011
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	normalize_data	0.003
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	TIMING	total	352.025
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	rss_peak	1359691776
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_clusters	531863079
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_key_message	2590878
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_key_trigrams	38447857
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_key_trigrams_norm	30842346
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_ngram_index	37691548
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_patterns	289782
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_posting_size	996979
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	consolidation_unmatched	1629563
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	heatmap_counters	2516532
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	heatmap_counters_hl	232
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	heatmap_data	85118
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	heatmap_raw	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	histogram_counters	302693
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	histogram_values	576
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_analysis	15661
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_messages	594583089
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_messages_counters	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_occurrences	37445
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_sessions	2319606
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_stats	30277
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	log_threadpools	232
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	threadpool_activity	762
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	udm_distinct	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY	udm_last_value	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	log_messages	594583089
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	log_analysis	12594
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_clusters	531863079
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_patterns	248469
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_key_message	131128
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_unmatched	424
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	MEMORY_FINAL	consolidation_key_trigrams_norm	65592
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	COUNTS	log_messages_entries	1317
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	COUNTS	log_stats_entries	28
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	CONFIG	terminal_width	200
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	CONFIG	terminal_height	24
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	CONFIG	max_log_message_length	200
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-heatmap-histogram-consolidate	-bs 1440 -hm -hg -g	CONFIG	bucket_size_seconds	86400.00
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	version	0.15.2
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	lines_read	7749167
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	lines_included	7749167
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	read_files	242.199
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	group_similar	0.000
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	calculate_statistics	2.053
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	heatmap_statistics	0.061
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	histogram_statistics	0.007
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	normalize_data	0.002
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	TIMING	total	244.323
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	rss_peak	2267709440
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_clusters	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_key_message	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_key_trigrams	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_ngram_index	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_patterns	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_posting_size	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	consolidation_unmatched	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	heatmap_counters	2516532
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	heatmap_counters_hl	232
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	heatmap_data	85630
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	heatmap_raw	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	histogram_counters	302693
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	histogram_values	576
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_analysis	15661
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_messages	1704450545
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_messages_counters	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_occurrences	37637
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_sessions	2319606
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_stats	30277
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	log_threadpools	232
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	threadpool_activity	762
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	udm_distinct	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY	udm_last_value	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	log_messages	1704450545
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	log_analysis	12594
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_clusters	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_patterns	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_key_message	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_unmatched	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	COUNTS	log_messages_entries	1212275
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	COUNTS	log_stats_entries	28
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	CONFIG	terminal_width	200
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	CONFIG	terminal_height	24
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	CONFIG	max_log_message_length	200
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-heatmap-histogram	-bs 1440 -hm -hg	CONFIG	bucket_size_seconds	86400.00
+month-single-server-access-logs-histogram	-bs 1440 -hg	version	0.15.2
+month-single-server-access-logs-histogram	-bs 1440 -hg	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-histogram	-bs 1440 -hg	lines_read	7749167
+month-single-server-access-logs-histogram	-bs 1440 -hg	lines_included	7749167
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	read_files	235.739
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	group_similar	0.000
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	calculate_statistics	4.934
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	heatmap_statistics	0.000
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	histogram_statistics	0.007
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	normalize_data	0.002
+month-single-server-access-logs-histogram	-bs 1440 -hg	TIMING	total	240.682
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	rss_peak	2657894400
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_clusters	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_key_message	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_key_trigrams	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_ngram_index	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_patterns	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_posting_size	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	consolidation_unmatched	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	heatmap_counters	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	heatmap_counters_hl	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	heatmap_data	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	heatmap_raw	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	histogram_counters	302565
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	histogram_values	576
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_analysis	594859077
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_messages	1626865705
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_messages_counters	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_occurrences	37445
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_sessions	2319606
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_stats	44643
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	log_threadpools	232
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	threadpool_activity	762
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	udm_distinct	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY	udm_last_value	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	log_messages	1626865705
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	log_analysis	13010
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_clusters	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_patterns	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_key_message	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_unmatched	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_key_trigrams	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-histogram	-bs 1440 -hg	COUNTS	log_messages_entries	1212275
+month-single-server-access-logs-histogram	-bs 1440 -hg	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-histogram	-bs 1440 -hg	COUNTS	log_stats_entries	28
+month-single-server-access-logs-histogram	-bs 1440 -hg	CONFIG	terminal_width	200
+month-single-server-access-logs-histogram	-bs 1440 -hg	CONFIG	terminal_height	24
+month-single-server-access-logs-histogram	-bs 1440 -hg	CONFIG	max_log_message_length	200
+month-single-server-access-logs-histogram	-bs 1440 -hg	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-histogram	-bs 1440 -hg	CONFIG	bucket_size_seconds	86400.00
+month-single-server-access-logs-heatmap	-bs 1440 -hm	version	0.15.2
+month-single-server-access-logs-heatmap	-bs 1440 -hm	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-heatmap	-bs 1440 -hm	lines_read	7749167
+month-single-server-access-logs-heatmap	-bs 1440 -hm	lines_included	7749167
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	read_files	224.333
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	group_similar	0.000
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	calculate_statistics	2.100
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	heatmap_statistics	0.068
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	histogram_statistics	0.000
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	normalize_data	0.002
+month-single-server-access-logs-heatmap	-bs 1440 -hm	TIMING	total	226.504
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	rss_peak	2256568320
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_clusters	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_key_message	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_key_trigrams	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_ngram_index	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_patterns	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_posting_size	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	consolidation_unmatched	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	heatmap_counters	2516532
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	heatmap_counters_hl	232
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	heatmap_data	83070
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	heatmap_raw	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	histogram_counters	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	histogram_values	576
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_analysis	15661
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_messages	1702537009
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_messages_counters	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_occurrences	37637
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_sessions	2319606
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_stats	30277
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	log_threadpools	232
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	threadpool_activity	762
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	udm_distinct	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY	udm_last_value	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	log_messages	1702537009
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	log_analysis	12594
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_clusters	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_patterns	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_key_message	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_unmatched	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_key_trigrams	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-heatmap	-bs 1440 -hm	COUNTS	log_messages_entries	1212275
+month-single-server-access-logs-heatmap	-bs 1440 -hm	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-heatmap	-bs 1440 -hm	COUNTS	log_stats_entries	28
+month-single-server-access-logs-heatmap	-bs 1440 -hm	CONFIG	terminal_width	200
+month-single-server-access-logs-heatmap	-bs 1440 -hm	CONFIG	terminal_height	24
+month-single-server-access-logs-heatmap	-bs 1440 -hm	CONFIG	max_log_message_length	200
+month-single-server-access-logs-heatmap	-bs 1440 -hm	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-heatmap	-bs 1440 -hm	CONFIG	bucket_size_seconds	86400.00
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	version	0.15.2
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	lines_read	7749167
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	lines_included	7749167
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	read_files	249.812
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	group_similar	98.955
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	calculate_statistics	7.224
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	heatmap_statistics	0.000
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	histogram_statistics	0.000
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	normalize_data	0.003
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	TIMING	total	355.995
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	rss_peak	1668874240
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_clusters	531863079
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_key_message	2590878
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_key_trigrams	38447345
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_key_trigrams_norm	30853610
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_ngram_index	37707548
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_patterns	289782
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_posting_size	996979
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	consolidation_unmatched	1629563
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	heatmap_counters	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	heatmap_counters_hl	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	heatmap_data	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	heatmap_raw	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	histogram_counters	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	histogram_values	576
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_analysis	594983589
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_messages	594593777
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_messages_counters	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_occurrences	37637
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_sessions	2319478
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_stats	44643
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	log_threadpools	232
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	threadpool_activity	762
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	udm_distinct	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY	udm_last_value	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	log_messages	594593777
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	log_analysis	13010
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_clusters	531863079
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_patterns	248469
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_key_message	131128
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_unmatched	424
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_key_trigrams	65592
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	MEMORY_FINAL	consolidation_key_trigrams_norm	65592
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	COUNTS	log_messages_entries	1317
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	COUNTS	log_stats_entries	28
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	CONFIG	terminal_width	200
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	CONFIG	terminal_height	24
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	CONFIG	max_log_message_length	200
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-top25-consolidate	-bs 1440 -n 25 -g	CONFIG	bucket_size_seconds	86400.00
+month-single-server-access-logs-top25	-bs 1440 -n 25	version	0.15.2
+month-single-server-access-logs-top25	-bs 1440 -n 25	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-top25	-bs 1440 -n 25	lines_read	7749167
+month-single-server-access-logs-top25	-bs 1440 -n 25	lines_included	7749167
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	read_files	211.428
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	group_similar	0.000
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	calculate_statistics	5.225
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	heatmap_statistics	0.000
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	histogram_statistics	0.000
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	normalize_data	0.002
+month-single-server-access-logs-top25	-bs 1440 -n 25	TIMING	total	216.655
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	rss_peak	2730934272
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_clusters	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_key_message	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_key_trigrams	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_ngram_index	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_patterns	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_posting_size	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	consolidation_unmatched	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	heatmap_counters	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	heatmap_counters_hl	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	heatmap_data	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	heatmap_raw	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	histogram_counters	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	histogram_values	576
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_analysis	594859077
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_messages	1704457993
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_messages_counters	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_occurrences	37445
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_sessions	2319606
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_stats	44643
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	log_threadpools	232
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	threadpool_activity	762
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	udm_distinct	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY	udm_last_value	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	log_messages	1704457993
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	log_analysis	13010
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_clusters	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_patterns	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_key_message	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_unmatched	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_key_trigrams	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-top25	-bs 1440 -n 25	COUNTS	log_messages_entries	1212275
+month-single-server-access-logs-top25	-bs 1440 -n 25	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-top25	-bs 1440 -n 25	COUNTS	log_stats_entries	28
+month-single-server-access-logs-top25	-bs 1440 -n 25	CONFIG	terminal_width	200
+month-single-server-access-logs-top25	-bs 1440 -n 25	CONFIG	terminal_height	24
+month-single-server-access-logs-top25	-bs 1440 -n 25	CONFIG	max_log_message_length	200
+month-single-server-access-logs-top25	-bs 1440 -n 25	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-top25	-bs 1440 -n 25	CONFIG	bucket_size_seconds	86400.00
+month-single-server-access-logs-standard	-bs 1440	version	0.15.2
+month-single-server-access-logs-standard	-bs 1440	FILES	/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-02.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-03.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-04.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-05.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-06.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-07.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-08.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-09.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-10.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-11.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-12.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-13.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-14.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-15.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-16.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-17.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-18.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-19.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-20.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-21.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-22.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-23.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-24.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-25.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-26.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-27.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-28.txt;/Users/gregeva/Documents/GitHub/logtimeline/logs/AccessLogs/really-big/localhost_access_log-twx01-twx-thingworx-1.2026-01-29.txt	1633537993
+month-single-server-access-logs-standard	-bs 1440	lines_read	7749167
+month-single-server-access-logs-standard	-bs 1440	lines_included	7749167
+month-single-server-access-logs-standard	-bs 1440	TIMING	read_files	211.794
+month-single-server-access-logs-standard	-bs 1440	TIMING	initialize_buckets	0.000
+month-single-server-access-logs-standard	-bs 1440	TIMING	group_similar	0.000
+month-single-server-access-logs-standard	-bs 1440	TIMING	calculate_statistics	4.962
+month-single-server-access-logs-standard	-bs 1440	TIMING	heatmap_statistics	0.000
+month-single-server-access-logs-standard	-bs 1440	TIMING	histogram_statistics	0.000
+month-single-server-access-logs-standard	-bs 1440	TIMING	normalize_data	0.002
+month-single-server-access-logs-standard	-bs 1440	TIMING	total	216.758
+month-single-server-access-logs-standard	-bs 1440	MEMORY	rss_peak	2735505408
+month-single-server-access-logs-standard	-bs 1440	MEMORY	bucket_stats_counters	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	bucket_stats_counters_hl	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_clusters	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_key_message	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_key_trigrams	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_ngram_index	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_patterns	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_posting_size	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	consolidation_unmatched	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	heatmap_counters	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	heatmap_counters_hl	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	heatmap_data	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	heatmap_data_hl	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	heatmap_raw	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	heatmap_raw_hl	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	histogram_counters	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	histogram_counters_hl	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	histogram_values	576
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_analysis	594859077
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_messages	1702537257
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_messages_counters	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_occurrences	37637
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_sessions	2319606
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_stats	44643
+month-single-server-access-logs-standard	-bs 1440	MEMORY	log_threadpools	232
+month-single-server-access-logs-standard	-bs 1440	MEMORY	threadpool_activity	762
+month-single-server-access-logs-standard	-bs 1440	MEMORY	udm_distinct	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY	udm_last_value	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	log_messages	1702537257
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	log_analysis	13010
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_clusters	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_patterns	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_key_message	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_unmatched	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_ngram_index	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_key_trigrams	120
+month-single-server-access-logs-standard	-bs 1440	MEMORY_FINAL	consolidation_key_trigrams_norm	120
+month-single-server-access-logs-standard	-bs 1440	COUNTS	log_messages_entries	1212275
+month-single-server-access-logs-standard	-bs 1440	COUNTS	log_occurrences_entries	28
+month-single-server-access-logs-standard	-bs 1440	COUNTS	log_stats_entries	28
+month-single-server-access-logs-standard	-bs 1440	CONFIG	terminal_width	200
+month-single-server-access-logs-standard	-bs 1440	CONFIG	terminal_height	24
+month-single-server-access-logs-standard	-bs 1440	CONFIG	max_log_message_length	200
+month-single-server-access-logs-standard	-bs 1440	CONFIG	time_bucket_size	1440
+month-single-server-access-logs-standard	-bs 1440	CONFIG	bucket_size_seconds	86400.00

--- a/tests/validate-statistics-demand.sh
+++ b/tests/validate-statistics-demand.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# validate-statistics-demand.sh — Validate the statistics-demand `-V` section:
+# per-store statistics-group demand resolution with raising consumers, the
+# shape-moment pass execution counters, and the per-store moment source
+# (Issue #305).
+# Usage: ./tests/validate-statistics-demand.sh
+#
+# Follows the self-documenting assertion design from tests/HARNESS-DESIGN.md
+# (reference implementation: tests/validate-histogram-bin-counters.sh).
+# Every assertion records:
+#   - asserts:     the application invariant being tested
+#   - produced_by: where in ltl the invariant is produced (function name)
+#   - contract:    the stability contract that makes it stable
+# All three are surfaced on failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LTL="$REPO_DIR/ltl"
+
+# shellcheck source=lib/runtime-warnings.sh
+source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+ACCESS_LOG="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+
+if [[ ! -x "$LTL" ]]; then
+    echo "ERROR: ltl not found or not executable at $LTL"
+    exit 1
+fi
+if [[ ! -f "$ACCESS_LOG" ]]; then
+    echo "ERROR: ACCESS_LOG not found: $ACCESS_LOG"
+    exit 1
+fi
+
+# Scenario 2 passes -o, which writes CSV artifacts into the CWD; run every
+# scenario inside a scratch workdir so no artifacts land in the repo.
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+cd "$WORKDIR"
+
+CONTRACT='features/305-shape-moment-extended-percentile-demand.md § -V statistics-demand section contract — stability-contracted; renames are breaking'
+
+pass=0
+fail=0
+failures=()
+current_scenario=""
+
+# Run ltl with the requested -V section(s) and the standard suppression flag.
+# Captures stdout to a temp file (path echoed); stderr lands beside it.
+# Args after the function name are forwarded verbatim before the input file.
+run_section() {
+    local sections="$1"; shift
+    local outfile
+    outfile=$(mktemp)
+    "$LTL" --disable-progress --terminal-width 200 -V "$sections" "$@" "$ACCESS_LOG" > "$outfile" 2>"$outfile.stderr" || true
+    echo "$outfile"
+}
+
+# Runtime-warning cleanliness for a run_section capture (stderr lives beside
+# the captured stdout as <capture>.stderr). Runs in the main shell so the
+# fail counters persist. HARNESS-DESIGN.md § Runtime-warning cleanliness.
+check_capture_warnings() {
+    local capture="$1"
+    if ! assert_no_runtime_warnings "$capture.stderr" "$current_scenario"; then
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: perl-runtime-warnings-on-stderr")
+    fi
+}
+
+# Self-documenting assertion: a line matching `pattern` must be present.
+assert_line() {
+    local outfile="$1"
+    shift
+    local pattern asserts produced_by contract
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            pattern)     pattern="$2";     shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            *) echo "assert_line: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${pattern:?assert_line requires pattern}"
+    : "${asserts:?assert_line requires asserts}"
+    : "${produced_by:?assert_line requires produced_by}"
+    : "${contract:?assert_line requires contract}"
+
+    if grep -qE "$pattern" "$outfile"; then
+        echo "  PASS  $current_scenario :: $pattern"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $current_scenario"
+        echo "        pattern:     $pattern"
+        echo "        asserts:     $asserts"
+        echo "        produced_by: $produced_by"
+        echo "        contract:    $contract"
+        echo "        (not found in $outfile)"
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: $pattern")
+    fi
+}
+
+# Self-documenting assertion for anything beyond a single-line grep.
+# `command` is eval'd (PASS if exit 0); `label` names it on the PASS line.
+assert_command() {
+    local command label asserts produced_by contract
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            command)     command="$2";     shift 2 ;;
+            label)       label="$2";       shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            *) echo "assert_command: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${command:?assert_command requires command}"
+    : "${label:?assert_command requires label}"
+    : "${asserts:?assert_command requires asserts}"
+    : "${produced_by:?assert_command requires produced_by}"
+    : "${contract:?assert_command requires contract}"
+
+    if eval "$command" >/dev/null 2>&1; then
+        echo "  PASS  $current_scenario :: $label"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $current_scenario"
+        echo "        command:     $command"
+        echo "        label:       $label"
+        echo "        asserts:     $asserts"
+        echo "        produced_by: $produced_by"
+        echo "        contract:    $contract"
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: $label")
+    fi
+}
+
+# Extract the statistics-demand section body; hard-fail (per HARNESS-DESIGN
+# "must fail on missing anchors") if the start or end marker is absent.
+extract_section() {
+    local outfile="$1"
+    local body="$outfile.section"
+    if ! grep -q '^=== statistics-demand ===$' "$outfile" \
+       || ! grep -q '^=== END statistics-demand ===$' "$outfile"; then
+        echo "  FAIL  $current_scenario"
+        echo "        pattern:     === statistics-demand === ... === END statistics-demand ==="
+        echo "        asserts:     The statistics-demand section is emitted with both start and end markers when requested via -V"
+        echo "        produced_by: emit_statistics_demand_verbose() in ltl"
+        echo "        contract:    $CONTRACT"
+        echo "        (anchor not found in $outfile)"
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: section-anchor-missing")
+        return 1
+    fi
+    sed -n '/^=== statistics-demand ===$/,/^=== END statistics-demand ===$/p' "$outfile" > "$body"
+    echo "$body"
+}
+
+# Extract the per-store sub-block (lines from `store: <name>` up to the next
+# `store:` or the shape_pass line) so per-store assertions cannot match the
+# other store's lines.
+extract_store() {
+    local body="$1" store="$2"
+    local out="$body.$store"
+    awk -v store="$store" '
+        $0 == "store: " store { inside=1; print; next }
+        inside && (/^store: / || /^shape_pass: / || /^=== END /) { inside=0 }
+        inside { print }
+    ' "$body" > "$out"
+    echo "$out"
+}
+
+echo "=== validate-statistics-demand: statistics-demand -V section (Issue #305) ==="
+echo "fixture: $ACCESS_LOG"
+echo
+
+############################################################
+current_scenario="scenario-1-terminal-only-default"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand)
+check_capture_warnings "$out"
+if body=$(extract_section "$out"); then
+    for store in bucket message; do
+        sb=$(extract_store "$body" "$store")
+        assert_line "$sb" \
+            pattern     '^  store_demand: 1$' \
+            asserts     "On a default terminal run the $store store is demanded (its terminal surface is active)" \
+            produced_by 'resolve_statistics_group_demand() in ltl (store-level booleans from adapt_to_command_line_options)' \
+            contract    "$CONTRACT"
+        assert_line "$sb" \
+            pattern     '^  group terminal_core: demanded=1 consumers=' \
+            asserts     "terminal_core is demanded on the $store store whenever the store is (every store-activating consumer declares it)" \
+            produced_by 'resolve_statistics_group_demand() in ltl' \
+            contract    "$CONTRACT"
+        for group in csv_body extended_percentiles shape_moments; do
+            assert_line "$sb" \
+                pattern     "^  group $group: demanded=0 consumers=-\$" \
+                asserts     "On a terminal-only run no consumer raises $group demand on the $store store (terminal surfaces read only terminal_core fields)" \
+                produced_by 'resolve_statistics_group_demand() in ltl' \
+                contract    "$CONTRACT"
+        done
+        assert_line "$sb" \
+            pattern     '^  moment_source: none$' \
+            asserts     "With shape_moments undemanded the $store store reports moment_source none" \
+            produced_by 'emit_statistics_demand_verbose() in ltl' \
+            contract    "$CONTRACT"
+    done
+    assert_line "$body" \
+        pattern     '^shape_pass: executed=0 skipped=[1-9][0-9]*$' \
+        asserts     'On a terminal-only run the raw O(n) shape-moment pass never executes and is skipped for every key/bucket with n>=4 — the observable proof that demand gating fires' \
+        produced_by 'calculate_statistics() in ltl (shape_pass counters in %stats_demand_telemetry)' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+current_scenario="scenario-2-csv-full-demand"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand -o)
+check_capture_warnings "$out"
+if body=$(extract_section "$out"); then
+    sb=$(extract_store "$body" bucket)
+    assert_line "$sb" \
+        pattern     '^  group shape_moments: demanded=1 consumers=.*stats-csv' \
+        asserts     'With -o active the STATS CSV raises shape_moments demand on the bucket store' \
+        produced_by 'resolve_statistics_group_demand() in ltl (@STAT_CONSUMERS stats-csv declaration)' \
+        contract    "$CONTRACT"
+    assert_line "$sb" \
+        pattern     '^  group extended_percentiles: demanded=1 consumers=.*stats-csv' \
+        asserts     'With -o active the STATS CSV raises extended_percentiles demand on the bucket store' \
+        produced_by 'resolve_statistics_group_demand() in ltl' \
+        contract    "$CONTRACT"
+    sm=$(extract_store "$body" message)
+    assert_line "$sm" \
+        pattern     '^  group shape_moments: demanded=1 consumers=.*messages-csv' \
+        asserts     'With -o active the MESSAGES CSV raises shape_moments demand on the message store' \
+        produced_by 'resolve_statistics_group_demand() in ltl (@STAT_CONSUMERS messages-csv declaration)' \
+        contract    "$CONTRACT"
+    assert_line "$sm" \
+        pattern     '^  moment_source: second_pass$' \
+        asserts     'Under the default raw data model with shape demanded, the message store reports moment_source second_pass' \
+        produced_by 'emit_statistics_demand_verbose() in ltl' \
+        contract    "$CONTRACT"
+    assert_line "$body" \
+        pattern     '^shape_pass: executed=[1-9][0-9]* skipped=0$' \
+        asserts     'With every group demanded the shape pass executes for every eligible key/bucket and nothing is skipped — output parity with the pre-gating behavior' \
+        produced_by 'calculate_statistics() in ltl (shape_pass counters)' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+current_scenario="scenario-3-sort-on-skewness"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand -so skewness)
+check_capture_warnings "$out"
+if body=$(extract_section "$out"); then
+    sm=$(extract_store "$body" message)
+    assert_line "$sm" \
+        pattern     '^  group shape_moments: demanded=1 consumers=sort-on:skewness$' \
+        asserts     'Sorting on a statistic makes -so an explicit demand contributor: -so skewness raises shape_moments demand on the message store with sort-on:<field> provenance' \
+        produced_by 'resolve_statistics_group_demand() in ltl (@STAT_CONSUMERS sort-on declaration)' \
+        contract    "$CONTRACT"
+    sb=$(extract_store "$body" bucket)
+    assert_line "$sb" \
+        pattern     '^  group shape_moments: demanded=0 consumers=-$' \
+        asserts     'A message-store sort key raises no demand on the bucket store' \
+        produced_by 'resolve_statistics_group_demand() in ltl' \
+        contract    "$CONTRACT"
+    assert_line "$sm" \
+        pattern     '^  moment_source: second_pass$' \
+        asserts     'The message store computes shape moments (via the raw second pass) when demanded by the sort key alone' \
+        produced_by 'emit_statistics_demand_verbose() in ltl' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+current_scenario="scenario-4-heatmap-no-bucket-demand"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand -hm duration)
+check_capture_warnings "$out"
+if body=$(extract_section "$out"); then
+    sb=$(extract_store "$body" bucket)
+    assert_line "$sb" \
+        pattern     '^  store_demand: 0$' \
+        asserts     'With the heatmap replacing the timeline latency column and no CSV active, the bucket store has no consumer and store demand is 0' \
+        produced_by 'adapt_to_command_line_options() in ltl (store-level demand resolution, #349)' \
+        contract    "$CONTRACT"
+    for group in terminal_core csv_body extended_percentiles shape_moments; do
+        assert_line "$sb" \
+            pattern     "^  group $group: demanded=0 consumers=-\$" \
+            asserts     "With the bucket store undemanded no group can be demanded on it ($group)" \
+            produced_by 'resolve_statistics_group_demand() in ltl (store-level demand is a precondition for every consumer)' \
+            contract    "$CONTRACT"
+    done
+    sm=$(extract_store "$body" message)
+    assert_line "$sm" \
+        pattern     '^  store_demand: 1$' \
+        asserts     'The heatmap does not suppress the message store: the messages table remains active' \
+        produced_by 'adapt_to_command_line_options() in ltl (store-level demand resolution, #349)' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+current_scenario="scenario-5-runtime-config-crosscheck"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand,runtime-config)
+check_capture_warnings "$out"
+if body=$(extract_section "$out"); then
+    assert_command \
+        command     "bd=\$(grep -oE 'bucket-duration-stats-demand: [01]' '$out' | grep -oE '[01]\$'); sd=\$(awk '/^store: bucket\$/{f=1;next} f&&/store_demand:/{print \$2; exit}' '$body'); [[ -n \"\$bd\" && \"\$bd\" == \"\$sd\" ]]" \
+        label       'bucket store_demand agrees with runtime-config bucket-duration-stats-demand' \
+        asserts     'The statistics-demand store_demand line and the runtime-config bucket-duration-stats-demand boolean report the same resolved value (single resolution surface)' \
+        produced_by 'emit_statistics_demand_verbose() and emit_runtime_config_verbose() in ltl, both reading $bucket_duration_stats_demand' \
+        contract    "$CONTRACT"
+    assert_command \
+        command     "md=\$(grep -oE 'message-duration-stats-demand: [01]' '$out' | grep -oE '[01]\$'); sd=\$(awk '/^store: message\$/{f=1;next} f&&/store_demand:/{print \$2; exit}' '$body'); [[ -n \"\$md\" && \"\$md\" == \"\$sd\" ]]" \
+        label       'message store_demand agrees with runtime-config message-duration-stats-demand' \
+        asserts     'The statistics-demand store_demand line and the runtime-config message-duration-stats-demand boolean report the same resolved value (single resolution surface)' \
+        produced_by 'emit_statistics_demand_verbose() and emit_runtime_config_verbose() in ltl, both reading $message_duration_stats_demand' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+echo "=== validate-statistics-demand: $pass passed, $fail failed ==="
+if [[ $fail -gt 0 ]]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do echo "  - $f"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Fixes #305.

## What

A declarative statistics-group demand registry extending the #349 store-level demand contract to statistic-group granularity. Four groups (`terminal_core`, `csv_body`, `extended_percentiles`, `shape_moments`); consumer surfaces (timeline latency column, messages table, STATS/MESSAGES CSVs, `-so <statistic>`) declare the groups they read; one resolver derives per-store per-group demand. Demand gates **capture** (bin-path Welford m2/m3/m4 sidecars + merge), **compute** (the O(n) shape pass, extended percentile reads), and **storage** (undemanded statistic fields are never written to `%log_stats`/`%log_messages` — the memory lever). The primitives return a hashref of only-computed fields, replacing the positional 22-tuple.

New `-V statistics-demand` section (registry + emitter + `tests/validate-statistics-demand.sh`) makes the gating observable: per-store group demand with raising consumers, `moment_source`, and `shape_pass executed/skipped` counters.

Design + contracts recorded in `features/305-shape-moment-extended-percentile-demand.md` (including the previously-undocumented #349 store-level contract).

## Verification (all observed, per the "fixes count only when observed working" requirement)

- **Demand-OFF byte-identity**: terminal output diff vs branch point empty; `validate-regression.sh` 46/46.
- **Demand-ON byte-identity**: MESSAGES/STATS CSVs byte-identical vs branch point; `validate-csv-output.sh` 20/20; `validate-statistics.sh` 18/18 (L1/L2/L3 unchanged — every scenario uses `-o` ⇒ full demand); `validate-distribution-shape.sh` 8/8; `validate-runtime-config.sh` 36/36; full sweep of all remaining harnesses green (15/15).
- **New harness**: 29/29; **prove-can-fail** demonstrated by sabotaging the resolver (forced shape demand) — scenario 1 failed with the full asserts/produced_by/contract triple, then reverted to 29/29.
- **Memory** (500k-line really-big node file, `-mem` HWMs, base vs head): `-so p99` (all-keys statistic sort): `log_messages` **−38.4%** (201→124 MB), peak RSS **−25.4%** (261→195 MB). Terminal-only: `log_messages` −3.6% (top-N pool already limits it), RSS −2.5%.
- **Performance** (month-single-server benchmark, label `305-post` vs `v0.14.5.tsv`): `calculate_statistics` **beats the v0.14.5 baseline on all 7 scenarios** (−5.8% to −16.3%; standard 5.72s → 4.96s), exceeding the ±5% acceptance. Direct base-vs-head: 6.45s → 4.87s (−24.5%), `read_files` identical.
- **#358 caveat**: `TIMING total`/`read_files` on release/0.16.0 carry a pre-existing ~2x read_files regression (filed as #358 with a three-binary control experiment; present at this branch's base, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpk5FTT2XQKtjsfEajEwzt