### PR TITLE
Input paths containing spaces open correctly: bsd_glob replaces csh glob (#379)

### DIFF
--- a/ltl
+++ b/ltl
@@ -30,6 +30,7 @@ use Devel::Size qw(total_size);
 # On Windows, Win32::API calls K32GetProcessMemoryInfo directly (kernel32.dll)
 use List::Util qw(min max);
 use Cwd qw(abs_path);
+use File::Glob qw(bsd_glob);
 use File::Spec;
 use Text::CSV;
 use Text::CSV_PP;
@@ -7605,7 +7606,7 @@ sub adapt_to_command_line_options {
     # $explain_arg, and $print_version are populated here but no longer read.
 
     foreach my $pattern (@ARGV) {									# do in process file globbing for common experience across environments (Windows doesn't glob in the shell, passes in the parameters)
-        push @in_files, glob($pattern);
+        push @in_files, bsd_glob($pattern);						    # bsd_glob: wildcard/brace/tilde expansion without treating whitespace as a pattern separator, so paths containing spaces survive as one candidate
     }
 
 	@in_files = grep { -f $_ } @in_files;								# only accept files in list to be read (remove anything else in the globbed directory list)


### PR DESCRIPTION
Fixes #379.

## What

`adapt_to_command_line_options()`'s in-process wildcard expansion (`push @in_files, glob($pattern)`) used Perl's csh-style `glob()`, which splits patterns on whitespace — any path containing a space (routine on macOS `/Volumes/My Shared Files/...` and Windows `C:\Program Files\...`, the very platforms the in-process globbing serves) shattered into never-matching fragments and ltl exited 2 with `unable to open any files`. Replaced with `File::Glob::bsd_glob()`: same wildcard/brace/tilde expansion, whitespace taken literally.

## Verification

- Spaced literal path opens (previously exit 2); spaced path **with wildcard** expands and opens (the metachar-gating alternative fix could not handle this case, which drove the choice).
- Expansion parity with the old `glob()` confirmed on wildcard and brace patterns over space-free paths (identical result lists); no-match behavior unchanged (`unable to open any files`, exit 2 — the `runtime-config` negative test still asserts it).
- Full `tests/validate-*.sh` suite run **from the spaced mount itself**: 19/21 green (up from 11/21 before the fix), zero glob-class failures. The two residuals are pre-existing environmental modes unrelated to this change: `index-read-back`'s shared-mount stat race (passes on local disk with this exact `ltl`) and `regression`'s file-legend diffs against references captured at the repo's previous location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)