### PR TITLE
Widen G1 GC format to cause-less pause and event forms (#382)

### DIFF
--- a/features/382-gc-log-g1-format-coverage.md
+++ b/features/382-gc-log-g1-format-coverage.md
@@ -1,0 +1,201 @@
+# Feature: G1 GC log format coverage (Issue #382)
+
+## Status
+
+Implemented on `382-gc-log-format-misses-pause-remark-cleanup`, targeting release 0.17.0.
+
+## Overview
+
+The Java GC registry entry (`mt6`) recognized only one shape: a pause name
+followed by a parenthesized cause clause, a heap transition, and a duration.
+G1 writes several pause and event forms that do not carry a cause clause, and
+those lines never matched — their pause durations and heap deltas were
+invisible to statistics, heatmaps, and histograms.
+
+This drop widens the entry to the full set of G1 `[info][gc]` forms that carry
+either a stop-the-world pause or a state marker, and deliberately excludes the
+concurrent-cycle forms.
+
+## Requirements
+
+### R1 — Recognize every cause-less G1 pause form
+
+`Pause Remark` and `Pause Cleanup` carry a heap transition and a pause duration
+but no cause clause. They are stop-the-world pauses and belong in the duration
+statistics alongside `Pause Young` and `Pause Full`.
+
+### R2 — Surface the G1 state markers
+
+`To-space exhausted` (evacuation failure) and `Using G1` (collector selection
+at JVM start) carry neither heap nor duration. They are counted and rendered as
+their own categories; `Using G1` doubles as a JVM restart count.
+
+### R3 — Extraction parity for the forms already recognized
+
+Every field the previous pattern produced must be reproduced byte-identically.
+Verified in D42 below.
+
+### R4 — G1 named explicitly, other collectors reserved
+
+The entry is scoped to G1 and named for it, leaving room for sibling entries
+covering Serial, Parallel, Shenandoah and ZGC without a further rename.
+
+## Locked decisions
+
+### D41 — Concurrent-cycle lines are deliberately not recognized (LOCKED 2026-08-21)
+
+`Concurrent Mark Cycle`, `Concurrent Cycle` and `Concurrent Undo Cycle` are
+excluded, and the event name in the pattern is a closed alternation rather than
+an open `(.+?)` so they cannot be admitted by accident.
+
+Each appears twice per cycle: once bare (start) and once with an elapsed figure
+(end). That elapsed figure is a wall-clock envelope containing the `Pause
+Remark` and `Pause Cleanup` pauses this same entry now captures:
+
+```
+11:18:07.399  Concurrent Mark Cycle              <- start
+11:18:07.412  Pause Remark   78M->78M(320M)  4.654ms
+11:18:07.413  Pause Cleanup  78M->78M(320M)  0.266ms
+11:18:07.416  Concurrent Mark Cycle  17.057ms   <- end, spans both pauses above
+```
+
+Admitting it would count concurrent (non-stop-the-world) time as pause time and
+double-count the two pauses. The rejection is also cheaper than the previous
+pattern's: measured at −31 ns/line on this class, because an explicit name list
+fails sooner than the previous backtracking prefix.
+
+### D42 — Level stays event identity, not severity (LOCKED 2026-08-21)
+
+`Pause Remark`, `Pause Cleanup`, `To-space exhausted` and `Using G1` each become
+their own entry in the log-level vocabulary, following the existing treatment of
+`Pause Young` and `Pause Full`. A severity mapping (evacuation failure to ERROR,
+collector banner to INFO) was considered and rejected: it does not survive the
+JDK-version divergence recorded in F1 below, and level in this tool already
+means identity rather than severity.
+
+### D43 — G1-scoped naming (LOCKED 2026-08-21)
+
+Slug renamed `java_gc_log` -> `java_gc_g1`. Accepted as a breaking change to the
+slug stability contract; all consuming surfaces updated in the same commit.
+
+## Research findings (2026-08-21)
+
+Sourced from HotSpot itself: every `[info][gc]` line originates in a
+`GCTraceTime(Info, gc)` or `log_info(gc)` call, so the vocabulary is finite and
+enumerable from the source rather than inferred from samples.
+
+### F1 — `To-space exhausted` is a legacy form; modern JDKs encode the same failure as a cause suffix
+
+`log_info(gc)("To-space exhausted")` is present at JDK 17
+(`g1CollectedHeap.cpp`) and absent from current master. It was replaced by a
+suffix appended to the pause name itself, built in
+`G1YoungGCTraceTime::update_young_gc_name()` (`g1YoungCollector.cpp`):
+
+```c
+"Pause Young (%s) (%s)%s"   /* trailing %s = " (Evacuation Failure: Allocation / Pinned)" */
+```
+
+The same failure therefore appears two different ways depending on JVM version.
+Both are now captured — the legacy form as its own category, the modern form as
+a cause clause on the pause line, where it was already being captured and simply
+carried no distinct marking.
+
+### F2 — Both conventions are present in the committed fixture corpus, in disjoint files
+
+Across `logs/GC/logs-gc/` (4,943,052 lines, 33 distinct shapes):
+
+| | `To-space exhausted` | `(Evacuation Failure)` suffix |
+|---|---|---|
+| `gc-twx01-twx-thingworx-0.out.3` | 5 | 0 |
+| 7 other files | 0 | 1,359 |
+
+No file carries both. This is a concrete instance of the umbrella concern in
+#385 (same line shape, divergent data quality as a registry-level problem).
+
+### F3 — The legacy marker is attached to the following pause, not an independent event
+
+It shares the `GC(n)` identifier and the millisecond timestamp of the pause it
+describes, and that pause carries no `(Evacuation Failure)` suffix of its own:
+
+```
+[2024-10-16T05:27:56.233+0000] GC(144521) To-space exhausted
+[2024-10-16T05:27:56.233+0000] GC(144521) Pause Young (Prepare Mixed) (G1 Evacuation Pause) 49138M->30591M(49152M) 148.622ms
+```
+
+### F4 — Wider `[info][gc]` vocabulary, recorded but not implemented
+
+Not implemented in this drop (G1 only, per D43), recorded so a future collector
+entry starts from the enumeration rather than repeating the research:
+
+- Error-grade: `GC Overhead Limit exceeded too often (N).` (G1, Parallel) ·
+  `Failed to expand young-gen by N bytes` (Serial) · `Out Of Memory (<thread>)`
+  (ZGC) · `Failed to allocate ...` (Shenandoah) · `Cancelling GC: <cause>`
+  (Shenandoah) · `<name> (<cause>) Aborted` (ZGC)
+- Informational: `Using <collector>` for Serial / Parallel / Shenandoah /
+  The Z Garbage Collector / Epsilon (`universe.cpp`, same statement as
+  `Using G1`) · `Soft Max Heap Size: ...`, `Trigger: ...`,
+  `Heuristics ergonomically sets -XX:...` (Shenandoah)
+
+The cause clause itself draws from a closed 35-entry table
+(`GCCause::to_string`, `gcCause.cpp`).
+
+## Measurements (2026-08-21)
+
+Against the full committed corpus, 4,943,052 lines.
+
+### Correctness
+
+| | |
+|---|---|
+| Lines matched before | 2,791,575 |
+| Lines matched after | 3,865,527 (**+1,073,952**) |
+| Divergent fields on previously-matching lines | **0** |
+| Still unmatched | 1,077,525 — exactly the three concurrent-cycle forms (D41) |
+
+Newly captured: `Pause Remark` 536,951 · `Pause Cleanup` 536,950 ·
+`Using G1` 46 · `To-space exhausted` 5.
+
+On a 20-minute single-server slice, measured GC pause time rises from 3.276 s to
+4.680 s — a 43% increase in observed stop-the-world time that was previously
+absent from every duration statistic.
+
+### Cost
+
+Medians of 7 runs, 400k lines per class, attributed by line class:
+
+| Line class | Corpus share | Delta |
+|---|---|---|
+| Matched before and after (like-for-like) | 56.5% | +205 ns/line (+14%) |
+| Newly captured | 21.7% | +548 ns/line (work not previously performed) |
+| Rejected before and after (concurrent) | 21.8% | **−31 ns/line (−5%)** |
+
+Net on a 1.5M-line mixed natural-order stream: 1.533 s -> 1.832 s, about
++199 ns/line on the recognition step, in exchange for 38% more of the file being
+captured.
+
+A branch-reset variant (`(?|...)`) placing the hot pause shape in its own branch
+was built and measured: it halved the like-for-like cost (+92 ns/line) but lost
+more than it gained on the rejection path (+234 ns/line), netting 1.924 s on the
+same stream — worse than the shipped form and considerably harder to read. The
+simple nested-optional form is the shipped design.
+
+## Defect found and fixed in the same change
+
+`gc_heap_delta` called `convert_bytes($heap_from)` unguarded, and
+`convert_bytes()` pattern-matches its argument with no `defined` test. The two
+payload-less forms have no heap transition, so the transform emitted
+uninitialized-value warnings on every such line. The transform is now gated on
+both heap operands being defined.
+
+The summary-table category loop computed a label into a variable that was never
+read, padding it to a fixed 14 characters. `To-space exhausted` is 18 characters,
+producing a negative repeat count warning. The dead assignment is removed.
+
+## Open items
+
+- Records with no message (`Pause Remark`, `Pause Cleanup`, `To-space
+  exhausted`, `Using G1`) are excluded from the top-messages table, so they
+  receive no per-message percentiles. Their durations and counts do reach the
+  bucket statistics, the graph legend, and the category totals. Whether these
+  forms should carry a synthesized message to gain per-message statistics is
+  undecided.

--- a/features/58-format-registry-staged-detection.md
+++ b/features/58-format-registry-staged-detection.md
@@ -543,3 +543,4 @@ The v0.16.0 access-log read-phase regression (+5–10% read_files, per #369's me
 - Prerequisite: #180 (Drop 0 — named stages; native `blocked_by` recorded)
 - `docs/regex-best-practices.md` — pattern-count scaling, ordering policies, alternation rejection, qr// handling
 - #369 (fixed by this drop), #17 (declarative half delivered), #179 (detect-stage hints)
+- `features/382-gc-log-g1-format-coverage.md` (#382) — widens the `mt6` entry to the cause-less G1 pause and event forms; carries D41–D43 and the HotSpot-sourced `[info][gc]` vocabulary. First worked example of editing a registry spec rather than hot-loop code.

--- a/ltl
+++ b/ltl
@@ -291,7 +291,7 @@ my %match_type_to_slug = (
     3  => 'tomcat_access_with_duration',     # Tomcat 9 %D; also catches Apache HTTP2 %D (see note above)
     4  => 'tomcat_access_common',            # access log without duration
     5  => 'connection_server_json',          # ThingWorx Connection Server JSON
-    6  => 'java_gc_log',                     # Java 11 GC info-level pause
+    6  => 'java_gc_g1',                      # Java G1 collector info-level pause and event lines
     7  => 'tw_analytics_v2',                 # ThingWorx Analytics V2
     8  => 'tw_analytics_worker',             # ThingWorx Analytics worker
     9  => 'jboss_access',                    # JBoss / Jersey access log
@@ -824,6 +824,8 @@ my @log_levels = (
     'DEBUG-HL', 'DEBUG', 'TRACE-HL', 'TRACE', '5xx-HL', '5xx', 
     '4xx-HL', '4xx', '3xx-HL', '3xx', '2xx-HL', '2xx', '1xx-HL', 
     '1xx', 'Pause Young-HL', 'Pause Young', 'Pause Full-HL', 'Pause Full',
+    'Pause Remark-HL', 'Pause Remark', 'Pause Cleanup-HL', 'Pause Cleanup',
+    'To-space exhausted-HL', 'To-space exhausted', 'Using G1-HL', 'Using G1',
     'DATA-HL', 'DATA', 'err-rate', 'msg-rate', 'empty'
 );
 
@@ -861,6 +863,10 @@ my %colors = (
     '5xx'  => "\033[0;31m",
     'Pause Young' => "\033[0;35m",
     'Pause Full' => "\033[0;31m",
+    'Pause Remark' => "\033[0;33m",
+    'Pause Cleanup' => "\033[0;32m",
+    'To-space exhausted' => "\033[0;31m",
+    'Using G1' => "\033[0;34m",
     'err-rate' => "\033[91m\033[109m",
     'msg-rate'    => "\033[0m",
     'NC'    => "\033[0m",
@@ -2177,7 +2183,7 @@ my %format_transform_code = (
     strip_query_string  => q{ $message =~ s/\?.+$//; },                # emitted only when query strings are excluded (CLI-gated at compile)
     prepend_session     => q{ $message = "[$session] $message" if defined $session; },  # emitted only when sessions are included (CLI-gated at compile)
     strip_trailing_ws   => q{ $message =~ s/\s+$//g; },
-    gc_heap_delta       => q{ $bytes = convert_bytes( $heap_from ) - convert_bytes( $heap_to ); $bytes = $bytes < 0 ? 0 : $bytes; },
+    gc_heap_delta       => q{ if( defined $heap_from && defined $heap_to ) { $bytes = convert_bytes( $heap_from ) - convert_bytes( $heap_to ); $bytes = $bytes < 0 ? 0 : $bytes; } },
     chop_message        => q{ chop $message; },
     strip_pid           => q{ $message =~ s/\d+ (.*)$/$1/; },
     hoist_cpp_object    => q{ if( $message =~ /\w+\.cpp:\d+ / ) { $message =~ s/(\w+\.cpp:\d+) (.*)$/$2/; $object = $1; } },
@@ -2362,8 +2368,18 @@ sub format_registry_specs {
         [ '2025-02-02 21:03:06', 'WARN', undef, undef, undef, undef, undef, undef, undef, undef, undef, '0', '0' ],
         [ '2025-02-02 21:03:07', 'INFO', undef, undef, undef, undef, undef, undef, undef, undef, undef, '0', '0' ],
       ] },
-    { name => 'mt6', slug => 'java_gc_log', match_type => 6, scanned => 1, head_class => 'bracket_digit',
-      pattern_src => '^[\[]?(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\.\d{3})[+-]\d{4}.*?\[info\]\[gc\s*\] GC\(\d+\) (.+?) (\(.+?\)) (\d[^-]+)->(\d[^(]+)\((\d[^)]+)\) (\d.*)ms',
+    # The event name is a closed alternation, not an open `(.+?)`: G1's
+    # concurrent-cycle lines (`Concurrent Mark Cycle`, `Concurrent Cycle`,
+    # `Concurrent Undo Cycle`) share this line head but are deliberately
+    # not recognized. Their end-of-cycle `Nms` figure is a wall-clock
+    # envelope that already contains the Remark and Cleanup pauses this
+    # entry captures, so admitting it would double-count stop-the-world
+    # time. Cause clause and heap/duration payload are both optional: G1
+    # writes `Pause Remark`/`Pause Cleanup` with no cause, and
+    # `To-space exhausted`/`Using G1` with neither. `Using G1` is also the
+    # only form with no `GC(n)` prefix.
+    { name => 'mt6', slug => 'java_gc_g1', match_type => 6, scanned => 1, head_class => 'bracket_digit',
+      pattern_src => '^[\[]?(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}\.\d{3})[+-]\d{4}.*?\[info\]\[gc\s*\] (?:GC\(\d+\) )?(Pause (?:Young|Full|Remark|Cleanup)|To-space exhausted|Using G1)(?: (\(.+?\)))?(?: (\d[^-]+)->(\d[^(]+)\((\d[^)]+)\) (\d.*)ms)?$',
       field_map => [ [1,'timestamp_str'],[2,'category_bucket'],[3,'message'],[4,'heap_from'],[5,'heap_to'],[6,'heap_size'],[7,'duration'] ],
       transforms => [ 'gc_heap_delta' ],
       time => { layout => 'iso_ms', precision => 'ms', tz => 'offset_in_line', frac => 'fixed3' },
@@ -2372,10 +2388,18 @@ sub format_registry_specs {
       samples => [
         '[2025-04-05T11:10:47.867+0000][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 2433M->66M(49152M) 18.406ms',
         '[2025-04-05T12:00:03.101+0000][info][gc] GC(7) Pause Young (Concurrent Start) (Metadata GC Threshold) 512M->128M(49152M) 7.250ms',
+        '[2025-04-05T11:10:50.305+0000][info][gc] GC(2) Pause Remark 74M->74M(320M) 2.422ms',
+        '[2025-04-05T11:10:50.309+0000][info][gc] GC(2) Pause Cleanup 82M->82M(320M) 0.204ms',
+        '[2024-10-16T05:27:56.233+0000][info][gc] GC(144521) To-space exhausted',
+        '[2025-06-05T11:17:57.418+0000][info][gc] Using G1',
       ],
       expect => [
         [ '2025-04-05T11:10:47', 'Pause Young', undef, undef, undef, undef, undef, undef, '(Normal) (G1 Evacuation Pause)', '2367000000', '18.406', '0', '1' ],
         [ '2025-04-05T12:00:03', 'Pause Young', undef, undef, undef, undef, undef, undef, '(Concurrent Start) (Metadata GC Threshold)', '384000000', '7.250', '0', '1' ],
+        [ '2025-04-05T11:10:50', 'Pause Remark', undef, undef, undef, undef, undef, undef, undef, '0', '2.422', '0', '1' ],
+        [ '2025-04-05T11:10:50', 'Pause Cleanup', undef, undef, undef, undef, undef, undef, undef, '0', '0.204', '0', '1' ],
+        [ '2024-10-16T05:27:56', 'To-space exhausted', undef, undef, undef, undef, undef, undef, undef, undef, undef, '0', '1' ],
+        [ '2025-06-05T11:17:57', 'Using G1', undef, undef, undef, undef, undef, undef, undef, undef, undef, '0', '1' ],
       ] },
     { name => 'mt7', slug => 'tw_analytics_v2', match_type => 7, scanned => 1, head_class => 'any',
       pattern_src => '^([^ ]+)\s+\[(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}[.,]\d{3})\] (.*)$',
@@ -13897,9 +13921,8 @@ sub print_summary_table {
     foreach my $category_bucket (@log_levels) {
         next if $category_bucket =~ /^(empty|err-rate|msg-rate)$/;
         next unless $category_totals{$category_bucket};
-	
-        my ( $legend_title ) =  "$category_bucket:" . " " x ( 14 - length( $category_bucket ) );
-        push @summary_table, sprintf( $table_format, $category_bucket, $category_totals{$category_bucket} ); 
+
+        push @summary_table, sprintf( $table_format, $category_bucket, $category_totals{$category_bucket} );
     }
 
     push @summary_table, sprintf( "$padding" . "─" x ( $category_column_width + $occurrences_column_width + 1 ) . "$padding\n" );

--- a/releases/v0.17.0.md
+++ b/releases/v0.17.0.md
@@ -9,3 +9,4 @@
 
 - Input file paths containing spaces now open correctly, with or without wildcards; previously the in-process wildcard expansion treated whitespace as a pattern separator and such paths failed with `unable to open any files` (#379)
 - The v0.16.0 access-log read-phase slowdown (4–11.5% on access-log selections) is fixed: the sequential per-line pattern cascade that caused it is gone, and access-log reading is now 13.6% faster than v0.16.0 (#369)
+- G1 garbage-collection logs now include the `Pause Remark` and `Pause Cleanup` pauses, which were previously skipped for carrying no cause clause — on the bundled sample logs this is 28% more stop-the-world pauses and 43% more measured pause time reaching the duration statistics, heatmaps and histograms — and the `To-space exhausted` evacuation-failure marker and `Using G1` collector banner are now counted as their own categories (#382)

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -14,7 +14,7 @@
 # jboss_access against a fixture derived from the same log (quoted
 # referrer/user-agent + trailing duration appended, issue #365). The
 # remaining slugs (thingworx_rac_client, connection_server_json,
-# java_gc_log, tw_analytics_v2, tw_analytics_worker,
+# java_gc_g1, tw_analytics_v2, tw_analytics_worker,
 # connection_server_standard) are asserted against fixtures derived from
 # the format registry's own sample lines (issue #58) — the same lines the
 # D24 load-time gates validate, so fixture and registry cannot drift.
@@ -485,15 +485,19 @@ EOF
     assert_registry_sample_scenario "$log" connection_server_json 5 2
 }
 
-scenario_java_gc_log() {
-    current_scenario="java-gc-log"
+scenario_java_gc_g1() {
+    current_scenario="java-gc-g1"
     echo "[$current_scenario]"
     local log="$TMP_DIR/gc.log"
     cat > "$log" <<'EOF'
 [2025-04-05T11:10:47.867+0000][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 2433M->66M(49152M) 18.406ms
 [2025-04-05T12:00:03.101+0000][info][gc] GC(7) Pause Young (Concurrent Start) (Metadata GC Threshold) 512M->128M(49152M) 7.250ms
+[2025-04-05T11:10:50.305+0000][info][gc] GC(2) Pause Remark 74M->74M(320M) 2.422ms
+[2025-04-05T11:10:50.309+0000][info][gc] GC(2) Pause Cleanup 82M->82M(320M) 0.204ms
+[2024-10-16T05:27:56.233+0000][info][gc] GC(144521) To-space exhausted
+[2025-06-05T11:17:57.418+0000][info][gc] Using G1
 EOF
-    assert_registry_sample_scenario "$log" java_gc_log 6 2
+    assert_registry_sample_scenario "$log" java_gc_g1 6 6
 }
 
 scenario_tw_analytics_v2() {
@@ -725,7 +729,7 @@ scenario_tw_edge_c_sdk;         echo ""
 scenario_csv_with_udm;          echo ""
 scenario_thingworx_rac_client;  echo ""
 scenario_connection_server_json; echo ""
-scenario_java_gc_log;           echo ""
+scenario_java_gc_g1;            echo ""
 scenario_tw_analytics_v2;       echo ""
 scenario_tw_analytics_worker;   echo ""
 scenario_connection_server_standard; echo ""


### PR DESCRIPTION
Fixes #382.

## Problem

The `mt6` registry entry required a parenthesized cause clause between the pause name and the heap transition. G1's `Pause Remark` and `Pause Cleanup` carry the same heap-transition and duration payload but no cause clause, so they never matched — their pause durations and heap deltas were invisible to statistics, heatmaps and histograms.

Across the committed GC corpus (4,943,052 lines) that is **1,073,952 hidden lines — 28% of all heap-carrying pauses**. On a 20-minute single-server slice, measured stop-the-world time rises from **3.276 s to 4.680 s (+43%)**.

## Change

The event name is now a closed alternation rather than an open `(.+?)`, with both the cause clause and the heap/duration payload optional. That admits `To-space exhausted` (evacuation-failure marker) and `Using G1` (collector banner, also a JVM restart count), which carry neither — `Using G1` is the only form with no `GC(n)` prefix.

The concurrent-cycle forms are excluded **by construction**, not by omission: `Concurrent Mark Cycle` / `Concurrent Cycle` / `Concurrent Undo Cycle` each appear twice per cycle, and the end-of-cycle figure is a wall-clock envelope that contains the Remark and Cleanup pauses this same entry now captures. Admitting it would count concurrent time as pause time and double-count those two pauses (D41).

Level stays event identity rather than severity, following the existing `Pause Young` / `Pause Full` treatment (D42). Slug renamed `java_gc_log` → `java_gc_g1` to scope the entry to G1 so sibling collectors can be added without a further rename — a breaking change to the slug contract, with all consuming surfaces updated here (D43).

## Verification

| | |
|---|---|
| Divergent fields on the 2,791,575 previously-matching lines | **0** |
| Lines newly captured | **+1,073,952** |
| Still unmatched | 1,077,525 — exactly the three concurrent-cycle forms |
| `validate-format-detection.sh` | **58 passed, 0 failed** (GC assertions confirmed firing) |
| All output modes (`-hm`×3, `-hg`×2, `-o`, `-ms`, `-g`, combined) | exit 0, **zero stderr lines** |

Cost, medians of 7 runs attributed by line class: +205 ns/line like-for-like, +548 ns/line on newly-captured lines, and **−31 ns/line on the rejection path** — an explicit name list fails sooner than the previous backtracking prefix. Net +199 ns/line on a 1.5M-line mixed stream. A branch-reset `(?|...)` variant was built and measured; it lost more on rejection than it gained on matching and is not shipped.

`validate-regression.sh` reports 24 failures; every diff hunk is the legend's absolute path (`/Users/gregeva/…` baseline vs the `/Volumes/…` dev mount), verified mechanically across all 8 failing scenarios. Pre-existing and environmental.

## Defects fixed in passing

Both exposed by the payload-less forms:

- `gc_heap_delta` called `convert_bytes()` on possibly-undefined heap operands, and `convert_bytes()` pattern-matches its argument with no `defined` test — uninitialized-value warnings on every such line.
- The summary-table loop padded a label to a fixed 14 characters, which goes negative for the 18-character `To-space exhausted`. That label was assigned and never read, so it is removed rather than widened.

## Research

Findings are sourced from HotSpot itself — every `[info][gc]` line originates in a `GCTraceTime(Info, gc)` or `log_info(gc)` call, so the vocabulary is enumerable rather than inferred. Recorded in `features/382-gc-log-g1-format-coverage.md`, including that `To-space exhausted` is a **legacy** form absent from current master, replaced by an `(Evacuation Failure: …)` suffix on the pause name — and that both conventions appear in our own corpus in disjoint files, a concrete instance of the #385 umbrella concern.

## Open item

Records with no message are excluded from the top-messages table, so Remark/Cleanup get no per-message percentiles. Their durations and counts do reach the bucket statistics, graph legend and category totals. Logged in the feature doc, undecided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)