### PR TITLE
Per-line log-level gate uses a hash set instead of a linear grep (#414)

### DIFF
--- a/ltl
+++ b/ltl
@@ -914,6 +914,10 @@ my @log_levels = (
     'START-HL', 'START', 'FINISH-HL', 'FINISH',
     'DATA-HL', 'DATA', 'err-rate', 'msg-rate', 'empty'
 );
+# Membership set for the per-line category gate in read_and_process_logs():
+# a hash lookup is constant-time where a grep over the list scans every
+# element per line.
+my %log_level_set = map { $_ => 1 } @log_levels;
 
 # Characters selected and usable for drawing the bar charts
 my %blocks = (
@@ -10463,7 +10467,7 @@ sub read_and_process_logs {
                     $fractional_ms = $frac > 0 ? $frac * 1000 : 0;
                 }
 
-                unless (grep { $_ eq $category_bucket } @log_levels) {				# this condition importantly only continues if the read/parsed log category is one of the ones defined
+                unless (exists $log_level_set{$category_bucket}) {				# this condition importantly only continues if the read/parsed log category is one of the ones defined
                     next;
                 } elsif (!$csv_epoch_timestamp && $match_type == 13) {
                     # Extract milliseconds if present (supports . or , separator, 1-6 digits)

--- a/tests/profile/results/414-readphase-new/10k/summary.txt
+++ b/tests/profile/results/414-readphase-new/10k/summary.txt
@@ -1,0 +1,49 @@
+====================================================================================================
+Profile:  /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/results/414-readphase-new/10k/nytprof.out
+Script:   /Users/gregeva/Documents/GitHub/logtimeline/ltl
+Perl:     5.42.2
+CPU time: 0.2651 s (sum of exclusive times)
+Subs:     25 shown of 447 matching (from 1175 total)
+Sort:     incl time | Filter: Perl subs only
+ltl -V:   lines_read=10000  total=0.307s  rss=34 MB
+====================================================================================================
+
+Rank  Subroutine                                               Calls   Incl(s)   Excl(s)   ms/call   %Tot
+----------------------------------------------------------------------------------------------------
+   1  pipeline_parse                                               1    0.1797  0.000026   179.722   67.8
+   2  read_and_process_logs                                        1    0.1757    0.1081   175.678   66.3
+   3  __ANON__[(eval 44)[/Users/gregeva/Documents/GitHu...     10041    0.0429    0.0200     0.004   16.2
+   4  get_memory_usage                                             7    0.0226    0.0002     3.225    8.5
+   5  measure_memory_structures                                    5    0.0163  0.000053     3.262    6.2
+   6  pipeline_render                                              1    0.0140  0.000091    14.019    5.3
+   7  Term::ReadKey::GetTerminalSize                               1    0.0133    0.0001    13.330    5.0
+   8  pipeline_finalize                                            1    0.0116  0.000045    11.618    4.4
+   9  pipeline_detect                                              1    0.0112  0.000006    11.183    4.2
+  10  build_format_registry                                        1    0.0111    0.0020    11.128    4.2
+  11  format_scan_sub_resolve                                      1    0.0109  0.000012    10.887    4.1
+  12  compile_format_scan_sub                                      1    0.0109    0.0035    10.875    4.1
+  13  calculate_all_statistics                                     1    0.0086    0.0011     8.553    3.2
+  14  BEGIN@35                                                     1    0.0067    0.0003     6.735    2.5
+  15  Text::CSV::_load                                             2    0.0064  0.000040     3.200    2.4
+  16  Text::CSV::_load_pp                                          1    0.0064  0.000001     6.358    2.4
+  17  Text::CSV::BEGIN@1.1                                         1    0.0063    0.0061     6.334    2.4
+  18  compile_format_extractor                                    34    0.0052    0.0046     0.154    2.0
+  19  BEGIN@21                                                     1    0.0052    0.0013     5.179    2.0
+  20  BEGIN@22                                                     1    0.0046    0.0014     4.563    1.7
+  21  write_index_file                                             1    0.0045    0.0001     4.483    1.7
+  22  BEGIN@25                                                     1    0.0041    0.0029     4.051    1.5
+  23  XSLoader::load                                               9    0.0037    0.0037     0.406    1.4
+  24  pipeline_accumulate                                          1    0.0029  0.000047     2.859    1.1
+  25  Text::CSV_PP::print                                          3    0.0028    0.0009     0.945    1.1
+
+Note: %Tot = incl_time / 0.2651 s (total Perl CPU time)
+      Use --all to include XSubs [xs] and opcodes [op]
+      Use --sort excl to rank by exclusive time
+
+====================================================================================================
+Cross-Validation: NYTProf call counts vs ltl -V output
+----------------------------------------------------------------------------------------------------
+  read_and_process_logs                     NYTProf calls=1  ltl-V lines_read=10000
+    (called once; loops internally over lines)
+
+  [OK] All cross-validation checks within tolerance.

--- a/tests/profile/results/414-readphase-new/10k/verbose.txt
+++ b/tests/profile/results/414-readphase-new/10k/verbose.txt
@@ -1,0 +1,297 @@
+[0;37m [90m[109m
+──────────────────────────────────────────────────────────────────────────────────────────────
+   ,:: ltl ::' log timeline [0.17.0] --  by Greg Eva // geva@ptc.com // gregeva@gmail.com
+──────────────────────────────────────────────────────────────────────────────────────────────
+[0m
+
+=== runtime-config ===
+include (merged): (not set)
+exclude (merged): (not set)
+highlight (merged): (not set)
+threadpool-activity (merged): (not set)
+bucket-duration-stats-demand: 1
+message-duration-stats-demand: 1
+=== runtime-config / command-line ===
+bucket-size: 60
+=== END runtime-config / command-line ===
+=== runtime-config / environment-variable ===
+=== END runtime-config / environment-variable ===
+=== END runtime-config ===
+
+=== index-read-back ===
+index_used: no
+index_filter_signature: -
+file: /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log
+  lookup: none
+  matched_entry_date: -
+  freshness: no_entry
+  preseed_duration_min: -
+  preseed_duration_max: -
+  preseed_bytes_min: -
+  preseed_bytes_max: -
+  preseed_count_min: -
+  preseed_count_max: -
+  preseed_first_timestamp: -
+  preseed_last_timestamp: -
+=== END index-read-back ===
+=== histogram-bin-counters ===
+data_model_precision: 5 (default)
+
+consumer: summary_table
+  path: user_opt_out
+
+consumer: csv_output
+  path: feature_not_active
+
+consumer: time_bucket_stats
+  path: user_opt_out
+
+consumer: heatmap_markers
+  path: feature_not_active
+
+consumer: heatmap_cells
+  path: feature_not_active
+
+consumer: histogram_view
+  path: feature_not_active
+
+consumer: histogram_bins
+  path: feature_not_active
+=== END histogram-bin-counters ===
+=== format-detection ===
+duration_unit_override: -
+format_pin: -
+legend: 1=thingworx_standard
+files: 1
+file: /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log
+  format: thingworx_standard
+  match_type: 1
+  is_access_log: yes
+  matched_lines: 10000
+  unmatched_lines: 0
+  first_match_line: 1
+  scan_attempts: 10000
+  scan_failed_attempts: 0
+  window: 0
+  sample: yes
+  sample_file_bytes: 4056729
+  sample_whole_file: no
+  sample_lines: 59
+  sample_matched_lines: 59
+  sample_formats: mt1std=59
+  sample_part: 1 offset=0 bytes=8192 lines=20 avg_line=407 matched=20 first_ts="2025-04-09 04:57:45.252" last_ts="2025-04-09 04:57:45.296"
+  sample_part: 2 offset=2024268 bytes=8192 lines=20 avg_line=406 matched=20 first_ts="2025-04-09 05:02:51.956" last_ts="2025-04-09 05:02:52.099"
+  sample_part: 3 offset=4048537 bytes=8192 lines=19 avg_line=414 matched=19 first_ts="2025-04-09 05:12:32.642" last_ts="2025-04-09 05:12:32.740"
+  sample_us: 581.0
+  formats: thingworx_standard
+  filename_evidence: stem=- ext=- date=- index=-
+=== format-detection / scan ===
+entries: 15
+guarded: mt12,mt4,mt9
+window_size: 0
+window_fallback: 1000
+sample_parts: 3
+sample_bytes_per_part: 8192
+final_order: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+promotions: 0
+match_counts: mt1std=10000,mt10=0,mt10ir=0,mt16=0,mt1gen=0,mt2=0,mt12=0,mt4=0,mt9=0,mt3=0,mt3us=0,mt5=0,mt6=0,mt7=0,mt8=0,mt17=0,mt11=0
+variant_groups: connection_server=mt10,access_with_duration=mt3
+nomatch_scan_samples: 0
+nomatch_scan_avg_us: -
+=== END format-detection / scan ===
+=== END format-detection ===
+=== format-registry ===
+entries: 18
+scanned_entries: 17
+scan_slots: 15
+  entry: mt1std slug=thingworx_standard group=mt1std default=yes role=scanned
+  entry: mt10 slug=connection_server_standard group=connection_server default=yes role=scanned
+  entry: mt10ir slug=integration_runtime_standard group=connection_server default=no role=scanned
+  entry: mt16 slug=windchill_workgroup_manager group=mt16 default=yes role=scanned
+  entry: mt1gen slug=thingworx_standard group=mt1gen default=yes role=scanned
+  entry: mt2 slug=thingworx_rac_client group=mt2 default=yes role=scanned
+  entry: mt12 slug=tomcat_codebeamer group=mt12 default=yes role=scanned
+  entry: mt4 slug=tomcat_access_common group=mt4 default=yes role=scanned
+  entry: mt9 slug=jboss_access group=mt9 default=yes role=scanned
+  entry: mt3 slug=tomcat_access_with_duration group=access_with_duration default=yes role=scanned
+  entry: mt3us slug=httpd_access_with_duration group=access_with_duration default=no role=scanned
+  entry: mt5 slug=connection_server_json group=mt5 default=yes role=scanned
+  entry: mt6 slug=java_gc_g1 group=mt6 default=yes role=scanned
+  entry: mt7 slug=tw_analytics_v2 group=mt7 default=yes role=scanned
+  entry: mt8 slug=tw_analytics_worker group=mt8 default=yes role=scanned
+  entry: mt17 slug=windchill_method_server group=mt17 default=yes role=scanned
+  entry: mt11 slug=tw_edge_c_sdk group=mt11 default=yes role=scanned
+  entry: csv slug=csv group=csv default=yes role=stateful
+variant_groups: connection_server=mt10,access_with_duration=mt3
+  group: connection_server slot=1 default=mt10 members=mt10,mt10ir
+  group: access_with_duration slot=8 default=mt3 members=mt3,mt3us
+static_order: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+  ancestors: mt1std <- -
+  ancestors: connection_server <- -
+  ancestors: mt16 <- -
+  ancestors: mt1gen <- mt1std
+  ancestors: mt2 <- mt1std,connection_server,mt16,mt1gen
+  ancestors: mt12 <- -
+  ancestors: mt4 <- -
+  ancestors: mt9 <- -
+  ancestors: access_with_duration <- mt12,mt4,mt9
+  ancestors: mt5 <- -
+  ancestors: mt6 <- -
+  ancestors: mt7 <- -
+  ancestors: mt8 <- mt1std,connection_server,mt1gen
+  ancestors: mt17 <- -
+  ancestors: mt11 <- -
+scan_subs_compiled: 1
+scan_sub_cache_hits: 0
+scan_subs_rss_bytes: 901120
+scan_sub_rss_measured: yes
+compiled_orders: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+=== END format-registry ===
+=== heatmap-palette ===
+heatmap_active: no
+metric: n/a
+light_bg: 0
+light_bg_source: default
+color_name: n/a
+gradient_dark: n/a
+gradient_light: n/a
+gradient_active: n/a
+=== END heatmap-palette ===
+=== csv-output ===
+csv_active: no
+=== END csv-output ===
+=== percentile-algorithm ===
+=== percentile-algorithm / histogram ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / histogram ===
+=== percentile-algorithm / heatmap ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / heatmap ===
+=== percentile-algorithm / message-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / message-stats ===
+=== percentile-algorithm / bucket-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / bucket-stats ===
+=== END percentile-algorithm ===
+=== statistics-demand ===
+store: bucket
+  store_demand: 1
+  population: 1
+  group terminal_core: demanded=1 consumers=timeline-latency-column
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 1
+  group_calc terminal_core: computed=1 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=1 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=1 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=1 ineligible=0
+store: message
+  store_demand: 1
+  population: 4223
+  group terminal_core: demanded=1 consumers=messages-table
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 7
+  group_calc terminal_core: computed=7 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=7 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=7 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=0 ineligible=7
+threadpool_population: 0
+=== END statistics-demand ===
+=== profile ===
+profile_active: no
+=== END profile ===
+=== udm-counting ===
+counting_udms: none
+=== END udm-counting ===
+=== benchmark-data ===
+version	0.17.0
+FILES	/Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log	4056729
+lines_read	10000
+lines_included	10000
+TIMING	detect/registry_build	0.013
+TIMING	detect/scan_sub_compile	0.005
+TIMING	parse/read_files	0.276
+TIMING	accumulate/initialize_buckets	0.000
+TIMING	finalize/group_similar	0.000
+TIMING	finalize/calculate_statistics	0.017
+TIMING	finalize/calculate_statistics/bucket_stats	0.000
+TIMING	finalize/calculate_statistics/population_walk	0.000
+TIMING	finalize/calculate_statistics/sort_selection	0.017
+TIMING	finalize/calculate_statistics/group_calc	0.000
+TIMING	finalize/calculate_statistics/threadpool_stats	0.000
+TIMING	finalize/calculate_statistics/untimed	0.000
+TIMING	finalize/heatmap_statistics	0.000
+TIMING	finalize/histogram_statistics	0.000
+TIMING	render/normalize_data	0.001
+TIMING	total	0.307
+MEMORY	rss_peak	35291136
+MEMORY	format_scan_subs	901120
+COUNTS	log_messages_entries	4223
+COUNTS	log_occurrences_entries	2
+COUNTS	log_stats_entries	2
+COUNTS	log_analysis_entries	1
+COUNTS	log_messages_population	4223
+COUNTS	threadpool_entries	0
+COUNTS	format_scan_subs_compiled	1
+COUNTS	format_scan_sub_cache_hits	0
+CONFIG	terminal_width	200
+CONFIG	terminal_height	24
+CONFIG	max_log_message_length	200
+CONFIG	time_bucket_size	60
+CONFIG	bucket_size_seconds	3600.00
+=== END benchmark-data ===
+
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[90m[109m     timestamp               legend                                        occurrences                                        duration                               latency statistics                 
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+ 2025-04-09 04:00 [0;31mERROR: 1403[0m    [91m[109m23.4[0m[90m[109m:[0m[0m23.4[0m[90m[109m/m[0m [90m[109m│[0m [0;31m███████████[0m                                                                                       [90m[109m│[0m  
+ 2025-04-09 05:00 [0;31mERROR: 8597[0m  [91m[109m143.3[0m[90m[109m:[0m[0m143.3[0m[90m[109m/m[0m [90m[109m│[0m [0;31m███████████████████████████████████████████████████████████████████[0m  [48;5;226m[38;5;0m[48;5;184m[38;5;0m 3.3 seconds                [0m[0m [90m[109m│[0m  [36m[49mP50:46ms  [0m [0;33mP95:53ms  [0m [93mP99:161ms [0m [0;31mP999:161ms [0m [4;37mCV:0.30[0m
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+
+[90m[109mcommand-line options: -V all --disable-progress -bs=60 --terminal-width=200 [0m
+
+  ─────────────────────────────────────────   
+  Category                            Total      [4;37mThese file(s) were processed with analysis including results between 2025-04-09 04:57 and 2025-04-09 05:12[0m
+  ─────────────────────────────────────────   
+  ERROR                               10000      [36m[37m[[0;32m√[0m[36m[37m] /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log                                           [[38;5;111m1[36m[37m][0m
+  ─────────────────────────────────────────   
+  LINES INCLUDED                      10000      [4;37mLog Formats[0m
+  LINES READ                          10000   
+  TOTAL TIME                     306.6 msec      [38;5;111m1[36m[37m thingworx_standard[0m
+  MAXIMUM MEMORY USED              33.9 MiB   
+  ─────────────────────────────────────────   
+
+ [96m[49m TOP OVERALL MESSAGES (retained for after inclusion, exclusion, time range, and duration filters)                                 Occurre.      Min      P50    P99.9     CV %         Duration [0m[96m
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+  [ERROR] [WC_MX_0K030012_Proce] [S.c.t.d.e.DSLScript] [WC_MX_0K030012.WU_000050] The following number of events have been ignor         10 
+  [ERROR] [WC_0K045012_ProcessP] [S.c.t.d.e.DSLScript] inputJson{"Action":"Create","Data":[{"ModelUID":240,"ShiftInstanceUID":nu          5 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLProcessor] Error in: PTCDTS.OperationKPI.MonitoringScheduler.CreateProductionBlocks j          3 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K002012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     43ms     44ms     58ms     0.17         145 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K004012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     44ms     48ms     50ms     0.06         142 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K004022.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     45ms     49ms     50ms     0.06         144 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K012022.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     42ms     45ms     46ms     0.05         133 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K020012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     50ms     50ms     53ms     0.03         153 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K022022.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     43ms     44ms     44ms     0.01         131 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K023012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     41ms     43ms     47ms     0.07         131 msec 
+
+

--- a/tests/profile/results/414-readphase-new/1k/summary.txt
+++ b/tests/profile/results/414-readphase-new/1k/summary.txt
@@ -1,0 +1,49 @@
+====================================================================================================
+Profile:  /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/results/414-readphase-new/1k/nytprof.out
+Script:   /Users/gregeva/Documents/GitHub/logtimeline/ltl
+Perl:     5.42.2
+CPU time: 0.1133 s (sum of exclusive times)
+Subs:     25 shown of 443 matching (from 1175 total)
+Sort:     incl time | Filter: Perl subs only
+ltl -V:   lines_read=1000  total=0.058s  rss=32 MB
+====================================================================================================
+
+Rank  Subroutine                                               Calls   Incl(s)   Excl(s)   ms/call   %Tot
+----------------------------------------------------------------------------------------------------
+   1  pipeline_parse                                               1    0.0320  0.000026    32.013   28.3
+   2  read_and_process_logs                                        1    0.0286    0.0107    28.579   25.2
+   3  get_memory_usage                                             7    0.0209    0.0001     2.985   18.4
+   4  measure_memory_structures                                    5    0.0147  0.000053     2.943   13.0
+   5  Term::ReadKey::GetTerminalSize                               1    0.0125    0.0001    12.472   11.0
+   6  pipeline_render                                              1    0.0121  0.000072    12.125   10.7
+   7  pipeline_detect                                              1    0.0112  0.000006    11.213    9.9
+   8  build_format_registry                                        1    0.0112    0.0021    11.152    9.8
+   9  format_scan_sub_resolve                                      1    0.0107  0.000014    10.661    9.4
+  10  compile_format_scan_sub                                      1    0.0106    0.0034    10.647    9.4
+  11  BEGIN@35                                                     1    0.0072    0.0003     7.155    6.3
+  12  Text::CSV::_load                                             2    0.0068  0.000043     3.397    6.0
+  13  Text::CSV::_load_pp                                          1    0.0068  0.000001     6.753    6.0
+  14  Text::CSV::BEGIN@1.1                                         1    0.0067    0.0064     6.726    5.9
+  15  BEGIN@21                                                     1    0.0066    0.0017     6.554    5.8
+  16  BEGIN@22                                                     1    0.0055    0.0017     5.543    4.9
+  17  pipeline_finalize                                            1    0.0055  0.000044     5.458    4.8
+  18  compile_format_extractor                                    34    0.0052    0.0046     0.153    4.6
+  19  __ANON__[(eval 44)[/Users/gregeva/Documents/GitHu...      1041    0.0050    0.0024     0.005    4.4
+  20  BEGIN@25                                                     1    0.0048    0.0033     4.759    4.2
+  21  XSLoader::load                                               9    0.0043    0.0043     0.479    3.8
+  22  write_index_file                                             1    0.0043    0.0001     4.299    3.8
+  23  pipeline_accumulate                                          1    0.0029  0.000043     2.887    2.5
+  24  Text::CSV_PP::print                                          3    0.0028    0.0009     0.927    2.5
+  25  calculate_all_statistics                                     1    0.0026    0.0004     2.616    2.3
+
+Note: %Tot = incl_time / 0.1133 s (total Perl CPU time)
+      Use --all to include XSubs [xs] and opcodes [op]
+      Use --sort excl to rank by exclusive time
+
+====================================================================================================
+Cross-Validation: NYTProf call counts vs ltl -V output
+----------------------------------------------------------------------------------------------------
+  read_and_process_logs                     NYTProf calls=1  ltl-V lines_read=1000
+    (called once; loops internally over lines)
+
+  [OK] All cross-validation checks within tolerance.

--- a/tests/profile/results/414-readphase-new/1k/verbose.txt
+++ b/tests/profile/results/414-readphase-new/1k/verbose.txt
@@ -1,0 +1,296 @@
+[0;37m [90m[109m
+──────────────────────────────────────────────────────────────────────────────────────────────
+   ,:: ltl ::' log timeline [0.17.0] --  by Greg Eva // geva@ptc.com // gregeva@gmail.com
+──────────────────────────────────────────────────────────────────────────────────────────────
+[0m
+
+=== runtime-config ===
+include (merged): (not set)
+exclude (merged): (not set)
+highlight (merged): (not set)
+threadpool-activity (merged): (not set)
+bucket-duration-stats-demand: 1
+message-duration-stats-demand: 1
+=== runtime-config / command-line ===
+bucket-size: 60
+=== END runtime-config / command-line ===
+=== runtime-config / environment-variable ===
+=== END runtime-config / environment-variable ===
+=== END runtime-config ===
+
+=== index-read-back ===
+index_used: no
+index_filter_signature: -
+file: /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log
+  lookup: none
+  matched_entry_date: -
+  freshness: no_entry
+  preseed_duration_min: -
+  preseed_duration_max: -
+  preseed_bytes_min: -
+  preseed_bytes_max: -
+  preseed_count_min: -
+  preseed_count_max: -
+  preseed_first_timestamp: -
+  preseed_last_timestamp: -
+=== END index-read-back ===
+=== histogram-bin-counters ===
+data_model_precision: 5 (default)
+
+consumer: summary_table
+  path: user_opt_out
+
+consumer: csv_output
+  path: feature_not_active
+
+consumer: time_bucket_stats
+  path: feature_not_active
+
+consumer: heatmap_markers
+  path: feature_not_active
+
+consumer: heatmap_cells
+  path: feature_not_active
+
+consumer: histogram_view
+  path: feature_not_active
+
+consumer: histogram_bins
+  path: feature_not_active
+=== END histogram-bin-counters ===
+=== format-detection ===
+duration_unit_override: -
+format_pin: -
+legend: 1=thingworx_standard
+files: 1
+file: /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log
+  format: thingworx_standard
+  match_type: 1
+  is_access_log: no
+  matched_lines: 1000
+  unmatched_lines: 0
+  first_match_line: 1
+  scan_attempts: 1000
+  scan_failed_attempts: 0
+  window: 0
+  sample: yes
+  sample_file_bytes: 405536
+  sample_whole_file: no
+  sample_lines: 59
+  sample_matched_lines: 59
+  sample_formats: mt1std=59
+  sample_part: 1 offset=0 bytes=8192 lines=20 avg_line=407 matched=20 first_ts="2025-04-09 04:57:45.252" last_ts="2025-04-09 04:57:45.296"
+  sample_part: 2 offset=198672 bytes=8192 lines=19 avg_line=405 matched=19 first_ts="2025-04-09 04:57:48.874" last_ts="2025-04-09 04:57:48.959"
+  sample_part: 3 offset=397344 bytes=8192 lines=20 avg_line=406 matched=20 first_ts="2025-04-09 04:57:53.021" last_ts="2025-04-09 04:57:53.230"
+  sample_us: 588.0
+  formats: thingworx_standard
+  filename_evidence: stem=- ext=- date=- index=-
+=== format-detection / scan ===
+entries: 15
+guarded: mt12,mt4,mt9
+window_size: 0
+window_fallback: 1000
+sample_parts: 3
+sample_bytes_per_part: 8192
+final_order: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+promotions: 0
+match_counts: mt1std=1000,mt10=0,mt10ir=0,mt16=0,mt1gen=0,mt2=0,mt12=0,mt4=0,mt9=0,mt3=0,mt3us=0,mt5=0,mt6=0,mt7=0,mt8=0,mt17=0,mt11=0
+variant_groups: connection_server=mt10,access_with_duration=mt3
+nomatch_scan_samples: 0
+nomatch_scan_avg_us: -
+=== END format-detection / scan ===
+=== END format-detection ===
+=== format-registry ===
+entries: 18
+scanned_entries: 17
+scan_slots: 15
+  entry: mt1std slug=thingworx_standard group=mt1std default=yes role=scanned
+  entry: mt10 slug=connection_server_standard group=connection_server default=yes role=scanned
+  entry: mt10ir slug=integration_runtime_standard group=connection_server default=no role=scanned
+  entry: mt16 slug=windchill_workgroup_manager group=mt16 default=yes role=scanned
+  entry: mt1gen slug=thingworx_standard group=mt1gen default=yes role=scanned
+  entry: mt2 slug=thingworx_rac_client group=mt2 default=yes role=scanned
+  entry: mt12 slug=tomcat_codebeamer group=mt12 default=yes role=scanned
+  entry: mt4 slug=tomcat_access_common group=mt4 default=yes role=scanned
+  entry: mt9 slug=jboss_access group=mt9 default=yes role=scanned
+  entry: mt3 slug=tomcat_access_with_duration group=access_with_duration default=yes role=scanned
+  entry: mt3us slug=httpd_access_with_duration group=access_with_duration default=no role=scanned
+  entry: mt5 slug=connection_server_json group=mt5 default=yes role=scanned
+  entry: mt6 slug=java_gc_g1 group=mt6 default=yes role=scanned
+  entry: mt7 slug=tw_analytics_v2 group=mt7 default=yes role=scanned
+  entry: mt8 slug=tw_analytics_worker group=mt8 default=yes role=scanned
+  entry: mt17 slug=windchill_method_server group=mt17 default=yes role=scanned
+  entry: mt11 slug=tw_edge_c_sdk group=mt11 default=yes role=scanned
+  entry: csv slug=csv group=csv default=yes role=stateful
+variant_groups: connection_server=mt10,access_with_duration=mt3
+  group: connection_server slot=1 default=mt10 members=mt10,mt10ir
+  group: access_with_duration slot=8 default=mt3 members=mt3,mt3us
+static_order: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+  ancestors: mt1std <- -
+  ancestors: connection_server <- -
+  ancestors: mt16 <- -
+  ancestors: mt1gen <- mt1std
+  ancestors: mt2 <- mt1std,connection_server,mt16,mt1gen
+  ancestors: mt12 <- -
+  ancestors: mt4 <- -
+  ancestors: mt9 <- -
+  ancestors: access_with_duration <- mt12,mt4,mt9
+  ancestors: mt5 <- -
+  ancestors: mt6 <- -
+  ancestors: mt7 <- -
+  ancestors: mt8 <- mt1std,connection_server,mt1gen
+  ancestors: mt17 <- -
+  ancestors: mt11 <- -
+scan_subs_compiled: 1
+scan_sub_cache_hits: 0
+scan_subs_rss_bytes: 966656
+scan_sub_rss_measured: yes
+compiled_orders: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+=== END format-registry ===
+=== heatmap-palette ===
+heatmap_active: no
+metric: n/a
+light_bg: 0
+light_bg_source: default
+color_name: n/a
+gradient_dark: n/a
+gradient_light: n/a
+gradient_active: n/a
+=== END heatmap-palette ===
+=== csv-output ===
+csv_active: no
+=== END csv-output ===
+=== percentile-algorithm ===
+=== percentile-algorithm / histogram ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / histogram ===
+=== percentile-algorithm / heatmap ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / heatmap ===
+=== percentile-algorithm / message-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / message-stats ===
+=== percentile-algorithm / bucket-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / bucket-stats ===
+=== END percentile-algorithm ===
+=== statistics-demand ===
+store: bucket
+  store_demand: 1
+  population: 0
+  group terminal_core: demanded=1 consumers=timeline-latency-column
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 0
+  group_calc terminal_core: computed=0 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=0 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=0 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=0 ineligible=0
+store: message
+  store_demand: 1
+  population: 998
+  group terminal_core: demanded=1 consumers=messages-table
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 0
+  group_calc terminal_core: computed=0 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=0 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=0 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=0 ineligible=0
+threadpool_population: 0
+=== END statistics-demand ===
+=== profile ===
+profile_active: no
+=== END profile ===
+=== udm-counting ===
+counting_udms: none
+=== END udm-counting ===
+=== benchmark-data ===
+version	0.17.0
+FILES	/Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log	405536
+lines_read	1000
+lines_included	1000
+TIMING	detect/registry_build	0.013
+TIMING	detect/scan_sub_compile	0.005
+TIMING	parse/read_files	0.040
+TIMING	accumulate/initialize_buckets	0.000
+TIMING	finalize/group_similar	0.000
+TIMING	finalize/calculate_statistics	0.005
+TIMING	finalize/calculate_statistics/bucket_stats	0.000
+TIMING	finalize/calculate_statistics/population_walk	0.000
+TIMING	finalize/calculate_statistics/sort_selection	0.005
+TIMING	finalize/calculate_statistics/group_calc	0.000
+TIMING	finalize/calculate_statistics/threadpool_stats	0.000
+TIMING	finalize/calculate_statistics/untimed	0.000
+TIMING	finalize/heatmap_statistics	0.000
+TIMING	finalize/histogram_statistics	0.000
+TIMING	render/normalize_data	0.000
+TIMING	total	0.058
+MEMORY	rss_peak	33259520
+MEMORY	format_scan_subs	966656
+COUNTS	log_messages_entries	998
+COUNTS	log_occurrences_entries	1
+COUNTS	log_stats_entries	1
+COUNTS	log_analysis_entries	0
+COUNTS	log_messages_population	998
+COUNTS	threadpool_entries	0
+COUNTS	format_scan_subs_compiled	1
+COUNTS	format_scan_sub_cache_hits	0
+CONFIG	terminal_width	200
+CONFIG	terminal_height	24
+CONFIG	max_log_message_length	200
+CONFIG	time_bucket_size	60
+CONFIG	bucket_size_seconds	3600.00
+=== END benchmark-data ===
+
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[90m[109m     timestamp              legend                                                                                   occurrences                                                                        
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+ 2025-04-09 04:00 [0;31mERROR: 1000[0m  [91m[109m16.7[0m[90m[109m:[0m[0m16.7[0m[90m[109m/m[0m [90m[109m│[0m [0;31m██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████[0m 
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+
+[90m[109mcommand-line options: -V all --disable-progress -bs=60 --terminal-width=200 [0m
+
+  ─────────────────────────────────────────   
+  Category                            Total      [4;37mThese file(s) were processed with analysis including results between 2025-04-09 04:57 and 2025-04-09 04:57[0m
+  ─────────────────────────────────────────   
+  ERROR                                1000      [36m[37m[[0;32m√[0m[36m[37m] /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log                                            [[38;5;111m1[36m[37m][0m
+  ─────────────────────────────────────────   
+  LINES INCLUDED                       1000      [4;37mLog Formats[0m
+  LINES READ                           1000   
+  TOTAL TIME                      57.7 msec      [38;5;111m1[36m[37m thingworx_standard[0m
+  MAXIMUM MEMORY USED              31.9 MiB   
+  ─────────────────────────────────────────   
+
+ [96m[49m TOP OVERALL MESSAGES (retained for after inclusion, exclusion, time range, and duration filters)                                                                                           Occurre. [0m[96m
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+  [ERROR] [WC_MX_0K030012_Proce] [S.c.t.d.e.DSLScript] [WC_MX_0K030012.WU_000050] The following number of events have been ignored because no running job order was found: production even          3 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] WC_MX_0K005012.VP_000000 - ProductionDataLoss_PacemakerWU:70.0 - Error: For AX Job Order Automatic JobOrder is not needed Joborder = Li          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000001] does not has property: [ScrapCode] at Service: [GetPTCAutomationProperties] , Error: [JavaException:           1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000001] does not has property: [ScrapQuantity] at Service: [GetPTCAutomationProperties] , Error: [JavaExcepti          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000001] does not has property: [SpeedLossTag] at Service: [GetPTCAutomationProperties] , Error: [JavaExceptio          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000005] does not has property: [ScrapCode] at Service: [GetPTCAutomationProperties] , Error: [JavaException:           1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000005] does not has property: [ScrapQuantity] at Service: [GetPTCAutomationProperties] , Error: [JavaExcepti          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000005] does not has property: [SpeedLossTag] at Service: [GetPTCAutomationProperties] , Error: [JavaExceptio          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000010_A] does not has property: [ScrapCode] at Service: [GetPTCAutomationProperties] , Error: [JavaException          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000010_A] does not has property: [ScrapQuantity] at Service: [GetPTCAutomationProperties] , Error: [JavaExcep          1 
+
+

--- a/tests/profile/results/414-readphase-new/analysis.md
+++ b/tests/profile/results/414-readphase-new/analysis.md
@@ -1,0 +1,95 @@
+# #414 read-phase regression — profile analysis (ScriptLog, 1k / 10k profiles, 100k wall-clock, bisection)
+
+## Hypothesis
+`read_and_process_logs` pays a higher per-line cost on ScriptLog under the generated
+scan sub than under the v0.16.0 inline cascade; expected call/iteration count = lines read.
+
+## Method
+- Construct: `logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.2025-04-09.1.log`, standard
+  scenario shape (`--disable-progress -bs=60 --terminal-width=200`), samples 1k and 10k.
+- Arms: 0.17.0 branch head (`414-readphase-new`, at release/0.17.0 `30371a4`, carries #413)
+  vs v0.16.0 detached worktree (`414-readphase-old`), same Perl 5.42.2, same machine.
+- Cross-validation: `lines_read` 1000/10000 both arms; loop-statement counts 10000 both arms.
+
+## What NYTProf showed (10k)
+
+`read_and_process_logs` incl 0.1632 s (old) → 0.1757 s (new), +7.7%. Decomposed:
+
+| component | old | new |
+|---|---|---|
+| per-line: excl + CORE:match + CORE:subst + readline (+ scan sub, new) | 0.1625 | 0.1633 |
+| fixed per file/run: `format_scan_sub_resolve` (lazy compile, #413) + `select_format_variants` + `sample_file_for_detection` | — | 0.0123 |
+
+- Regex work is equal: the ScriptLog pattern costs 0.0310 s on the old cascade's
+  `if ($csv_detected)` line and 0.0319 s on the scan sub's L128. The old cascade ran
+  50,273 `CORE:match` calls (5/line) vs the new path's 30,616 (3/line) — the reduction
+  is small on ScriptLog because this format sat early in the old cascade, unlike access
+  logs, which now skip several failed tries per line (their −10–15%).
+- The new per-line machinery the old path did not have: the sub call
+  (`$format_scan_sub->($_)` 0.0028 s), the record return (`return $entries[0]` 0.0075 s),
+  and the caller-side unpack — ~1 µs/line under the profiler, offset at 10k by the
+  two fewer regex tries.
+- Statement times inside the loop are otherwise the same on both arms
+  (`grep { $_ eq $category_bucket } @log_levels` 0.0087 → 0.0124 is the one outlier).
+
+## Cross-validation
+NYTProf loop counts 10,000 == `lines_read` 10,000 (both arms). Scan sub called 10,000×
++ 41 detection-sample calls (`sample_file_for_detection`). Clean.
+
+## Diagnosis (provisional at 10k)
+Under NYTProf the per-line cost is equal to within 0.5%; the whole +12 ms delta is fixed
+detection/compile cost, which is invisible at 460 MB. NYTProf under-reports exactly the
+cost the new path added — sub entry/exit, list return, record unpack (#58 finding F9:
+prototype-vs-production +0.8–2.2 s/M lines for per-line closures) — so the profiler
+cannot resolve a +4–6% wall-clock delta that is ~0.5 µs/line. The 100k stage must be a
+wall-clock comparison (median-of-3, both binaries, `-V benchmark-data`) rather than
+another NYTProf run; if it reproduces the +4–6%, attribution is the per-line call/return
+shape of the generated scan sub, not the regex.
+
+## Surprises
+- `format_scan_sub_resolve` (the #413 lazy compile) now lands inside `parse/read_files`
+  timing — 11 ms profiled, ~4 ms unprofiled (`detect/scan_sub_compile`).
+- `extract-profile.pl --lines` reports "no line-level data" although the profile carries
+  it (`line_time_data(['line'])` works); the script's line accessor needs a look.
+
+## 100k wall-clock stage and bisection (2026-08-24)
+
+Wall-clock, `head -100000` of the same file (40.6 MB), `--disable-progress -V benchmark-data
+--terminal-width 200 -bs 60`, median-of-3 ABAB: `parse/read_files` **0.874 s (0.869–0.875)
+→ 0.923 s (0.921–0.925), +5.6%**, reproducing the benchmark's +4–6%; ≈0.44 µs/line net of
+~5 ms fixed cost. #58's own blessing battery had pure-scriptlog at −1.5% vs the pre-registry
+cascade, so the cost landed after #58 merged. Bisection over the release-branch merge
+commits (`ltl` at each commit, same construct, 3 runs sorted):
+
+| merge | issue | read_files (s) |
+|---|---|---|
+| a78ec23 | #58 format registry | 0.864 0.872 0.875 |
+| 390e441 | #23 umbrella docs | 0.860 0.865 0.878 |
+| **3e6dc3a** | **#382 GC Pause Remark/Cleanup** | **0.896 0.896 0.919** |
+| c2a2ea9 / ab264c8 / bcb4033 | #388 / #384 / #400 | 0.885–0.902 |
+| **ab17cfc** | **#396 Windchill method-server format** | **0.910 0.911 0.919** |
+| 20830ae … 3d2d5b8 | #395 … #422 (head) | 0.904–0.937 |
+
+## Diagnosis
+
+`read_and_process_logs` evaluates `unless (grep { $_ eq $category_bucket } @log_levels)`
+on every line; Perl's `grep` never short-circuits, so the cost is one string compare per
+list element per line. `@log_levels` grew 31 → 49 entries: +8 in #382 (Pause Remark /
+Pause Cleanup / To-space exhausted / Using G1, each with its `-HL` twin) and +10 in #396
+(CONFIG / CREATE / DESTROY / START / FINISH, likewise). Microbenchmark (1M iterations ×3,
+`$category_bucket = 'INFO'`): grep over 31 = 0.52 µs, over 49 = 1.13 µs (+0.61 µs/line);
+a hash `exists` is ~0.03 µs. The measured +0.44–0.49 µs/line sits inside that constant.
+The two bisection steps (+3.5% at #382, +3% at #396) are the two list growths.
+
+Why the pattern in the benchmark: every format pays it, but access logs gained 10–15% from
+the registry's regex savings (they sat late in the old cascade) which swamps it; ScriptLog
+sat early, gained ~nothing from the registry, and shows the list growth undiluted. Not a
+scan-path cost at all — #414's original title hypothesis (registry scan path) was wrong and the issue has been reframed; the registry is exonerated.
+
+Other `@log_levels` consumers: `resolve_csv_column_family()` (CSV output, per column) and
+four per-bucket `foreach` loops in render — none per-line, none in the stats phase, so this
+does not explain #415.
+
+Candidate fix (not implemented): a `%log_level_set` built once beside `@log_levels` and an
+`exists` test in the loop — removes the whole 1.1 µs/line, not just the 0.6 µs regression
+(~12% of ScriptLog's ~9 µs/line read cost).

--- a/tests/profile/results/414-readphase-old/10k/summary.txt
+++ b/tests/profile/results/414-readphase-old/10k/summary.txt
@@ -1,0 +1,49 @@
+====================================================================================================
+Profile:  /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/results/414-readphase-old/10k/nytprof.out
+Script:   /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/ltl
+Perl:     5.42.2
+CPU time: 0.2378 s (sum of exclusive times)
+Subs:     25 shown of 382 matching (from 1102 total)
+Sort:     incl time | Filter: Perl subs only
+ltl -V:   lines_read=10000  total=0.268s  rss=30 MB
+====================================================================================================
+
+Rank  Subroutine                                               Calls   Incl(s)   Excl(s)   ms/call   %Tot
+----------------------------------------------------------------------------------------------------
+   1  read_and_process_logs                                        1    0.1632    0.1214   163.188   68.6
+   2  measure_memory_structures                                    5    0.0151  0.000048     3.019    6.3
+   3  get_memory_usage                                             5    0.0150    0.0001     3.010    6.3
+   4  Term::ReadKey::GetTerminalSize                               1    0.0120    0.0001    11.961    5.0
+   5  calculate_all_statistics                                     1    0.0086    0.0010     8.582    3.6
+   6  BEGIN@51                                                     1    0.0067    0.0003     6.683    2.8
+   7  Text::CSV::_load                                             2    0.0064  0.000040     3.181    2.7
+   8  Text::CSV::_load_pp                                          1    0.0063  0.000002     6.324    2.7
+   9  Text::CSV::BEGIN@1.1                                         1    0.0063    0.0061     6.298    2.6
+  10  BEGIN@38                                                     1    0.0051    0.0013     5.094    2.1
+  11  BEGIN@39                                                     1    0.0045    0.0014     4.503    1.9
+  12  write_index_file                                             1    0.0043    0.0001     4.315    1.8
+  13  BEGIN@42                                                     1    0.0040    0.0029     4.038    1.7
+  14  XSLoader::load                                               9    0.0038    0.0038     0.418    1.6
+  15  Text::CSV_PP::print                                          3    0.0028    0.0009     0.932    1.2
+  16  BEGIN@41                                                     1    0.0019    0.0010     1.929    0.8
+  17  BEGIN@43                                                     1    0.0016    0.0013     1.648    0.7
+  18  adapt_to_command_line_options                                1    0.0016  0.000095     1.611    0.7
+  19  Tie::Hash::BEGIN@190                                         1    0.0016    0.0013     1.579    0.7
+  20  BEGIN@49                                                     1    0.0014    0.0010     1.423    0.6
+  21  Exporter::import                                            33    0.0014    0.0008     0.041    0.6
+  22  Time::Piece::BEGIN@6                                         1    0.0012    0.0003     1.230    0.5
+  23  Getopt::Long::GetOptionsFromArray                            2    0.0011    0.0003     0.556    0.5
+  24  BEGIN@37                                                     1    0.0011    0.0011     1.109    0.5
+  25  POSIX::BEGIN@11                                              1    0.0008    0.0002     0.803    0.3
+
+Note: %Tot = incl_time / 0.2378 s (total Perl CPU time)
+      Use --all to include XSubs [xs] and opcodes [op]
+      Use --sort excl to rank by exclusive time
+
+====================================================================================================
+Cross-Validation: NYTProf call counts vs ltl -V output
+----------------------------------------------------------------------------------------------------
+  read_and_process_logs                     NYTProf calls=1  ltl-V lines_read=10000
+    (called once; loops internally over lines)
+
+  [OK] All cross-validation checks within tolerance.

--- a/tests/profile/results/414-readphase-old/10k/verbose.txt
+++ b/tests/profile/results/414-readphase-old/10k/verbose.txt
@@ -1,0 +1,206 @@
+[0;37m [90m[109m
+──────────────────────────────────────────────────────────────────────────────────────────────
+   ,:: ltl ::' log timeline [0.16.0] --  by Greg Eva // geva@ptc.com // gregeva@gmail.com
+──────────────────────────────────────────────────────────────────────────────────────────────
+[0m
+
+=== runtime-config ===
+include (merged): (not set)
+exclude (merged): (not set)
+highlight (merged): (not set)
+threadpool-activity (merged): (not set)
+bucket-duration-stats-demand: 1
+message-duration-stats-demand: 1
+=== runtime-config / command-line ===
+bucket-size: 60
+=== END runtime-config / command-line ===
+=== runtime-config / environment-variable ===
+=== END runtime-config / environment-variable ===
+=== END runtime-config ===
+
+=== index-read-back ===
+index_used: no
+index_filter_signature: -
+file: /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log
+  lookup: none
+  matched_entry_date: -
+  freshness: no_entry
+  preseed_duration_min: -
+  preseed_duration_max: -
+  preseed_bytes_min: -
+  preseed_bytes_max: -
+  preseed_count_min: -
+  preseed_count_max: -
+  preseed_first_timestamp: -
+  preseed_last_timestamp: -
+=== END index-read-back ===
+=== histogram-bin-counters ===
+data_model_precision: 5 (default)
+
+consumer: summary_table
+  path: user_opt_out
+
+consumer: csv_output
+  path: feature_not_active
+
+consumer: time_bucket_stats
+  path: user_opt_out
+
+consumer: heatmap_markers
+  path: feature_not_active
+
+consumer: heatmap_cells
+  path: feature_not_active
+
+consumer: histogram_view
+  path: feature_not_active
+
+consumer: histogram_bins
+  path: feature_not_active
+=== END histogram-bin-counters ===
+=== format-detection ===
+duration_unit_override: -
+files: 1
+file: /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log
+  format: thingworx_standard
+  match_type: 1
+  is_access_log: yes
+  matched_lines: 10000
+  unmatched_lines: 0
+  first_match_line: 1
+=== END format-detection ===
+=== heatmap-palette ===
+heatmap_active: no
+metric: n/a
+light_bg: 0
+light_bg_source: default
+color_name: n/a
+gradient_dark: n/a
+gradient_light: n/a
+gradient_active: n/a
+=== END heatmap-palette ===
+=== csv-output ===
+csv_active: no
+=== END csv-output ===
+=== percentile-algorithm ===
+=== percentile-algorithm / histogram ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / histogram ===
+=== percentile-algorithm / heatmap ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / heatmap ===
+=== percentile-algorithm / message-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / message-stats ===
+=== percentile-algorithm / bucket-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / bucket-stats ===
+=== END percentile-algorithm ===
+=== statistics-demand ===
+store: bucket
+  store_demand: 1
+  group terminal_core: demanded=1 consumers=timeline-latency-column
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 1
+  group_calc terminal_core: computed=1 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=1 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=1 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=1 ineligible=0
+store: message
+  store_demand: 1
+  group terminal_core: demanded=1 consumers=messages-table
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 7
+  group_calc terminal_core: computed=7 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=7 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=7 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=0 ineligible=7
+=== END statistics-demand ===
+=== profile ===
+profile_active: no
+=== END profile ===
+=== udm-counting ===
+counting_udms: none
+=== END udm-counting ===
+=== benchmark-data ===
+version	0.16.0
+FILES	/private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log	4056729
+lines_read	10000
+lines_included	10000
+TIMING	read_files	0.250
+TIMING	initialize_buckets	0.000
+TIMING	group_similar	0.000
+TIMING	calculate_statistics	0.017
+TIMING	heatmap_statistics	0.000
+TIMING	histogram_statistics	0.000
+TIMING	normalize_data	0.001
+TIMING	total	0.268
+MEMORY	rss_peak	31539200
+COUNTS	log_messages_entries	4223
+COUNTS	log_occurrences_entries	2
+COUNTS	log_stats_entries	2
+CONFIG	terminal_width	200
+CONFIG	terminal_height	24
+CONFIG	max_log_message_length	200
+CONFIG	time_bucket_size	60
+CONFIG	bucket_size_seconds	3600.00
+=== END benchmark-data ===
+
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[90m[109m     timestamp               legend                                        occurrences                                        duration                               latency statistics                 
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+ 2025-04-09 04:00 [0;31mERROR: 1403[0m    [91m[109m23.4[0m[90m[109m:[0m[0m23.4[0m[90m[109m/m[0m [90m[109m│[0m [0;31m███████████[0m                                                                                       [90m[109m│[0m  
+ 2025-04-09 05:00 [0;31mERROR: 8597[0m  [91m[109m143.3[0m[90m[109m:[0m[0m143.3[0m[90m[109m/m[0m [90m[109m│[0m [0;31m███████████████████████████████████████████████████████████████████[0m  [48;5;226m[38;5;0m[48;5;184m[38;5;0m 3.3 seconds                [0m[0m [90m[109m│[0m  [36m[49mP50:46ms  [0m [0;33mP95:53ms  [0m [93mP99:161ms [0m [0;31mP999:161ms [0m [4;37mCV:0.30[0m
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+
+[90m[109mcommand-line options: -V all --disable-progress -bs=60 --terminal-width=200 [0m
+
+  ─────────────────────────────────────────   
+  Category                            Total      [4;37mThese file(s) were processed with analysis including results between 2025-04-09 04:57 and 2025-04-09 05:12[0m
+  ─────────────────────────────────────────   
+  ERROR                               10000      [36m[37m[[0;32m√[0m[36m[37m] /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c...chpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-10000.log[0m
+  ─────────────────────────────────────────   
+  LINES INCLUDED                      10000   
+  LINES READ                          10000   
+  FILE PROCESSING TIME           250.5 msec   
+  INITIALIZE EMPTY BUCKETS          30 usec   
+  CALCULATE STATISTICS            17.1 msec   
+  SCALE DATA TO TERMINAL           613 usec   
+  TOTAL TIME                     268.2 msec   
+  MAXIMUM MEMORY USED              30.2 MiB   
+  ─────────────────────────────────────────   
+
+ [96m[49m TOP OVERALL MESSAGES (retained for after inclusion, exclusion, time range, and duration filters)                                 Occurre.      Min      P50    P99.9     CV %         Duration [0m[96m
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+  [ERROR] [WC_MX_0K030012_Proce] [S.c.t.d.e.DSLScript] [WC_MX_0K030012.WU_000050] The following number of events have been ignor         10 
+  [ERROR] [WC_0K045012_ProcessP] [S.c.t.d.e.DSLScript] inputJson{"Action":"Create","Data":[{"ModelUID":240,"ShiftInstanceUID":nu          5 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLProcessor] Error in: PTCDTS.OperationKPI.MonitoringScheduler.CreateProductionBlocks j          3 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K002012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     43ms     44ms     58ms     0.17         145 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K004012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     44ms     48ms     50ms     0.06         142 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K004022.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     45ms     49ms     50ms     0.06         144 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K012022.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     42ms     45ms     46ms     0.05         133 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K020012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     50ms     50ms     53ms     0.03         153 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K022022.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     43ms     44ms     44ms     0.01         131 msec 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] FAILED - WC_0K023012.VP_000000 UpdateShiftInstanceOnShiftChange - durationMS=          3     41ms     43ms     47ms     0.07         131 msec 
+
+

--- a/tests/profile/results/414-readphase-old/1k/summary.txt
+++ b/tests/profile/results/414-readphase-old/1k/summary.txt
@@ -1,0 +1,49 @@
+====================================================================================================
+Profile:  /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/results/414-readphase-old/1k/nytprof.out
+Script:   /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/ltl
+Perl:     5.42.2
+CPU time: 0.0861 s (sum of exclusive times)
+Subs:     25 shown of 378 matching (from 1101 total)
+Sort:     incl time | Filter: Perl subs only
+ltl -V:   lines_read=1000  total=0.030s  rss=28 MB
+====================================================================================================
+
+Rank  Subroutine                                               Calls   Incl(s)   Excl(s)   ms/call   %Tot
+----------------------------------------------------------------------------------------------------
+   1  read_and_process_logs                                        1    0.0161    0.0119    16.078   18.7
+   2  measure_memory_structures                                    5    0.0134  0.000046     2.684   15.6
+   3  get_memory_usage                                             5    0.0134  0.000097     2.675   15.5
+   4  Term::ReadKey::GetTerminalSize                               1    0.0118    0.0001    11.838   13.7
+   5  BEGIN@51                                                     1    0.0071    0.0003     7.077    8.2
+   6  Text::CSV::_load                                             2    0.0067  0.000046     3.368    7.8
+   7  Text::CSV::_load_pp                                          1    0.0067  0.000001     6.694    7.8
+   8  Text::CSV::BEGIN@1.1                                         1    0.0067    0.0064     6.664    7.7
+   9  BEGIN@38                                                     1    0.0063    0.0017     6.332    7.4
+  10  BEGIN@39                                                     1    0.0055    0.0017     5.457    6.3
+  11  BEGIN@42                                                     1    0.0045    0.0032     4.502    5.2
+  12  write_index_file                                             1    0.0043  0.000094     4.304    5.0
+  13  XSLoader::load                                               9    0.0042    0.0042     0.469    4.9
+  14  Text::CSV_PP::print                                          3    0.0028    0.0009     0.921    3.2
+  15  calculate_all_statistics                                     1    0.0025    0.0004     2.508    2.9
+  16  BEGIN@41                                                     1    0.0022    0.0011     2.248    2.6
+  17  Tie::Hash::BEGIN@190                                         1    0.0019    0.0016     1.914    2.2
+  18  BEGIN@43                                                     1    0.0018    0.0015     1.817    2.1
+  19  adapt_to_command_line_options                                1    0.0017    0.0001     1.663    1.9
+  20  Exporter::import                                            33    0.0016    0.0009     0.048    1.8
+  21  BEGIN@49                                                     1    0.0015    0.0011     1.522    1.8
+  22  Time::Piece::BEGIN@6                                         1    0.0015    0.0003     1.485    1.7
+  23  BEGIN@37                                                     1    0.0013    0.0013     1.338    1.6
+  24  Getopt::Long::GetOptionsFromArray                            2    0.0011    0.0003     0.572    1.3
+  25  POSIX::BEGIN@11                                              1    0.0010    0.0002     0.980    1.1
+
+Note: %Tot = incl_time / 0.0861 s (total Perl CPU time)
+      Use --all to include XSubs [xs] and opcodes [op]
+      Use --sort excl to rank by exclusive time
+
+====================================================================================================
+Cross-Validation: NYTProf call counts vs ltl -V output
+----------------------------------------------------------------------------------------------------
+  read_and_process_logs                     NYTProf calls=1  ltl-V lines_read=1000
+    (called once; loops internally over lines)
+
+  [OK] All cross-validation checks within tolerance.

--- a/tests/profile/results/414-readphase-old/1k/verbose.txt
+++ b/tests/profile/results/414-readphase-old/1k/verbose.txt
@@ -1,0 +1,205 @@
+[0;37m [90m[109m
+──────────────────────────────────────────────────────────────────────────────────────────────
+   ,:: ltl ::' log timeline [0.16.0] --  by Greg Eva // geva@ptc.com // gregeva@gmail.com
+──────────────────────────────────────────────────────────────────────────────────────────────
+[0m
+
+=== runtime-config ===
+include (merged): (not set)
+exclude (merged): (not set)
+highlight (merged): (not set)
+threadpool-activity (merged): (not set)
+bucket-duration-stats-demand: 1
+message-duration-stats-demand: 1
+=== runtime-config / command-line ===
+bucket-size: 60
+=== END runtime-config / command-line ===
+=== runtime-config / environment-variable ===
+=== END runtime-config / environment-variable ===
+=== END runtime-config ===
+
+=== index-read-back ===
+index_used: no
+index_filter_signature: -
+file: /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log
+  lookup: none
+  matched_entry_date: -
+  freshness: no_entry
+  preseed_duration_min: -
+  preseed_duration_max: -
+  preseed_bytes_min: -
+  preseed_bytes_max: -
+  preseed_count_min: -
+  preseed_count_max: -
+  preseed_first_timestamp: -
+  preseed_last_timestamp: -
+=== END index-read-back ===
+=== histogram-bin-counters ===
+data_model_precision: 5 (default)
+
+consumer: summary_table
+  path: user_opt_out
+
+consumer: csv_output
+  path: feature_not_active
+
+consumer: time_bucket_stats
+  path: feature_not_active
+
+consumer: heatmap_markers
+  path: feature_not_active
+
+consumer: heatmap_cells
+  path: feature_not_active
+
+consumer: histogram_view
+  path: feature_not_active
+
+consumer: histogram_bins
+  path: feature_not_active
+=== END histogram-bin-counters ===
+=== format-detection ===
+duration_unit_override: -
+files: 1
+file: /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log
+  format: thingworx_standard
+  match_type: 1
+  is_access_log: no
+  matched_lines: 1000
+  unmatched_lines: 0
+  first_match_line: 1
+=== END format-detection ===
+=== heatmap-palette ===
+heatmap_active: no
+metric: n/a
+light_bg: 0
+light_bg_source: default
+color_name: n/a
+gradient_dark: n/a
+gradient_light: n/a
+gradient_active: n/a
+=== END heatmap-palette ===
+=== csv-output ===
+csv_active: no
+=== END csv-output ===
+=== percentile-algorithm ===
+=== percentile-algorithm / histogram ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / histogram ===
+=== percentile-algorithm / heatmap ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / heatmap ===
+=== percentile-algorithm / message-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / message-stats ===
+=== percentile-algorithm / bucket-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / bucket-stats ===
+=== END percentile-algorithm ===
+=== statistics-demand ===
+store: bucket
+  store_demand: 1
+  group terminal_core: demanded=1 consumers=timeline-latency-column
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 0
+  group_calc terminal_core: computed=0 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=0 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=0 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=0 ineligible=0
+store: message
+  store_demand: 1
+  group terminal_core: demanded=1 consumers=messages-table
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 0
+  group_calc terminal_core: computed=0 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=0 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=0 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=0 ineligible=0
+=== END statistics-demand ===
+=== profile ===
+profile_active: no
+=== END profile ===
+=== udm-counting ===
+counting_udms: none
+=== END udm-counting ===
+=== benchmark-data ===
+version	0.16.0
+FILES	/private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c025a74-1b22-41cf-bd3d-4322ed792c77/scratchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log	405536
+lines_read	1000
+lines_included	1000
+TIMING	read_files	0.025
+TIMING	initialize_buckets	0.000
+TIMING	group_similar	0.000
+TIMING	calculate_statistics	0.005
+TIMING	heatmap_statistics	0.000
+TIMING	histogram_statistics	0.000
+TIMING	normalize_data	0.001
+TIMING	total	0.030
+MEMORY	rss_peak	29229056
+COUNTS	log_messages_entries	998
+COUNTS	log_occurrences_entries	1
+COUNTS	log_stats_entries	1
+CONFIG	terminal_width	200
+CONFIG	terminal_height	24
+CONFIG	max_log_message_length	200
+CONFIG	time_bucket_size	60
+CONFIG	bucket_size_seconds	3600.00
+=== END benchmark-data ===
+
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[90m[109m     timestamp              legend                                                                                   occurrences                                                                        
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+ 2025-04-09 04:00 [0;31mERROR: 1000[0m  [91m[109m16.7[0m[90m[109m:[0m[0m16.7[0m[90m[109m/m[0m [90m[109m│[0m [0;31m██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████[0m 
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+
+[90m[109mcommand-line options: -V all --disable-progress -bs=60 --terminal-width=200 [0m
+
+  ─────────────────────────────────────────   
+  Category                            Total      [4;37mThese file(s) were processed with analysis including results between 2025-04-09 04:57 and 2025-04-09 04:57[0m
+  ─────────────────────────────────────────   
+  ERROR                                1000      [36m[37m[[0;32m√[0m[36m[37m] /private/tmp/claude-501/-Users-gregeva-Documents-GitHub-logtimeline/9c...tchpad/wt-v0.16.0/tests/profile/samples/ScriptLog.2025-04-09.1-1000.log[0m
+  ─────────────────────────────────────────   
+  LINES INCLUDED                       1000   
+  LINES READ                           1000   
+  FILE PROCESSING TIME            24.6 msec   
+  INITIALIZE EMPTY BUCKETS          27 usec   
+  CALCULATE STATISTICS             4.9 msec   
+  SCALE DATA TO TERMINAL           506 usec   
+  TOTAL TIME                        30 msec   
+  MAXIMUM MEMORY USED                28 MiB   
+  ─────────────────────────────────────────   
+
+ [96m[49m TOP OVERALL MESSAGES (retained for after inclusion, exclusion, time range, and duration filters)                                                                                           Occurre. [0m[96m
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+  [ERROR] [WC_MX_0K030012_Proce] [S.c.t.d.e.DSLScript] [WC_MX_0K030012.WU_000050] The following number of events have been ignored because no running job order was found: production even          3 
+  [ERROR] [TWEventProcessor] [S.c.t.d.e.DSLScript] WC_MX_0K005012.VP_000000 - ProductionDataLoss_PacemakerWU:70.0 - Error: For AX Job Order Automatic JobOrder is not needed Joborder = Li          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000001] does not has property: [ScrapCode] at Service: [GetPTCAutomationProperties] , Error: [JavaException:           1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000001] does not has property: [ScrapQuantity] at Service: [GetPTCAutomationProperties] , Error: [JavaExcepti          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000001] does not has property: [SpeedLossTag] at Service: [GetPTCAutomationProperties] , Error: [JavaExceptio          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000005] does not has property: [ScrapCode] at Service: [GetPTCAutomationProperties] , Error: [JavaException:           1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000005] does not has property: [ScrapQuantity] at Service: [GetPTCAutomationProperties] , Error: [JavaExcepti          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000005] does not has property: [SpeedLossTag] at Service: [GetPTCAutomationProperties] , Error: [JavaExceptio          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000010_A] does not has property: [ScrapCode] at Service: [GetPTCAutomationProperties] , Error: [JavaException          1 
+  [ERROR] [WC_0K001012_ProcessP] [S.c.t.d.e.DSLScript] Thing [WC_0K001012.WU_000010_A] does not has property: [ScrapQuantity] at Service: [GetPTCAutomationProperties] , Error: [JavaExcep          1 
+
+

--- a/tests/profile/results/414-readphase-old/analysis.md
+++ b/tests/profile/results/414-readphase-old/analysis.md
@@ -1,0 +1,1 @@
+# #414 read-phase regression — v0.16.0 control arm (see 414-readphase-new/analysis.md for the analysis)


### PR DESCRIPTION
Fixes #414.

`read_and_process_logs` gated every line on `grep { $_ eq $category_bucket } @log_levels`. `grep` never short-circuits, so the gate cost one string compare per list element per line — and `@log_levels` grew 31 → 49 entries on this release (#382, #396), which is the read-phase regression on non-access formats in the v0.17.0-first benchmark. A `%log_level_set` built once beside `@log_levels` makes the gate an `exists` lookup.

- 100k ScriptLog sample, median-of-3: `read_files` 0.930 s → 0.795 s (−14.5%; −9.5% vs v0.16.0). Output byte-identical.
- Attribution record (1k/10k NYTProf, 100k wall-clock, bisection over release merges): `tests/profile/results/414-readphase-new/analysis.md`.
- Completion gate on this commit: all 22 `tests/validate-*.sh` exit 0 with assertions counted; benchmark `single-day-access-log-standard` vs v0.16.0: total −22.1%, rss_peak +1.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6h8wVd7JQWGRM7M7SZnYE