### PR TITLE
#395 Rename the WGM format to windchill_workgroup_manager

### DIFF
--- a/docs/test-logs.md
+++ b/docs/test-logs.md
@@ -69,7 +69,7 @@ Fields: `date`(T)`time`(ms precision)`Z` (combined ISO-8601 UTC timestamp), `msg
 
 **Structure**: every line in every file matches the one shape — no continuation lines, no blank lines, ASCII throughout. A minority of trace messages (HTTP response headers echoed into the log) end in a carriage return, which the line reader strips. The `uwgm.log.1` header declares `log_base_name "uwgm_client"`, so the in-file name does not distinguish it from `uwgm_client.log.1` — only the file name does. `D` dominates every file (80–90% of lines); `X`/`Y` and `S`/`F` come in matched create/destroy and start/finish pairs on the same `area`.
 
-**ltl format**: `wgm_client` — one entry for all three filenames; the letters become the `DEBUG`/`ERROR`/`INFO`/`TRACE`/`WARN` levels plus the `CONFIG`/`CREATE`/`DESTROY`/`START`/`FINISH` categories. Occurrences only (no duration, bytes or count at the line level). The committed fixture `tests/fixtures/format-detection/wgm-client.txt` is a scrubbed 44-line slice of an `uwgm_client.log.1`.
+**ltl format**: `windchill_workgroup_manager` — one entry for all three filenames; the letters become the `DEBUG`/`ERROR`/`INFO`/`TRACE`/`WARN` levels plus the `CONFIG`/`CREATE`/`DESTROY`/`START`/`FINISH` categories. Occurrences only (no duration, bytes or count at the line level). The committed fixture `tests/fixtures/format-detection/wgm-client.txt` is a scrubbed 44-line slice of an `uwgm_client.log.1`.
 
 ---
 

--- a/features/395-wgm-client-log-format.md
+++ b/features/395-wgm-client-log-format.md
@@ -3,7 +3,7 @@
 ## Status
 
 Implemented on `395-wgm-client-log-format`, targeting release 0.17.0. Registry
-entry `mt16`, user-facing name `wgm_client`, match_type 16. Decisions D54–D56
+entry `mt16`, user-facing name `windchill_workgroup_manager`, match_type 16. Decisions D54–D56
 locked by the architect 2026-08-23.
 
 ## Overview

--- a/ltl
+++ b/ltl
@@ -304,7 +304,7 @@ my %match_type_to_slug = (
     13 => 'csv',                             # CSV via detect_and_parse_csv_header()
     14 => 'httpd_access_with_duration',      # Apache httpd / Tomcat 10.1+ %D in microseconds (variant of 3)
     15 => 'integration_runtime_standard',    # ThingWorx Integration Runtime, yyyy-dd-MM dates (variant of 10)
-    16 => 'wgm_client',                      # Windchill Workgroup Manager client logs (genlwsc / uwgm_client / uwgm)
+    16 => 'windchill_workgroup_manager', # Windchill Workgroup Manager client logs (genlwsc / uwgm_client / uwgm)
     17 => 'windchill_method_server',         # Windchill Method Server / Background Method Server log4j
 );
 
@@ -2384,7 +2384,7 @@ sub format_registry_specs {
     # The bracket-bearing sample is the cross-shadow proof that this group
     # must stay ahead of mt2 (whose `.*? \[...\]` tail accepts any line
     # with a bracketed token).
-    { name => 'mt16', slug => 'wgm_client', match_type => 16, scanned => 1, head_class => 'digit',
+    { name => 'mt16', slug => 'windchill_workgroup_manager', match_type => 16, scanned => 1, head_class => 'digit',
       filename => { stem => '(?:genlwsc|uwgm_client|uwgm)', index => 'dot_n', ext => '.log', placement => 'after',
                     samples => [ 'genlwsc.log.1', 'uwgm_client.log.1', 'uwgm.log.1', 'uwgm_client.log', 'genlwsc.log' ] },
       pattern_src => '^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})Z: ([A-Z]): (P[0-9a-f]+): (T[0-9a-f]+): ([^ :]+): (.*)',

--- a/tests/fixtures/format-detection/manifest.tsv
+++ b/tests/fixtures/format-detection/manifest.tsv
@@ -10,7 +10,7 @@ httpd-access.txt	access.log-20260609	Apache httpd 2.x access log with %D in micr
 httpd-access.txt	renamed.txt	(same slice)	ext absent -> default Tomcat member (confidence 0.75) + ambiguity note
 thingworx-application-log.txt	ApplicationLog.2025-05-06.0.log	ThingWorx ApplicationLog.2025-05-06.0.log, first 300 lines	filename date/index decomposition; filename-date cross-check matches the content
 mixed.txt	mixed.log	connection-server.txt + tomcat-access.txt concatenated	[1,2] bracket and legend
-wgm-client.txt	uwgm_client.log.1	Windchill Workgroup Manager uwgm_client.log.1, header block + 33 representative data lines (every msgtype letter, #-qualified areas, a bracketed message; pid/tid kept, no hosts or user paths)	wgm_client binds; every msgtype letter survives the category gate (lines_included = matched_lines); stem + .log + rotation index decompose
+wgm-client.txt	uwgm_client.log.1	Windchill Workgroup Manager uwgm_client.log.1, header block + 33 representative data lines (every msgtype letter, #-qualified areas, a bracketed message; pid/tid kept, no hosts or user paths)	windchill_workgroup_manager binds; every msgtype letter survives the category gate (lines_included = matched_lines); stem + .log + rotation index decompose
 wgm-client.txt	genlwsc.log.1	(same slice)	the second WGM filename stem decomposes to the same entry
 wgm-client.txt	uwgm.log.1	(same slice)	the third WGM filename stem decomposes to the same entry (and is not consumed as a prefix of uwgm_client)
 wgm-client.txt	renamed.txt	(same slice)	no name evidence: a group of one still binds by shape alone; filename_evidence reports stem=-

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -18,7 +18,7 @@
 # connection_server_standard, windchill_method_server) are asserted against fixtures derived from
 # the format registry's own sample lines (issue #58) — the same lines the
 # D24 load-time gates validate, so fixture and registry cannot drift.
-# wgm_client is asserted against the committed wgm-client.txt fixture
+# windchill_workgroup_manager is asserted against the committed wgm-client.txt fixture
 # staged under each of its three producer-true names (issue #395).
 # The `format-detection / scan` sub-section (registry scan telemetry,
 # issue #58) is asserted by the scan-telemetry scenarios.
@@ -1209,17 +1209,17 @@ scenario_variant_mixed_legend() {
 # bracketed message (the mt2 cross-shadow case). `-bs 1440 -oe -n 1 -osum`
 # via run_format_detection: every assertion reads -V format-detection or
 # the benchmark-data line counts; the 8-second span never reads a bucket.
-scenario_wgm_client() {
+scenario_windchill_workgroup_manager() {
     current_scenario="wgm-client"
     echo "[$current_scenario]"
     local log; log=$(stage_fixture wgm-client.txt uwgm_client.log.1) || return
     local out; out=$(run_format_detection "$log" -V benchmark-data); check_capture_warnings "$out"
-    assert_line "$out" pattern '^  format: wgm_client$' \
-        asserts 'A WGM client log binds the wgm_client format' \
+    assert_line "$out" pattern '^  format: windchill_workgroup_manager$' \
+        asserts 'A WGM client log binds the windchill_workgroup_manager format' \
         produced_by 'read_and_process_logs() in ltl (first-match block); emitted by emit_format_detection_verbose()' \
         contract '%match_type_to_slug in ltl GLOBALS - slug names are locked; renames are breaking under HARNESS-DESIGN.md section Stability contract'
     assert_line "$out" pattern '^  match_type: 16$' \
-        asserts 'Slug wgm_client binds to internal match_type 16' \
+        asserts 'Slug windchill_workgroup_manager binds to internal match_type 16' \
         produced_by 'emit_format_detection_verbose() in ltl (per-file match_type field)' \
         contract 'features/log-format-registry.md section -V format-detection section-contract - match_type integers are diagnostic; the slug is the user-facing contract'
     assert_line "$out" pattern '^  matched_lines: 44$' \
@@ -1263,11 +1263,11 @@ scenario_wgm_filename_family() {
         log=$(stage_fixture wgm-client.txt "$name") || return
         out=$(run_format_detection "$log"); check_capture_warnings "$out"
         assert_line "$out" pattern '^  filename_evidence: stem=mt16 ext=match date=- index=present$' \
-            asserts "$name decomposes to the wgm_client entry's stem, extension and rotation index" \
+            asserts "$name decomposes to the windchill_workgroup_manager entry's stem, extension and rotation index" \
             produced_by 'format_filename_decompose() in ltl; emitted by emit_format_detection_evidence_verbose()' \
             contract 'features/395-wgm-client-log-format.md section D55 (filename family)'
-        assert_line "$out" pattern '^  format: wgm_client$' \
-            asserts "$name binds the wgm_client format" \
+        assert_line "$out" pattern '^  format: windchill_workgroup_manager$' \
+            asserts "$name binds the windchill_workgroup_manager format" \
             produced_by 'read_and_process_logs() in ltl (first-match block)' \
             contract 'features/log-format-registry.md section -V format-detection section-contract'
     done
@@ -1277,7 +1277,7 @@ scenario_wgm_filename_family() {
         asserts 'A renamed WGM file matches no declared stem: the name signal is withheld, never contradicting (D45)' \
         produced_by 'format_filename_decompose() in ltl; emitted by emit_format_detection_evidence_verbose()' \
         contract 'features/log-format-registry.md section Drop 1.5 D45'
-    assert_line "$out" pattern '^  format: wgm_client$' \
+    assert_line "$out" pattern '^  format: windchill_workgroup_manager$' \
         asserts 'A group of one binds by line shape alone; filename evidence only reports' \
         produced_by 'read_and_process_logs() in ltl (first-match block)' \
         contract 'features/395-wgm-client-log-format.md section D55 (filename family)'
@@ -1362,7 +1362,7 @@ scenario_windchill_method_server_rolled; echo ""
 scenario_windchill_method_server_bare; echo ""
 scenario_windchill_method_server_renamed; echo ""
 scenario_variant_mixed_legend; echo ""
-scenario_wgm_client;            echo ""
+scenario_windchill_workgroup_manager; echo ""
 scenario_wgm_filename_family;   echo ""
 scenario_format_pin
 


### PR DESCRIPTION
Follow-up to #395 (merged in PR #407): the user-facing format name `wgm_client` is renamed to `windchill_workgroup_manager` (mt16). Touches the slug map and entry in `ltl`, the format-detection harness assertions and scenario, the fixture manifest, `docs/test-logs.md` and the feature doc. The `uwgm_client` filename stem is unchanged (it is the file's real name).

`validate-format-detection.sh` 192/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6h8wVd7JQWGRM7M7SZnYE