### PR TITLE
compare-results.sh: stage/category rollups and new-metric surfacing (#416)

### DIFF
--- a/tests/baseline/compare-results.sh
+++ b/tests/baseline/compare-results.sh
@@ -4,7 +4,9 @@
 # Usage: ./compare-results.sh [summary|detailed|table|all] [--markdown] [--save] <baseline.tsv> <current.tsv>
 #
 # Modes:
-#   summary  — timing total and RSS peak per test case (default)
+#   summary  — per-stage timing rollup, per-category memory rollup, metrics
+#              new to the current version, then timing total and RSS peak
+#              per test case (default)
 #   detailed — all timing stages and per-structure memory
 #   table    — matrix view: file selections x scenarios, time and memory deltas
 #   all      — summary + detailed + table
@@ -16,7 +18,8 @@
 # MAINTENANCE — renaming a TIMING row is a breaking change to this script.
 # Committed baselines are kept for years and carry whatever labels their
 # release emitted. When a TIMING label in ltl is renamed, add an
-# old -> new entry to the tmap block below IN THE SAME COMMIT; otherwise
+# old -> new entry to TIMING_TMAP_AWK below IN THE SAME COMMIT — that is the
+# single definition every section of the report resolves through; otherwise
 # every comparison spanning the rename silently stops pairing that row and
 # reports it as two half-empty N/A rows instead of a delta. The script
 # reports unpaired TIMING labels on stderr after each run as a backstop,
@@ -165,22 +168,24 @@ format_table() {
     fi
 }
 
-# --- Comparison output ---
-run_comparison() {
-    local filter_mode="$1"
-
-    awk -F'\t' -v filter="$filter_mode" '
-    # TIMING label compat map: old label -> the label in use today. Baselines
-    # are kept for years and carry whatever labels their release emitted, so
-    # every rename of a TIMING row must add an entry here IN THE SAME CHANGE
-    # or cross-version rows stop pairing — the old and new names each become
-    # a half-empty N/A row and the metric silently drops out of every
-    # comparison spanning the rename.
-    #
-    # Chains are resolved (a -> b -> c collapses to c), so a second rename of
-    # an already-renamed row only needs its own new entry.
-    #
-    # #180 moved the flat stage labels to stage/step form:
+# --- TIMING label compat map — THE one definition ---
+# Old label -> the label in use today. Baselines are kept for years and carry
+# whatever labels their release emitted, so every rename of a TIMING row must
+# add an entry here IN THE SAME CHANGE or cross-version rows stop pairing —
+# the old and new names each become a half-empty N/A row and the metric
+# silently drops out of every comparison spanning the rename.
+#
+# Chains are resolved (a -> b -> c collapses to c), so a second rename of an
+# already-renamed row only needs its own new entry.
+#
+# Every awk program in this script that reads a TIMING label shares this
+# block and calls canon_timing(). A second copy of the table would mean a
+# rename could be recorded in one place and missed in another, so the rows
+# pair in one section of the report and silently stop pairing in another —
+# the exact failure the map exists to prevent.
+#
+# #180 moved the flat stage labels to stage/step form:
+TIMING_TMAP_AWK='
     BEGIN {
         tmap["read_files"] = "parse/read_files"
         tmap["initialize_buckets"] = "accumulate/initialize_buckets"
@@ -190,12 +195,24 @@ run_comparison() {
         tmap["histogram_statistics"] = "finalize/histogram_statistics"
         tmap["normalize_data"] = "render/normalize_data"
     }
+
+    # Follow the chain so a label renamed more than once still lands on the
+    # current name; the guard stops a mistaken cycle looping.
+    function canon_timing(label,    hops) {
+        hops = 0
+        while (label in tmap && hops++ < 10) label = tmap[label]
+        return label
+    }
+'
+
+# --- Comparison output ---
+run_comparison() {
+    local filter_mode="$1"
+
+    awk -F'\t' -v filter="$filter_mode" "$TIMING_TMAP_AWK"'
     {
         if ($3 == "TIMING") {
-            # Follow the chain so a label renamed more than once still lands
-            # on the current name; the guard stops a mistaken cycle looping.
-            hops = 0
-            while ($4 in tmap && hops++ < 10) $4 = tmap[$4]
+            $4 = canon_timing($4)
             if (NR == FNR) timing_base[$4] = 1; else timing_cur[$4] = 1
         }
     }
@@ -345,7 +362,7 @@ run_comparison() {
         if (nb > 0 || nc > 0) {
             printf "\n" > "/dev/stderr"
             printf "NOTE: TIMING labels present on only one side of this comparison.\n" > "/dev/stderr"
-            printf "      If a row was RENAMED, add old -> new to tmap in compare-results.sh\n" > "/dev/stderr"
+            printf "      If a row was RENAMED, add old -> new to TIMING_TMAP_AWK in compare-results.sh\n" > "/dev/stderr"
             printf "      so baselines spanning the rename keep pairing.\n" > "/dev/stderr"
             for (i = 0; i < nb; i++)
                 printf "      baseline only: %s\n", unpaired_base[i] > "/dev/stderr"
@@ -406,6 +423,326 @@ run_comparison() {
             result = result substr(s, i, 1)
         }
         return neg result
+    }
+    ' "$BASELINE" "$CURRENT" | format_table
+}
+
+# --- Rollup: per-stage timing and per-category memory, aggregated across
+# --- test cases, plus metrics new to the current version (Issue #416).
+#
+# The top-line matrices show only TIMING/total and MEMORY/rss_peak, so a
+# regression confined to one stage or one memory category sits in the detail
+# rows and is found only by manual TSV analysis (#413: a fixed +20 MB in
+# MEMORY/unattributed and a new 0.1 s detect/registry_build stage, both
+# missed at v0.17.0-first).
+#
+# Aggregation is the SUM over the test cases the current run executed, not
+# the mean of per-case percentages: a 60 s case and a 0.1 s case must not
+# carry equal weight in a stage's verdict.
+#
+# Containment: a TIMING label with a third stage/step/sub_step segment
+# measures time INSIDE its parent row, and detect/scan_sub_compile measures
+# compile cost that fires within whichever stage triggered it. Neither is
+# part of TIMING total. Both are marked "(within parent)" and excluded from
+# the additive stage sum, so a sub-stage can never read as exceeding the
+# stage that contains it.
+run_rollup() {
+    local kind="$1"
+
+    awk -F'\t' -v kind="$kind" "$TIMING_TMAP_AWK"'
+
+    NR == FNR && FNR == 1 { next }
+    NR != FNR && FNR == 1 { next }
+
+    # Which test cases did the current run execute? A case the current run
+    # skipped contributes to neither side (same rule as run_comparison), and
+    # that set is only known after the current file has been read — so both
+    # files are buffered here and accumulated in END.
+    NR != FNR && $3 == "TIMING" && $4 == "total" { current_test[$1] = 1 }
+
+    NR == FNR { base_rows[FNR] = $0; base_n = FNR; next }
+    { cur_rows[FNR] = $0; cur_n = FNR }
+
+    END {
+        OFS = "\t"
+
+        for (i = 1; i <= base_n; i++) accumulate(base_rows[i], 1)
+        for (i = 1; i <= cur_n;  i++) accumulate(cur_rows[i],  0)
+
+        if (kind == "timing")      emit_rollup("TIMING")
+        else if (kind == "memory") emit_rollup("MEMORY")
+        else if (kind == "new")    emit_new()
+    }
+
+    # Accumulate one TSV row into the baseline or current totals for its
+    # metric. TIMING labels go through canon_timing() — the same shared
+    # rename map the detail comparison uses — so a rollup spanning a rename
+    # pairs its rows exactly as the detail rows do.
+    function accumulate(row, is_base,    f, nfields, type, name, val, key) {
+        nfields = split(row, f, "\t")
+        if (nfields < 5) return
+        type = f[3]; name = f[4]; val = f[5]
+        if (!(f[1] in current_test)) return
+        if (type != "TIMING" && type != "MEMORY") return
+        if (val + 0 != val || val == "") return
+
+        if (type == "TIMING") name = canon_timing(name)
+
+        key = type "/" name
+        if (!(key in seen_metric)) {
+            seen_metric[key] = 1
+            order[++n_order] = key
+        }
+        if (is_base) {
+            base_sum[key] += val
+            base_cases[key]++
+            base_val[key, f[1]] = val
+        } else {
+            cur_sum[key] += val
+            cur_cases[key]++
+            # Per-test range, for the "new in this version" section.
+            if (!(key in cur_min) || val + 0 < cur_min[key] + 0) cur_min[key] = val
+            if (!(key in cur_max) || val + 0 > cur_max[key] + 0) cur_max[key] = val
+            # Per-case direction. The summed delta alone can report IMPROVE
+            # for a metric that regressed in most test cases, when a few
+            # large cases move the other way — exactly the shape of the
+            # fixed +20 MB in MEMORY/unattributed (#413), which sums to a
+            # net improvement against the large cases decreasing. The
+            # up/down split makes a uniform small regression visible.
+            if ((key SUBSEP f[1]) in base_val) {
+                if (val + 0 > base_val[key, f[1]] + 0) cases_up[key]++
+                else if (val + 0 < base_val[key, f[1]] + 0) cases_down[key]++
+            }
+        }
+    }
+
+    function is_contained(type, name,    parts) {
+        if (type != "TIMING") return 0
+        if (name == "detect/scan_sub_compile") return 1
+        return (split(name, parts, "/") >= 3)
+    }
+
+    function emit_rollup(want_type,    i, key, parts, type, name, b, c,
+                         stage_b, stage_c, floor_on) {
+        print "metric", "baseline", "current", "delta", "change%", "cases +/-", "result"
+
+        # The noise floor de-ranks the quiet rows so the loud one leads. If
+        # nothing is loud there is nothing to rank against, and collapsing
+        # the table would hide the whole pipeline to say "all quiet" — so
+        # the floor only engages once some row has cleared it.
+        floor_on = 0
+        for (i = 1; i <= n_order; i++) {
+            key = order[i]
+            split(key, parts, "/")
+            if (parts[1] != want_type) continue
+            if (!(key in base_sum)) continue
+            name = substr(key, length(parts[1]) + 2)
+            if (name == "total" || name == "rss_peak") continue
+            if (!is_quiet(want_type, base_sum[key],
+                          (key in cur_sum) ? cur_sum[key] : 0)) { floor_on = 1; break }
+        }
+
+        stage_b = 0; stage_c = 0
+        nrank = 0
+        quiet_n = 0; quiet_b = 0; quiet_c = 0
+        qc_n = 0; qc_b = 0; qc_c = 0
+        for (i = 1; i <= n_order; i++) {
+            key = order[i]
+            split(key, parts, "/")
+            type = parts[1]
+            name = substr(key, length(type) + 2)
+            if (type != want_type) continue
+
+            # A metric absent from the baseline belongs in the "new in this
+            # version" section, which has an aggregate to show; a rollup row
+            # comparing it against nothing does not.
+            if (!(key in base_sum)) continue
+
+            b = base_sum[key]
+            c = (key in cur_sum) ? cur_sum[key] : 0
+            if (b == 0 && c == 0) continue
+
+            if (want_type == "TIMING" && name != "total" && !is_contained(type, name)) {
+                stage_b += b
+                stage_c += c
+            }
+
+            # Noise floor. A category that moved by a few hundred bytes, or
+            # a stage by a millisecond, carries the same REGRESS badge as a
+            # systematic leak and pushes the row that matters down the page.
+            # Sub-threshold rows collapse into one line that still accounts
+            # for their total, so nothing is hidden — only de-ranked.
+            # Contained rows are kept separate from the additive ones, so
+            # the collapsed line never mixes time counted inside a parent
+            # with time counted alongside it — a mixed total cannot be read
+            # against the sum-of-stages row and looks like an inconsistency.
+            if (floor_on && is_quiet(want_type, b, c) && name != "total" && name != "rss_peak") {
+                if (is_contained(want_type, name)) {
+                    qc_n++; qc_b += b; qc_c += c
+                } else {
+                    quiet_n++; quiet_b += b; quiet_c += c
+                }
+                continue
+            }
+
+            rank_key[++nrank] = key
+            rank_name[nrank] = name
+            rank_b[nrank] = b
+            rank_c[nrank] = c
+            rank_mag[nrank] = ((c - b) < 0) ? (b - c) : (c - b)
+            # The run-level roof anchors its table regardless of magnitude:
+            # TIMING total and MEMORY rss_peak are the frame the categories
+            # below them are read against, not competitors for the top slot.
+            if (want_type == "TIMING" && name == "total") rank_mag[nrank] = -1
+            if (want_type == "MEMORY" && name == "rss_peak") rank_mag[nrank] = 1e18
+        }
+
+        # Memory has no intrinsic order, so the largest absolute movement
+        # leads — that is the row to drill into. Timing keeps pipeline order
+        # (parse -> accumulate -> finalize -> render), which is itself the
+        # diagnostic: where in the run the cost moved.
+        if (want_type == "MEMORY") sort_by_magnitude(nrank)
+
+        for (i = 1; i <= nrank; i++)
+            print_row(want_type, rank_name[i], rank_b[i], rank_c[i],
+                      is_contained(want_type, rank_name[i]) ? " (within parent)" : "",
+                      rank_key[i])
+
+        if (quiet_n > 0)
+            print_row(want_type, sprintf("(%d below noise floor)", quiet_n),
+                      quiet_b, quiet_c, "", "")
+        if (qc_n > 0)
+            print_row(want_type, sprintf("(%d below noise floor)", qc_n),
+                      qc_b, qc_c, " (within parent)", "")
+
+        # Additive check: the stages that make up TIMING total should sum to
+        # it. A gap means wall-clock time that no stage row accounts for.
+        # No per-case split: this row is a sum across metrics, not a metric.
+        if (want_type == "TIMING" && stage_b > 0)
+            print_row(want_type, "sum of stages", stage_b, stage_c, "", "")
+    }
+
+    # Below this movement a row is bookkeeping, not a lead: 1 MB for a
+    # memory category, 100 ms for a timing stage, aggregated across every
+    # test case in the run.
+    function is_quiet(type, b, c,    d) {
+        d = (c - b < 0) ? b - c : c - b
+        if (type == "MEMORY") return (d < 1048576)
+        return (d < 0.100)
+    }
+
+    function sort_by_magnitude(cnt,    i, j, t) {
+        for (i = 2; i <= cnt; i++)
+            for (j = i; j > 1 && rank_mag[j] > rank_mag[j-1]; j--) {
+                t = rank_mag[j]; rank_mag[j] = rank_mag[j-1]; rank_mag[j-1] = t
+                t = rank_key[j];  rank_key[j]  = rank_key[j-1];  rank_key[j-1]  = t
+                t = rank_name[j]; rank_name[j] = rank_name[j-1]; rank_name[j-1] = t
+                t = rank_b[j];    rank_b[j]    = rank_b[j-1];    rank_b[j-1]    = t
+                t = rank_c[j];    rank_c[j]    = rank_c[j-1];    rank_c[j-1]    = t
+            }
+    }
+
+    function print_row(type, name, b, c, note, key,
+                       delta, pct, ind, bd, cd, dd, up, dn, split_col) {
+        delta = c - b
+        if (b != 0)       pct = sprintf("%.1f%%", (delta / b) * 100)
+        else if (c == 0)  pct = "0.0%"
+        else              pct = "NEW"
+
+        if (delta > 0)      ind = "REGRESS"
+        else if (delta < 0) ind = "IMPROVE"
+        else                ind = ""
+
+        # The summed delta is the magnitude; the per-case split is the
+        # breadth. When they disagree — a net improvement carried by a few
+        # large cases while most cases got worse — the summed verdict alone
+        # is misleading, so the row says so.
+        up = (key != "" && (key in cases_up))   ? cases_up[key]   : 0
+        dn = (key != "" && (key in cases_down)) ? cases_down[key] : 0
+        if (key == "" || (up == 0 && dn == 0)) {
+            split_col = "-"
+        } else {
+            split_col = sprintf("%d/%d", up, dn)
+            if (delta < 0 && up > dn)      ind = "IMPROVE (most cases REGRESS)"
+            else if (delta > 0 && dn > up) ind = "REGRESS (most cases IMPROVE)"
+        }
+
+        if (type == "MEMORY") {
+            bd = format_bytes(b); cd = format_bytes(c); dd = format_bytes_signed(delta)
+        } else {
+            bd = format_time(b); cd = format_time(c); dd = format_time_signed(delta)
+        }
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", name note, bd, cd, dd, pct, split_col, ind
+    }
+
+    # Metrics the current run emits that the baseline has no counterpart
+    # for. These are the rows that would otherwise render as "N/A -> ?" and
+    # feed no summary at all; here they get an aggregate and the per-test
+    # range that shows whether the cost is uniform or concentrated.
+    function emit_new(   i, key, parts, type, name, any, lo, hi, agg) {
+        print "metric", "test cases", "per-test range", "aggregate"
+        any = 0
+        for (i = 1; i <= n_order; i++) {
+            key = order[i]
+            if (key in base_sum) continue
+            if (!(key in cur_sum)) continue
+            split(key, parts, "/")
+            type = parts[1]
+            name = substr(key, length(type) + 2)
+
+            if (type == "MEMORY") {
+                lo = format_bytes(cur_min[key]); hi = format_bytes(cur_max[key])
+                agg = format_bytes(cur_sum[key])
+            } else {
+                lo = format_time(cur_min[key]); hi = format_time(cur_max[key])
+                agg = format_time(cur_sum[key])
+            }
+            printf "%s\t%d\t%s - %s\t%s\n", \
+                key (is_contained(type, name) ? " (within parent)" : ""), \
+                cur_cases[key], lo, hi, agg
+            any = 1
+        }
+        if (!any) printf "(none)\t-\t-\t-\n"
+    }
+
+    function format_bytes(n,    abs_n, val, unit) {
+        abs_n = (n < 0) ? -n : n
+        if (abs_n >= 1073741824) { val = n / 1073741824; unit = "GB" }
+        else if (abs_n >= 1048576) { val = n / 1048576; unit = "MB" }
+        else if (abs_n >= 1024) { val = n / 1024; unit = "KB" }
+        else return sprintf("%d B", n)
+        if (sprintf("%.1f", val) == sprintf("%d.0", int(val)))
+            return sprintf("%d %s", val, unit)
+        return sprintf("%.1f %s", val, unit)
+    }
+
+    function format_bytes_signed(n) {
+        if (n == 0) return "0 B"
+        if (n > 0) return "+" format_bytes(n)
+        return format_bytes(n)
+    }
+
+    function format_time(n,    abs_n, val) {
+        abs_n = (n < 0) ? -n : n
+        if (abs_n >= 60) {
+            val = n / 60
+            if (sprintf("%.1f", val) == sprintf("%d.0", int(val)))
+                return sprintf("%d min", val)
+            return sprintf("%.1f min", val)
+        }
+        if (abs_n >= 1) {
+            if (sprintf("%.1f", n) == sprintf("%d.0", int(n)))
+                return sprintf("%d s", n)
+            return sprintf("%.1f s", n)
+        }
+        if (abs_n >= 0.001) return sprintf("%.0f ms", n * 1000)
+        return sprintf("%.0f us", n * 1000000)
+    }
+
+    function format_time_signed(n) {
+        if (n == 0) return "0 ms"
+        if (n > 0) return "+" format_time(n)
+        return format_time(n)
     }
     ' "$BASELINE" "$CURRENT" | format_table
 }
@@ -574,6 +911,26 @@ if [[ "$MODE" == "table" || "$MODE" == "all" ]]; then
     fi
     echo ""
     run_table_memory
+    echo ""
+fi
+
+# The rollups precede the per-test Summary: they are the headline the
+# matrices above do not carry. Unlike Summary they are always titled, since
+# three untitled tables in a row cannot be told apart.
+if [[ "$MODE" == "summary" || "$MODE" == "all" ]]; then
+    if [[ $MARKDOWN -eq 1 ]]; then echo "### Stage Rollup (timing)"; else echo "--- Stage Rollup (timing) ---"; fi
+    echo ""
+    run_rollup "timing"
+    echo ""
+
+    if [[ $MARKDOWN -eq 1 ]]; then echo "### Category Rollup (memory)"; else echo "--- Category Rollup (memory) ---"; fi
+    echo ""
+    run_rollup "memory"
+    echo ""
+
+    if [[ $MARKDOWN -eq 1 ]]; then echo "### New In This Version"; else echo "--- New In This Version ---"; fi
+    echo ""
+    run_rollup "new"
     echo ""
 fi
 


### PR DESCRIPTION
Closes #416.

The v0.16.0 -> v0.17.0-first comparison contained every signal needed to catch two regressions, but the top-line matrices show only `TIMING/total` and `MEMORY/rss_peak`, so both sat in 3,851 detail rows and were found only by manual TSV analysis. Metrics with no baseline counterpart rendered as `N/A -> ?` and fed no summary at all.

## What changed

Three sections now precede the per-test Summary, in `summary` and `all` modes:

- **Stage Rollup (timing)** — every `TIMING` stage aggregated across the test cases the current run executed, in pipeline order, with a `sum of stages` row cross-checking against `TIMING/total`.
- **Category Rollup (memory)** — every `MEMORY` category, ranked by absolute movement so the largest leads. `unattributed` is an ordinary row, so untracked growth is a headline.
- **New In This Version** — metrics present only in the current run, with test count, per-test range and aggregate.

## Design notes

**Aggregation is the sum over shared test cases**, not the mean of per-case percentages, so a 60 s case and a 0.1 s case do not carry equal weight.

**The summed delta alone can point the wrong way.** `MEMORY/unattributed` sums to a net *improvement* across v0.16.0 -> v0.17.0-first while 37 of 60 cases regressed — the shape of the fixed +20 MB in #413, drowned by large cases improving. A `cases +/-` column carries the per-case direction, and the verdict says so explicitly when magnitude and breadth disagree.

**Noise floor.** Rows below 1 MB (memory) / 100 ms (timing), aggregated, collapse into one accounted-for line so the row worth drilling into leads. Both collapsed lines were verified arithmetically against the raw TSVs. The floor disengages when nothing clears it, so an unchanged run still shows the whole pipeline.

**Containment.** `stage/step/sub_step` labels (#417) and `detect/scan_sub_compile` are marked `(within parent)`, excluded from the additive stage sum, and collapsed separately — so a sub-stage can never read as exceeding its parent, and no mixed total is read against `sum of stages`.

**One rename map.** `TIMING_TMAP_AWK` / `canon_timing()` is now a single shared definition used by both the detail comparison and the rollups. A second copy would let a rename be recorded in one place and missed in another — pairing rows in one section and silently dropping them in another, the exact failure the map exists to prevent.

## Triage path

On the single-case gate run, the memory rollup is three lines: `rss_peak +18.3 MB`, `unattributed +18.1 MB`, everything else `+198 KB` — untracked growth, not a tracked structure. On a synthetic sub-stage regression, top-down in three lines: total +2 s -> `finalize/calculate_statistics` owns all of it -> `population_walk` owns all of that, +57.1%.

## Verification

- All committed baseline pairs compare cleanly, including `v0.14.2 -> v0.16.0` across the #180 rename.
- The shared-map refactor is output-neutral: cross-rename comparison byte-identical before and after.
- Simulated future rename: one entry restores pairing in every section at once, clears the stderr note, and removes the row from "New In This Version".
- `summary`, `all`, `--markdown` and single-case gate invocations all exercised.

No change to `ltl` or any harness — this is benchmark analysis tooling only, so the validation suite has nothing to prove here and was not run.
