### PR TITLE
Issue #362: clamp top-keys slice bound to avoid O(-n) transient RSS burst

### DIFF
--- a/ltl
+++ b/ltl
@@ -13161,7 +13161,7 @@ sub print_message_summary {
 
         # Ensure the grouping exists and is a hash reference
         if (exists $log_messages{$grouping} && ref($log_messages{$grouping}) eq 'HASH') {
-            my @top_keys = @{$sorted_keys{$grouping}}[0..($top_n_messages-1)] if scalar( @{$sorted_keys{$grouping}} ) > 0;
+            my @top_keys = @{$sorted_keys{$grouping}}[0 .. min($#{$sorted_keys{$grouping}}, $top_n_messages - 1)] if scalar( @{$sorted_keys{$grouping}} ) > 0;
             next unless scalar(@top_keys) > 0;			# skip to the next category if their are no top message keys
             my $header_title = " ";
 
@@ -13419,7 +13419,7 @@ sub print_threadpool_summary {
 
         # Ensure the grouping exists and is a hash reference
         if (exists $threadpool_activity{$grouping} && ref($threadpool_activity{$grouping}) eq 'HASH') {
-            my @top_keys = @{$sorted_keys{$grouping}}[0..($top_n_messages-1)] if scalar( @{$sorted_keys{$grouping}} ) > 0;
+            my @top_keys = @{$sorted_keys{$grouping}}[0 .. min($#{$sorted_keys{$grouping}}, $top_n_messages - 1)] if scalar( @{$sorted_keys{$grouping}} ) > 0;
 
             next unless scalar(@top_keys) > 0;			# skip to the next category if their are no top message keys
 


### PR DESCRIPTION
Fixes #362.

## Change

`print_message_summary()` and `print_threadpool_summary()` built `@top_keys` with an unclamped range slice `@{...}[0..($top_n_messages-1)]`. Because the bound is a runtime variable, Perl materializes a full range list of `-n` integer SVs regardless of key count — ~160 MB at `-n 2000000` during the output phase. RSS is a ratchet, so the transient burst permanently inflates peak RSS.

Both bounds are now clamped with `min($#{$sorted_keys{$grouping}}, $top_n_messages - 1)`, matching the existing idiom in `calculate_all_statistics()`. `min` was already imported.

## Validation (OS-level peak RSS, 44 MB access log, `-mdm bin -mem`)

| run | `-n 2000000` peak RSS | `-n 50000` peak RSS | burst |
|---|---|---|---|
| before | 199.2 MB | 41.3 MB | +157.9 MB |
| after | 38.3 MB | 38.7 MB | ≈ 0 MB |

The `-n`-proportional burst is eliminated; analytical output is byte-identical (only run-to-run timing and the RSS figure differ). No runtime warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)