### PR TITLE
Issue lifecycle status tracking via mutually-exclusive status labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,12 +139,12 @@ When a feature/bugfix branch lands via PR into the release branch, complete the 
 
 1. Commit all changes to feature branch
 2. Push feature branch: `git push origin {feature-branch}`
-3. Create PR into the active release branch: `gh pr create --base release/X.Y.Z --head {feature-branch}`
+3. Create PR into the active release branch: `gh pr create --base release/X.Y.Z --head {feature-branch}`, then immediately `./build/issue-status.sh set {number} "in review"`
 4. Merge the PR: `gh pr merge {PR#} --merge`
 5. Verify the release branch picked up the merge: `git log origin/release/X.Y.Z --oneline -3`
 6. Update `releases/v{version}.md` directly on the release branch: add ONE bullet per merged issue with `(#NNN)` reference. No prose, no metacommentary. Commit + push directly to the release branch (this is the canonical exception to "no direct commits" — release-notes maintenance is release-process work, not issue work).
 7. Add a completion comment to the GitHub issue: commit hash, branch name, PR #, merge commit, summary of what shipped.
-8. Close the issue: `gh issue close {number} --reason completed`. The issue is addressed when it makes it into a release branch — it does not need to wait for the release to ship.
+8. Close the issue: `gh issue close {number} --reason completed`. The issue is addressed when it makes it into a release branch — it does not need to wait for the release to ship. Closing removes the issue from status tracking: strip its status label in the same step with `gh issue edit {number} --remove-label "status: in review"` (`./build/issue-status.sh sweep` is the repair path if one is missed).
 
 ### Cutting the release
 
@@ -211,6 +211,21 @@ Hidden CLI options: `--disable-progress` (ALWAYS use from Claude Code), `--termi
 
 ## Development Workflow
 
+### Named Branch Sync (MANDATORY FIRST STEP)
+
+**When the architect names a branch, that branch is checked out and synced from origin before any other action** — before reading a file, before answering a question about its contents, before planning against it. Not "eventually", not "when we start editing": first.
+
+```bash
+git fetch origin --prune
+git checkout {branch} 2>/dev/null || git checkout -b {branch} origin/{branch}   # local branch may not exist yet
+git pull --ff-only origin {branch}
+git branch --show-current   # confirm; then confirm the tree is clean with git status
+```
+
+Never read, plan, or work from a stale local copy, and never from a different branch than the one named. A branch that exists only on origin is the common case after time away — `git checkout -b {branch} origin/{branch}` creates the tracking branch. If the working tree is dirty or the pull is not a fast-forward, stop and raise it rather than improvising a merge.
+
+Why: reasoning from the wrong branch produces conclusions that are confidently wrong. Every file read, every line number, every "the code currently does X" is silently false, and the error is invisible until it has propagated through a plan.
+
 ### Branch Naming (MANDATORY)
 
 Each issue gets its own branch named `{issue-number}-{semantic-slug-from-issue-title}`. The slug MUST be derived from the GitHub issue's title (kebab-cased, semantically tight) — **never** from the activity being performed on the branch.
@@ -231,7 +246,8 @@ If multiple branches are genuinely needed for one issue (rare), differentiate wi
 
 ### Branch Verification (MANDATORY FIRST STEP)
 ```bash
-git branch --show-current  # Must start with the issue number AND match the issue's semantic title
+git branch --show-current                          # Must start with the issue number AND match the issue's semantic title
+./build/issue-status.sh set {number} "in progress"  # Before the first line of code
 ```
 
 **CRITICAL:** Verify branch before making code changes. Do not write production code until implementation plan is approved.
@@ -240,6 +256,31 @@ git branch --show-current  # Must start with the issue number AND match the issu
 Update issues throughout development: when starting, during investigation, on design decisions, and when complete. Close with `gh issue close <number> --reason completed`.
 
 The **`not planned` label** marks an **open** issue retained as a decision/spec record (e.g. #370, temporal interpolation): the capability is specified for the record but not planned for implementation. Do not close such issues — "label as not planned" and "close as not planned" are different dispositions.
+
+### Issue Status (MANDATORY)
+
+Every **open** issue carries exactly one `status:` label recording where it sits in the development flow. Closed issues carry **none** — their terminal state is native (closed as completed, or closed as not planned).
+
+| Label | Meaning |
+|---|---|
+| `status: backlog` | Accepted and understood; no work underway. The state anything filed lands in. |
+| `status: in progress` | Branch cut, work underway. Set **before** the first line of code. |
+| `status: in review` | PR open against the release branch. |
+| `status: on hold` | Deliberately paused by the architect — nothing external is stopping it. |
+
+**Status is updated at the moment the state changes — never batched, never deferred to a tidy-up pass.** A status that is correct only in retrospect is worse than none: it reports work as idle while it is running, or as running after it has stopped. The transitions are already embedded in the steps that cause them (Branch Verification sets `in progress`; per-feature workflow step 3 sets `in review`; step 8 strips the label on close) — there is no separate moment at which status gets "brought up to date."
+
+`build/issue-status.sh` is the **only** sanctioned writer. Labels are a set, not an enum, so mutual exclusion is enforced by the script rather than by memory: `set` swaps the old label for the new in a single call, so an issue is never transiently statusless or double-statused.
+
+```bash
+./build/issue-status.sh set {number} "in progress"   # Set status (accepts bare name or full label)
+./build/issue-status.sh show {number}                # One issue's status
+./build/issue-status.sh list                         # All open issues with status
+./build/issue-status.sh sweep                        # Repair drift: strip status from closed issues,
+                                                     # report open issues with none or with several
+```
+
+Status is orthogonal to blocking. An issue can be `blocked_by` an open issue **and** be `in progress` at the same time — blocking is tracked exclusively through native dependencies (see *Issue Blocking Relationships* below) and is never expressed as a status. `not planned` is likewise orthogonal: it is a *reason*, not a state — #370 (temporal interpolation, spec'd as a decision record) is `status: backlog` and carries `not planned` to explain why it stays there.
 
 ### Issue Blocking Relationships (MANDATORY)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,9 +266,21 @@ Every **open** issue carries exactly one `status:` label recording where it sits
 | `status: backlog` | Accepted and understood; no work underway. The state anything filed lands in. |
 | `status: in progress` | Branch cut, work underway. Set **before** the first line of code. |
 | `status: in review` | PR open against the release branch. |
-| `status: on hold` | Deliberately paused by the architect — nothing external is stopping it. |
+| `status: on hold` | Deliberately paused by an explicit decision. Says nothing about whether work has started. |
 
 **Status is updated at the moment the state changes — never batched, never deferred to a tidy-up pass.** A status that is correct only in retrospect is worse than none: it reports work as idle while it is running, or as running after it has stopped. The transitions are already embedded in the steps that cause them (Branch Verification sets `in progress`; per-feature workflow step 3 sets `in review`; step 8 strips the label on close) — there is no separate moment at which status gets "brought up to date."
+
+**Status is a deliberate decision, never a computed value.** Whoever moves an issue chooses its status and is accountable for it. There is no rule that derives status automatically, and none should be added: the reasons an issue is where it is — an architect deferred it, an approach was rejected pending redesign, work was folded into a broader effort — live in comments, closed issues and PRs, and feature docs, where no mechanical signal can see them. A status that a tool recalculated is a status nobody decided.
+
+Consequences:
+
+- **A recorded status stands until another deliberate decision changes it.** A general convention stated later does not reach back and overwrite a specific call already made on an issue.
+- **`build/issue-status.sh sweep` proposes, it never applies.** Its advisory pass reads the mechanical signals — an open PR, a live branch, an open `blocked_by` dependency — and prints a proposed status *with the reasoning that produced it*, for a human to accept or reject. It speaks only where a status is missing or is the weakest one (`backlog`); it leaves `on hold` and `in progress` alone, because both record a judgement no signal can second-guess. The only thing it changes on its own is stripping status from closed issues, where there is exactly one correct answer.
+- **When a status change is not self-evident from the issue thread, comment the reasoning and where the decision lives.** #209 (benchmark TSV absolute paths) sat unexplained because its governing decision was in the closing comment of a *closed* PR — invisible from the open issue. A status whose justification cannot be found from the issue is a status that will be re-litigated or silently reverted.
+
+**`on hold` is about a decision, not about progress.** It records that someone deliberately paused the issue — deferred it, folded it into other work, rejected the proposed approach pending a redesign. It carries no implication either way about whether work has started: an issue can be paused before anything begins, or after a branch has been merged. What distinguishes `on hold` from `backlog` is the existence of an explicit decision to stop, not the amount of work behind it. Where that decision lives — a comment, a closed issue or PR, a feature-doc section — is recorded on the issue so it stays discoverable from the open thread.
+
+**Parent issues follow the same rule, evaluated over themselves *and* their children.** A parent (umbrella) issue is ordinary — it can have its own branch and its own commits, and often does. It is `in progress` once work has started either on the parent itself or on any child issue beneath it. Closing a child does not move the parent back: the parent stays `in progress` until it is closed, or until it is deliberately moved to `on hold`. A parent with no work started anywhere in its tree is `backlog` like anything else.
 
 `build/issue-status.sh` is the **only** sanctioned writer. Labels are a set, not an enum, so mutual exclusion is enforced by the script rather than by memory: `set` swaps the old label for the new in a single call, so an issue is never transiently statusless or double-statused.
 

--- a/build/issue-status.sh
+++ b/build/issue-status.sh
@@ -68,7 +68,8 @@ issue_status_labels() {
 
 cmd_set() {
     [ $# -eq 2 ] || usage
-    local issue="$1" label state current remove_args=() existing
+    local issue="$1" label state current existing
+    local -a remove_args=()
 
     label="$(resolve_status_label "$2")"
 
@@ -92,7 +93,7 @@ cmd_set() {
         remove_args+=(--remove-label "$existing")
     done <<< "$current"
 
-    gh issue edit "$issue" --add-label "$label" "${remove_args[@]}" >/dev/null
+    gh issue edit "$issue" --add-label "$label" ${remove_args[@]+"${remove_args[@]}"} >/dev/null
     echo "[ok] #$issue -> '$label'${current:+ (was: $(printf '%s' "$current" | paste -sd, -))}"
 }
 
@@ -120,7 +121,8 @@ cmd_list() {
 
 cmd_sweep() {
     [ $# -eq 0 ] || usage
-    local stripped=0 missing=0 multiple=0 number labels label remove_args
+    local stripped=0 missing=0 multiple=0 number labels label
+    local -a remove_args
 
     # Closed issues must carry no status label — strip whatever is there.
     while IFS=$'\t' read -r number labels; do
@@ -130,7 +132,7 @@ cmd_sweep() {
             [ -n "$label" ] || continue
             remove_args+=(--remove-label "$label")
         done <<< "$(printf '%s' "$labels" | tr ',' '\n')"
-        gh issue edit "$number" "${remove_args[@]}" >/dev/null
+        gh issue edit "$number" ${remove_args[@]+"${remove_args[@]}"} >/dev/null
         echo "[fixed] #$number closed — stripped: $labels"
         stripped=$((stripped + 1))
     done < <(gh issue list --state closed --limit 500 --json number,labels \

--- a/build/issue-status.sh
+++ b/build/issue-status.sh
@@ -13,7 +13,7 @@
 #   ./build/issue-status.sh set <issue> <status>   set status (swaps in one call)
 #   ./build/issue-status.sh show <issue>           print one issue's status
 #   ./build/issue-status.sh list                   list open issues with status
-#   ./build/issue-status.sh sweep                  report and repair drift
+#   ./build/issue-status.sh sweep                  integrity check + advisory proposals
 
 set -euo pipefail
 
@@ -33,8 +33,10 @@ Usage: ./build/issue-status.sh <command> [args]
                          ("status: in review").
   show <issue>           Print one issue's current status.
   list                   List open issues with their status.
-  sweep                  Strip status labels from closed issues; report open
-                         issues carrying none or more than one.
+  sweep                  Integrity + advisory pass. Strips status from closed issues,
+                         reports open issues carrying several, and proposes a status
+                         (with reasoning) where one is missing or looks understated.
+                         Proposals are printed, never applied.
 USAGE
     exit 1
 }
@@ -121,10 +123,10 @@ cmd_list() {
 
 cmd_sweep() {
     [ $# -eq 0 ] || usage
-    local stripped=0 missing=0 multiple=0 number labels label
+    local stripped=0 multiple=0 proposed=0 number labels label
     local -a remove_args
 
-    # Closed issues must carry no status label — strip whatever is there.
+    # --- Integrity: closed issues carry no status. One correct answer, so fix it. ---
     while IFS=$'\t' read -r number labels; do
         [ -n "$number" ] || continue
         remove_args=()
@@ -139,22 +141,85 @@ cmd_sweep() {
         --jq "[.[] | {number, s: [.labels[].name | select(startswith(\"$LABEL_PREFIX\"))]} | select(.s | length > 0)]
               | .[] | [.number, (.s | join(\",\"))] | @tsv")
 
-    # Open issues must carry exactly one. Report, never guess.
+    # --- Integrity: exactly one status per open issue. Which one is a judgement call. ---
     while IFS=$'\t' read -r number labels; do
         [ -n "$number" ] || continue
-        if [ -z "$labels" ]; then
-            echo "[warn] #$number open with no status — set one with: ./build/issue-status.sh set $number <status>"
-            missing=$((missing + 1))
-        else
-            echo "[warn] #$number open with multiple statuses ($labels) — resolve with: ./build/issue-status.sh set $number <status>"
-            multiple=$((multiple + 1))
-        fi
+        echo "[conflict] #$number carries several statuses ($labels) — pick one:"
+        echo "           ./build/issue-status.sh set $number <status>"
+        multiple=$((multiple + 1))
     done < <(gh issue list --state open --limit 500 --json number,labels \
-        --jq "[.[] | {number, s: [.labels[].name | select(startswith(\"$LABEL_PREFIX\"))]} | select(.s | length != 1)]
+        --jq "[.[] | {number, s: [.labels[].name | select(startswith(\"$LABEL_PREFIX\"))]} | select(.s | length > 1)]
               | .[] | [.number, (.s | join(\",\"))] | @tsv")
 
-    echo "[ok] sweep complete — $stripped closed issue(s) stripped, $missing open without status, $multiple open with multiple"
-    [ "$missing" -eq 0 ] && [ "$multiple" -eq 0 ]
+    # --- Advisory: propose, never apply. ---
+    #
+    # Status is a deliberate decision. These signals cannot see the decisions that
+    # live in comments, closed PRs and feature docs, so they never overrule a
+    # recorded status — they only speak where the state is absent or is the weakest
+    # one (`backlog`), and where a mechanical signal says otherwise. `on hold` and
+    # `in progress` are left alone: both record a judgement no signal can second-guess.
+    local branches prs current proposal reason
+    branches="$(git branch -a --format='%(refname:short)' 2>/dev/null | sed 's|^origin/||' | sort -u)"
+    prs="$(gh pr list --state open --limit 200 --json number,headRefName,body \
+           --jq '.[] | [.number, .headRefName, (.body // "" | gsub("\n"; " "))] | @tsv' 2>/dev/null)"
+
+    while IFS=$'\t' read -r number current; do
+        [ -n "$number" ] || continue
+        [ "$current" = "on hold" ] && continue
+        [ "$current" = "in progress" ] && continue
+
+        proposal=""; reason=""
+
+        # An open PR for the issue is unambiguous and outranks the rest.
+        local pr_num
+        pr_num="$(printf '%s\n' "$prs" | awk -F'\t' -v n="$number" \
+            '$2 ~ "^"n"-" || $3 ~ ("#"n"([^0-9]|$)") { print $1; exit }')"
+        if [ -n "$pr_num" ] && [ "$current" != "in review" ]; then
+            proposal="in review"
+            reason="PR #$pr_num is open for this issue"
+        fi
+
+        # A live branch means work is underway now.
+        if [ -z "$proposal" ]; then
+            local branch
+            branch="$(printf '%s\n' "$branches" | grep -E "^${number}-" | head -1 || true)"
+            if [ -n "$branch" ]; then
+                proposal="in progress"
+                reason="branch '$branch' exists — work is underway"
+            fi
+        fi
+
+        # A recorded dependency means the issue was planned for delivery and picked
+        # up out of the backlog; it is waiting for the blocker, not queued unstarted.
+        if [ -z "$proposal" ]; then
+            local blockers
+            blockers="$(gh api "repos/{owner}/{repo}/issues/$number/dependencies/blocked_by" \
+                --jq '[.[] | select(.state=="open") | "#\(.number)"] | join(", ")' 2>/dev/null || true)"
+            if [ -n "$blockers" ]; then
+                proposal="on hold"
+                reason="blocked by $blockers (open) — a recorded dependency means delivery was planned and the issue picked up"
+            fi
+        fi
+
+        # Nothing else to go on.
+        if [ -z "$proposal" ] && [ -z "$current" ]; then
+            proposal="backlog"
+            reason="no open blocker, no branch, no open PR — nothing indicates work started or planned"
+        fi
+
+        if [ -n "$proposal" ]; then
+            echo "[propose] #$number  ${current:-(no status)} -> $proposal"
+            echo "          why:   $reason"
+            echo "          apply: ./build/issue-status.sh set $number \"$proposal\""
+            proposed=$((proposed + 1))
+        fi
+    done < <(gh issue list --state open --limit 500 --json number,labels \
+        --jq "[.[] | {number, s: [.labels[].name | select(startswith(\"$LABEL_PREFIX\")) | ltrimstr(\"$LABEL_PREFIX\")]} | select(.s | length <= 1)]
+              | .[] | [.number, (.s | join(\"\"))] | @tsv")
+
+    echo "[ok] sweep complete — $stripped closed stripped, $multiple conflicting, $proposed proposal(s) for review"
+    echo "     Proposals are advisory. Status is a deliberate decision; nothing above was applied."
+    [ "$multiple" -eq 0 ]
 }
 
 main() {

--- a/build/issue-status.sh
+++ b/build/issue-status.sh
@@ -165,16 +165,20 @@ cmd_sweep() {
 
     while IFS=$'\t' read -r number current; do
         [ -n "$number" ] || continue
-        [ "$current" = "on hold" ] && continue
-        [ "$current" = "in progress" ] && continue
+        # Only the absent and the weakest state invite a proposal. Every other
+        # status records a judgement no mechanical signal can second-guess.
+        case "$current" in
+            ""|backlog) ;;
+            *) continue ;;
+        esac
 
         proposal=""; reason=""
 
         # An open PR for the issue is unambiguous and outranks the rest.
         local pr_num
         pr_num="$(printf '%s\n' "$prs" | awk -F'\t' -v n="$number" \
-            '$2 ~ "^"n"-" || $3 ~ ("#"n"([^0-9]|$)") { print $1; exit }')"
-        if [ -n "$pr_num" ] && [ "$current" != "in review" ]; then
+            '$2 ~ "^"n"-" || tolower($3) ~ ("(close[sd]?|fix(e[sd])?|resolve[sd]?)[ ]*#"n"([^0-9]|$)") { print $1; exit }')"
+        if [ -n "$pr_num" ]; then
             proposal="in review"
             reason="PR #$pr_num is open for this issue"
         fi

--- a/build/issue-status.sh
+++ b/build/issue-status.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Issue lifecycle status: the single writer for the "status: *" label set.
+#
+# Status is tracked ONLY through these labels, and ONLY on open issues. Exactly
+# one status label may be present at a time; this script is what makes that true.
+# Closed issues carry no status label — their terminal state is native
+# (closed as completed / closed as not planned).
+#
+# Blocking is a separate axis, tracked through GitHub's native blocked_by
+# dependencies. This script neither reads nor reports it.
+#
+# Usage:
+#   ./build/issue-status.sh set <issue> <status>   set status (swaps in one call)
+#   ./build/issue-status.sh show <issue>           print one issue's status
+#   ./build/issue-status.sh list                   list open issues with status
+#   ./build/issue-status.sh sweep                  report and repair drift
+
+set -euo pipefail
+
+# The vocabulary. Order is the lifecycle order; "on hold" is the deliberate pause.
+STATUSES=("backlog" "in progress" "in review" "on hold")
+
+LABEL_PREFIX="status: "
+
+die() { echo "[error] $*" >&2; exit 1; }
+
+usage() {
+    cat >&2 <<USAGE
+Usage: ./build/issue-status.sh <command> [args]
+
+  set <issue> <status>   Set an open issue's status. Valid: ${STATUSES[*]/#/}
+                         Accepts the bare name ("in review") or the full label
+                         ("status: in review").
+  show <issue>           Print one issue's current status.
+  list                   List open issues with their status.
+  sweep                  Strip status labels from closed issues; report open
+                         issues carrying none or more than one.
+USAGE
+    exit 1
+}
+
+# Single resolution surface for status operands: normalises whatever the caller
+# typed into the canonical label name, or fails. Every command routes through
+# this — the vocabulary is never restated elsewhere.
+resolve_status_label() {
+    local operand="$1" candidate
+    operand="${operand#"$LABEL_PREFIX"}"
+    operand="$(printf '%s' "$operand" | tr '[:upper:]' '[:lower:]')"
+    for candidate in "${STATUSES[@]}"; do
+        if [ "$operand" = "$candidate" ]; then
+            printf '%s%s' "$LABEL_PREFIX" "$candidate"
+            return 0
+        fi
+    done
+    die "unknown status '$1' — valid statuses are: $(printf '%s, ' "${STATUSES[@]}" | sed 's/, $//')"
+}
+
+require_repo_root() {
+    [ -f ltl ] && [ -d build ] || die "run from the repository root"
+    command -v gh >/dev/null 2>&1 || die "gh CLI not found on PATH"
+}
+
+# Echoes the issue's status labels, one per line (empty output = none).
+issue_status_labels() {
+    gh issue view "$1" --json labels \
+        --jq "[.labels[].name | select(startswith(\"$LABEL_PREFIX\"))] | .[]"
+}
+
+cmd_set() {
+    [ $# -eq 2 ] || usage
+    local issue="$1" label state current remove_args=() existing
+
+    label="$(resolve_status_label "$2")"
+
+    state="$(gh issue view "$issue" --json state --jq '.state')" \
+        || die "issue #$issue not found"
+    if [ "$state" != "OPEN" ]; then
+        die "issue #$issue is $state — status is tracked on open issues only; its terminal state is the close reason"
+    fi
+
+    current="$(issue_status_labels "$issue")"
+    if [ "$current" = "$label" ]; then
+        echo "[ok] #$issue already '$label'"
+        return 0
+    fi
+
+    # Every other status label is removed in the SAME call that adds the new one,
+    # so the issue is never transiently statusless or double-statused.
+    while IFS= read -r existing; do
+        [ -n "$existing" ] || continue
+        [ "$existing" = "$label" ] && continue
+        remove_args+=(--remove-label "$existing")
+    done <<< "$current"
+
+    gh issue edit "$issue" --add-label "$label" "${remove_args[@]}" >/dev/null
+    echo "[ok] #$issue -> '$label'${current:+ (was: $(printf '%s' "$current" | paste -sd, -))}"
+}
+
+cmd_show() {
+    [ $# -eq 1 ] || usage
+    local current
+    current="$(issue_status_labels "$1")" || die "issue #$1 not found"
+    if [ -z "$current" ]; then
+        echo "#$1: (no status)"
+    else
+        printf '#%s: %s\n' "$1" "$(printf '%s' "$current" | paste -sd', ' -)"
+    fi
+}
+
+cmd_list() {
+    [ $# -eq 0 ] || usage
+    gh issue list --state open --limit 200 --json number,title,labels \
+        --jq "sort_by(.number) | reverse | .[]
+              | [.number,
+                 ([.labels[].name | select(startswith(\"$LABEL_PREFIX\")) | ltrimstr(\"$LABEL_PREFIX\")] | join(\",\") | if . == \"\" then \"(none)\" else . end),
+                 (.title[0:64])]
+              | @tsv" \
+        | awk -F'\t' '{ printf "%-6s %-14s %s\n", "#"$1, $2, $3 }'
+}
+
+cmd_sweep() {
+    [ $# -eq 0 ] || usage
+    local stripped=0 missing=0 multiple=0 number labels label remove_args
+
+    # Closed issues must carry no status label — strip whatever is there.
+    while IFS=$'\t' read -r number labels; do
+        [ -n "$number" ] || continue
+        remove_args=()
+        while IFS= read -r label; do
+            [ -n "$label" ] || continue
+            remove_args+=(--remove-label "$label")
+        done <<< "$(printf '%s' "$labels" | tr ',' '\n')"
+        gh issue edit "$number" "${remove_args[@]}" >/dev/null
+        echo "[fixed] #$number closed — stripped: $labels"
+        stripped=$((stripped + 1))
+    done < <(gh issue list --state closed --limit 500 --json number,labels \
+        --jq "[.[] | {number, s: [.labels[].name | select(startswith(\"$LABEL_PREFIX\"))]} | select(.s | length > 0)]
+              | .[] | [.number, (.s | join(\",\"))] | @tsv")
+
+    # Open issues must carry exactly one. Report, never guess.
+    while IFS=$'\t' read -r number labels; do
+        [ -n "$number" ] || continue
+        if [ -z "$labels" ]; then
+            echo "[warn] #$number open with no status — set one with: ./build/issue-status.sh set $number <status>"
+            missing=$((missing + 1))
+        else
+            echo "[warn] #$number open with multiple statuses ($labels) — resolve with: ./build/issue-status.sh set $number <status>"
+            multiple=$((multiple + 1))
+        fi
+    done < <(gh issue list --state open --limit 500 --json number,labels \
+        --jq "[.[] | {number, s: [.labels[].name | select(startswith(\"$LABEL_PREFIX\"))]} | select(.s | length != 1)]
+              | .[] | [.number, (.s | join(\",\"))] | @tsv")
+
+    echo "[ok] sweep complete — $stripped closed issue(s) stripped, $missing open without status, $multiple open with multiple"
+    [ "$missing" -eq 0 ] && [ "$multiple" -eq 0 ]
+}
+
+main() {
+    [ $# -ge 1 ] || usage
+    require_repo_root
+    local command="$1"; shift
+    case "$command" in
+        set)   cmd_set   "$@" ;;
+        show)  cmd_show  "$@" ;;
+        list)  cmd_list  "$@" ;;
+        sweep) cmd_sweep "$@" ;;
+        *)     usage ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Closes #373.

## What this adds

Open issues now carry exactly one `status:` label — `backlog`, `in progress`, `in review`, `on hold`. Closed issues carry none; their terminal state stays native (closed as completed / not planned). Blocking remains a separate axis on native `blocked_by` dependencies and is not restated as a status.

### `build/issue-status.sh`

The only sanctioned writer.

- `set <issue> <status>` — resolves the operand through one function (accepts `in review` or `status: in review`, any case), refuses closed issues, and swaps old label for new in a single `gh issue edit` so an issue is never transiently statusless or double-statused.
- `sweep` — two passes. **Integrity:** strips status from closed issues (one correct answer), reports open issues carrying several. **Advisory:** reads the mechanical signals — open PR, live branch, open `blocked_by` — and prints a proposed status *with the reasoning that produced it*, applying nothing.
- `show <issue>` / `list`.

### CLAUDE.md

**The governing model:** status is a deliberate decision, never a computed value. The reasons an issue sits where it does — a deferral, a rejected approach, work folded into a broader effort — live in comments, closed PRs and feature docs, where no mechanical signal can see them. A recorded status stands until another deliberate decision changes it; a convention stated later does not reach back over a specific call already made. `sweep` therefore proposes and never applies, and speaks only where a status is missing or is the weakest one (`backlog`) — `on hold` and `in progress` record judgements no signal can second-guess.

**Transitions live inside the mandatory steps that already cause them**, not in a new free-floating obligation: § *Branch Verification* sets `in progress` before the first line of code, per-feature workflow step 3 sets `in review` at PR creation, step 8 strips the label on close. Status updates at the moment the state changes — never batched, never deferred to a tidy-up.

**Supporting rules recorded:** the parent-issue rule (a parent is `in progress` once work starts on itself or any child, and stays there until closed or deliberately parked); `on hold` semantics (an explicit decision to pause, saying nothing about whether work started); and the requirement to comment the reasoning and its location when a status change is not evident from the issue thread.

**§ Named Branch Sync (MANDATORY FIRST STEP)** — when the architect names a branch it is fetched and checked out before any other action. Reasoning from a stale or wrong branch produces confidently wrong conclusions, and the error stays invisible until it has propagated through a plan.

## Backfill

All 41 open issues were given a status from evidence — issue comments, feature docs, and branch/commit history — rather than from titles or labels. Result: **21 backlog, 18 on hold, 2 in progress**.

Every non-obvious call was put to the architect individually rather than decided here. Notably #209 (benchmark TSV absolute paths) looked abandoned from its own thread; the governing decision was in the closing comment of the closed PR #211 — work completed, then deliberately deferred because the real fix is production code in `ltl` and should ride a release cycle. That decision and its location are now commented onto #209, with a note that no `blocked_by` is recorded because both related items are closed and a closed issue is not a block.

## Verification

- `bash -n` clean; round-trip through all four values; idempotent re-set; unknown status and closed issue both rejected.
- Drift seeded deliberately (a status label on closed #347, a second on #373) — integrity pass stripped the first and reported the second.
- Advisory pass exercised on the missing-status path (#5) and the `blocked_by` path (#58, #60, both since accepted by the architect).
- Final state: 0 conflicts, 0 outstanding proposals, no closed issue carrying a status label.

One bug surfaced and fixed during the backfill: macOS ships bash 3.2, where `"${arr[@]}"` on an empty array is an unbound-variable error under `set -u` — the exact path every first-time status assignment takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157Kjz4zwLrbwKVweNZtZXJ
