### PR TITLE
Issue #365: enhanced/JBoss access-log format (match_type 9) shadowed by with-duration pattern

### DIFF
--- a/features/358-read-files-regression-format-cascade.md
+++ b/features/358-read-files-regression-format-cascade.md
@@ -192,6 +192,30 @@ Accepted residuals (deliberate, documented above):
 - Spaces inside the host/ident/authuser prefix fields are no longer tolerated (see
   § Deterministic-prefix validation behavioral delta).
 
+## Cascade reorder for match_type 9 reachability (#365, 2026-07-13)
+
+Issue #365 resolved finding 3 above: the match_type 9 `elsif` block was moved to sit
+immediately before the match_type 3 block, making the access-log family order
+**12 → 4 → 9 → 3**. match_type 9 is end-anchored and strictly more specific than
+match_type 3 (it requires quoted referrer + quoted user-agent + trailing duration
+after numeric bytes), so it cannot claim genuine match_type 3 lines; enhanced/JBoss
+lines now bind to `jboss_access` with their trailing duration captured instead of
+being claimed by match_type 3 with duration=undef.
+
+Cost, measured on the 57 MB probe (median of 3): read_files 4.005 s → 4.326 s
+(**+0.32 s, ~+1.2 µs/line**) — every ordinary with-duration line now pays a second
+cheap failed anchored attempt (match_type 9, deterministic prefix), the same
+accepted-residual class as match_type 4's. Output remains byte-identical on the 5k
+Tomcat sample and the Apache HTTP2 Windchill log (timing/memory block aside).
+Regression coverage: `scenario_jboss_enhanced` in `validate-format-detection.sh`
+(classification) and `run_jboss_duration_scenario` in `validate-duration-display.sh`
+(latency-surface presence), both proven to fail against the pre-reorder binary.
+
+Known limitation (by format definition, not a defect): an enhanced-format line whose
+bytes field is `-` does not match match_type 9 (its bytes group is `(\d+)`) and falls
+through to match_type 3, losing its duration. No such lines exist in the fixtures;
+revisit under the format-registry rewrite (#23) if real corpora surface them.
+
 ## Measurement hygiene notes
 
 - `tests/baseline/results/305-post.tsv` totals are poisoned by this regression (noted

--- a/ltl
+++ b/ltl
@@ -8093,6 +8093,23 @@ sub read_and_process_logs {
                 $message =~ s/ HTTP\/\d\.\d$//;					# chop off the HTTP protocol and version
                 $message =~ s/\?.+$// unless $include_query_string;		# chop off the query string from the URI
 
+            ## JBoss/Jersey Enhanced Access Log Format: quoted referrer, quoted user-agent, then execution time ##
+            # Anchored to end-of-line after the trailing duration so it wins over the
+            # broader with-duration pattern below; that pattern's all-optional tail
+            # would otherwise claim these lines with duration=undef and junk
+            # thread/session captures from the quoted fields.
+            } elsif ( (undef, $timestamp_str, $message, $category_bucket, $bytes, undef, undef, $duration) = $_ =~ /^([^ ]+ ){3}[\[]([^\]]+)[\]] "([^"]+)" (\d{3}) (\d+) "([^"]+)" "([^"]+)" (\d+)$/ ) {
+            # access logs # 127.0.0.1 - - [13/Mar/2025:09:02:41 +0000] "GET /async/prediction/evaluation?limit=99999 HTTP/1.1" 200 51 "-" "Jersey/2.37 (HttpUrlConnection 11.0.22)" 651
+                $is_line_match = 1;
+                $match_type = 9;			# this is matching Jboss access log format with service execution time 127.0.0.1 - - [13/Mar/2025:09:02:41 +0000] "GET /async/prediction/evaluation?limit=99999 HTTP/1.1" 200 51 "-" "Jersey/2.37 (HttpUrlConnection 11.0.22)" 651
+                $is_access_log = 1;
+                $status_code = $category_bucket;
+                $category_bucket =~ s/(\d)\d{2}/$1xx/;	# bucket HTTP status codes into their primary families
+                $timestamp_str =~ s/ \+\d{4}$//;	# chop off the timezone offset
+
+                $message =~ s/ HTTP\/\d\.\d$//;					# chop off the HTTP protocol and version
+                $message =~ s/\?.+$// unless $include_query_string;		# chop off the query string from the URI
+
             ## Apache Tomcat Access Log with Service Execution Time (%D), and optionally thread (%I) and session (%S) ##
             } elsif ( (undef, $timestamp_str, $message, $category_bucket, $bytes, $duration, $thread, $session) = $_ =~ /^([^ ]+ ){3}[\[]([^\]]+)[\]] "([^"]+)" (\d{3}) (\d+|-)[ ]?([0-9.]+)?[ ]?(\S+)?[ ]?(\S+)?/ ) {
                 $is_line_match = 1;
@@ -8143,19 +8160,7 @@ sub read_and_process_logs {
                 $timestamp_str =~ tr/T/ /;
                 $message =~ s/\s+$//g;
 
-            } elsif ( (undef, $timestamp_str, $message, $category_bucket, $bytes, undef, undef, $duration) = $_ =~ /^([^ ]+ ){3}[\[]([^\]]+)[\]] "([^"]+)" (\d{3}) (\d+) "([^"]+)" "([^"]+)" (\d+)$/ ) {
-            # access logs # 127.0.0.1 - - [13/Mar/2025:09:02:41 +0000] "GET /async/prediction/evaluation?limit=99999 HTTP/1.1" 200 51 "-" "Jersey/2.37 (HttpUrlConnection 11.0.22)" 651
-                $is_line_match = 1;
-                $match_type = 9;			# this is matching Jboss access log format with service execution time 127.0.0.1 - - [13/Mar/2025:09:02:41 +0000] "GET /async/prediction/evaluation?limit=99999 HTTP/1.1" 200 51 "-" "Jersey/2.37 (HttpUrlConnection 11.0.22)" 651
-                $is_access_log = 1;
-                $status_code = $category_bucket;
-                $category_bucket =~ s/(\d)\d{2}/$1xx/;	# bucket HTTP status codes into their primary families
-                $timestamp_str =~ s/ \+\d{4}$//;	# chop off the timezone offset
-
-                $message =~ s/ HTTP\/\d\.\d$//;					# chop off the HTTP protocol and version
-                $message =~ s/\?.+$// unless $include_query_string;		# chop off the query string from the URI
-
-            } elsif ( ( $category_bucket, $timestamp_str, $message ) = $_ =~ /^([^ ]+) (\d{4}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2}[,.]\d+) (.*)/ ) {  
+            } elsif ( ( $category_bucket, $timestamp_str, $message ) = $_ =~ /^([^ ]+) (\d{4}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2}[,.]\d+) (.*)/ ) {
                 $is_line_match = 1;
                 $match_type = 11;			# this is matching ThingWorx Edge C SDK format # FORCE 2025-08-09 18:27:18,40 8012 twx_connection.cpp:246 Run Error in the TWX processor thread, have to reinitialize. Error was [sdk_wrapper_->IsConnected() failed]
                 chop $message;

--- a/tests/validate-duration-display.sh
+++ b/tests/validate-duration-display.sh
@@ -238,6 +238,50 @@ run_no_duration_scenario() {
         contract    'docs/usage.md section Metric extraction - columns appear only for metrics detected in the data; issue #345'
 }
 
+# Enhanced/JBoss source: when the input is the enhanced access-log format
+# (quoted referrer, quoted user-agent, trailing duration — match_type 9), the
+# observed durations must activate the latency surfaces: timeline latency
+# column and the latency-column messages-table variant. This is the presence
+# mirror of run_no_duration_scenario: the format's duration sits after the
+# quoted fields, and a cascade-ordering regression that lets the broader
+# with-duration pattern claim these lines captures duration=undef and
+# silently deactivates every latency surface. Issue #365.
+run_jboss_duration_scenario() {
+    current_scenario="jboss-duration-w200"
+    echo "[$current_scenario]"
+
+    local fixture="$TMP_DIR/jboss-enhanced-access.txt"
+    awk '$(NF-1) ~ /^[0-9]+$/ {dur=$NF; $NF="\"-\" \"Jersey/2.37 (HttpUrlConnection 11.0.22)\" " dur; print}' "$ACCESS_LOG" > "$fixture"
+    if [[ ! -s "$fixture" ]]; then
+        echo "  FAIL  $current_scenario :: could not derive enhanced-format fixture from $ACCESS_LOG" >&2
+        fail=$((fail + 1)); failures+=("$current_scenario :: fixture derivation failed"); return 0
+    fi
+
+    local render="$TMP_DIR/render-jboss-duration.txt"
+    capture_render "$render" "$fixture" --terminal-width 200 || return 0
+
+    assert_command \
+        command     "grep -q 'TOP OVERALL MESSAGES' '$render' && grep -q 'occurrences' '$render'" \
+        label       "render contains the occurrences surfaces (anchor for the presence assertions)" \
+        asserts     'The enhanced-format source renders the timeline occurrences graph and the messages table; the presence assertions below are meaningful only if these anchor surfaces exist.' \
+        produced_by 'print_bar_graph() and print_summary_table() in ltl' \
+        contract    'tests/HARNESS-DESIGN.md section Harnesses must fail on missing anchors - a presence check over an empty render would fail for the wrong reason'
+
+    assert_command \
+        command     "grep -qE 'latency statistics|P50:' '$render'" \
+        label       "timeline latency column renders for the enhanced-format source (durations observed)" \
+        asserts     'A source whose every line carries a trailing duration (enhanced/JBoss access-log format, match_type 9) must render the timeline latency statistics column. If the broader with-duration pattern (match_type 3) claims these lines first, it captures duration=undef and no latency surface activates despite every line carrying a duration.' \
+        produced_by 'detection cascade in read_and_process_logs() (match_type 9 branch ordered before match_type 3) and build_column_layout() in ltl (show_latency gate on $durations_observed)' \
+        contract    'docs/usage.md section Metric extraction - columns appear only for metrics detected in the data; issue #365'
+
+    assert_command \
+        command     "grep 'TOP OVERALL MESSAGES' '$render' | grep -qE 'P99\\.9'" \
+        label       "messages table renders the latency-column variant (Min/P50/P99.9 captions present)" \
+        asserts     'The messages-table header for the enhanced-format source is the latency-column variant; the occurrences-only variant means the observed durations were lost during format detection.' \
+        produced_by 'print_summary_table() in ltl (messages-table variant gate on $durations_observed)' \
+        contract    'docs/usage.md section Metric extraction - columns appear only for metrics detected in the data; issue #365'
+}
+
 echo "Validating duration-statistic display invariants (Issue #292)"
 echo "Surfaces: timeline rows (P50/P95/P99/P999) + summary table (Min/P50/P99.9)"
 echo ""
@@ -264,6 +308,10 @@ echo ""
 
 # Absence invariants for a source with no duration values at all (issue #345).
 run_no_duration_scenario
+echo ""
+
+# Presence invariants for the enhanced/JBoss format's trailing duration (issue #365).
+run_jboss_duration_scenario
 echo ""
 
 echo "Results: $pass passed, $fail failed"

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -10,9 +10,11 @@
 #
 # Scope: slugs with fixtures under logs/ are asserted directly;
 # tomcat_access_common is asserted against a fixture derived on the fly
-# from the Tomcat 9 log (duration field stripped, issue #345). The
+# from the Tomcat 9 log (duration field stripped, issue #345), and
+# jboss_access against a fixture derived from the same log (quoted
+# referrer/user-agent + trailing duration appended, issue #365). The
 # remaining slugs (thingworx_rac_client, connection_server_json,
-# java_gc_log, tw_analytics_v2, tw_analytics_worker, jboss_access,
+# java_gc_log, tw_analytics_v2, tw_analytics_worker,
 # connection_server_standard) are out of scope until fixtures exist or
 # until the format-registry rewrite (#23) lands.
 #
@@ -194,6 +196,54 @@ scenario_tomcat_common() {
         contract    'Derived 1:1 from the hand-truncated 5000-line Tomcat 9 fixture; if that fixture changes, the expected count changes in the same commit'
 }
 
+scenario_jboss_enhanced() {
+    current_scenario="jboss-enhanced"
+    echo "[$current_scenario]"
+
+    # JBoss/Jersey enhanced access log format (%h %l %u %t "%r" %s %b
+    # "%{Referer}i" "%{User-Agent}i" %D). Derived on the fly from the canonical
+    # Tomcat 9 fixture by rewriting the trailing %D field into quoted referrer +
+    # quoted user-agent + duration, so the scenarios cannot drift apart and no
+    # near-duplicate corpus file is needed. Lines with "-" bytes are excluded:
+    # the match_type 9 regex requires numeric bytes, and such lines fall through
+    # to match_type 3 by design. Issue #365.
+    local src="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+    local log="$TMP_DIR/jboss-enhanced-access.txt"
+    awk '$(NF-1) ~ /^[0-9]+$/ {dur=$NF; $NF="\"-\" \"Jersey/2.37 (HttpUrlConnection 11.0.22)\" " dur; print}' "$src" > "$log"
+    if [[ ! -s "$log" ]]; then
+        echo "FAIL: could not derive enhanced-format fixture from $src" >&2
+        exit 1
+    fi
+    local expected_lines
+    expected_lines=$(wc -l < "$log" | tr -d ' ')
+    if [[ -z "$expected_lines" || "$expected_lines" -eq 0 ]]; then
+        echo "FAIL: derived enhanced-format fixture is empty" >&2
+        exit 1
+    fi
+
+    local out
+    out=$(run_format_detection "$log")
+    check_capture_warnings "$out"
+
+    assert_line "$out" \
+        pattern     '^  format: jboss_access$' \
+        asserts     'An enhanced/JBoss access log (quoted referrer, quoted user-agent, trailing duration) binds to slug `jboss_access`, not to `tomcat_access_with_duration`. The end-anchored match_type 9 regex is ordered before the broader match_type 3 regex, whose all-optional tail would otherwise claim these lines with duration=undef and junk thread/session captures (issue #365).' \
+        produced_by 'emit_format_detection_verbose() in ltl; detection cascade in read_and_process_logs() (match_type 9 branch, `$`-anchored after the trailing duration field)' \
+        contract    '%match_type_to_slug in ltl GLOBALS - slug names are locked; renames are breaking under HARNESS-DESIGN.md section Stability contract'
+
+    assert_line "$out" \
+        pattern     '^  match_type: 9$' \
+        asserts     'Enhanced/JBoss access log binds to internal match_type 9' \
+        produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
+        contract    'features/225-test-harness-coverage-gaps.md section #228 - match_type integers are an implementation detail surfaced for diagnostic value; the slug is the user-facing contract'
+
+    assert_line "$out" \
+        pattern     "^  matched_lines: $expected_lines\$" \
+        asserts     'Every line of the derived enhanced-format fixture parses as match_type 9 (no fallthroughs to match_type 3 or other branches)' \
+        produced_by 'emit_format_detection_verbose() in ltl (per-file matched_lines field)' \
+        contract    'Derived from the hand-truncated Tomcat 9 fixture (numeric-bytes lines only); the expected count is computed from the derived file so the assertion tracks the fixture'
+}
+
 scenario_apache_httpd_us() {
     current_scenario="apache-httpd-us"
     echo "[$current_scenario]"
@@ -344,6 +394,7 @@ echo ""
 
 scenario_tomcat9_ms;            echo ""
 scenario_tomcat_common;         echo ""
+scenario_jboss_enhanced;        echo ""
 scenario_apache_httpd_us;       echo ""
 scenario_codebeamer;            echo ""
 scenario_thingworx_standard;    echo ""


### PR DESCRIPTION
Fixes #365 (enhanced/JBoss access-log lines claimed by match_type 3 with duration=undef — duration silently lost).

## Fix

- `64580c6` — move the match_type 9 `elsif` block immediately before match_type 3 in `read_and_process_logs()`; access-log family order is now **12 → 4 → 9 → 3**. Same reorder remedy as #345. match_type 9 is end-anchored and strictly more specific, so it cannot claim genuine match_type 3 lines; the #358 deterministic `([^ ]+ ){3}` prefix is preserved.
- `9675123` — regression scenarios, both proven to fail against the pre-fix binary: `scenario_jboss_enhanced` (format-detection: `jboss_access` / match_type 9 / full matched-line count) and `run_jboss_duration_scenario` (duration-display: latency surfaces must render for the enhanced format).
- `4cb55e2` — cascade order + measured cost recorded in `features/358-read-files-regression-format-cascade.md`.

## Verification

- Pre-fix reproduction: derived enhanced-format fixture classified match_type 3, zero latency surfaces. Post-fix: `jboss_access` / match_type 9, all lines matched, latency statistics present, stderr runtime-warning-clean.
- Output byte-identical on unaffected corpora (5k Tomcat sample, Apache HTTP2 Windchill log).
- `validate-format-detection.sh` 22/22; `validate-duration-display.sh` 21/21.
- Performance (57 MB probe, median of 3): read_files 4.005 s → 4.326 s (**+1.2 µs/line**) — one extra cheap failed anchored attempt per with-duration line, same accepted-residual class as match_type 4's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpk5FTT2XQKtjsfEajEwzt