### PR TITLE
Record file paths as given, keeping harness output portable (#209)

### DIFF
--- a/features/209-benchmark-tsv-absolute-paths.md
+++ b/features/209-benchmark-tsv-absolute-paths.md
@@ -1,0 +1,136 @@
+# Issue #209 — Portable file paths in recorded test-harness output
+
+Branch: `209-benchmark-tsv-absolute-paths` (off `release/0.17.0`)
+
+## Scope
+
+Two committed test artifacts recorded the absolute paths of the machine that
+produced them, tying them to a single checkout:
+
+- `tests/baseline/results/*.tsv` — the `FILES` rows of the benchmark TSV.
+- `tests/reference-output/*.txt` — the rendered file legend in 8 of the 46
+  regression references.
+
+Both are addressed here. The contract adopted is that **`ltl` records input
+paths exactly as the caller supplied them**, and the harnesses supply
+repo-relative paths from the repo root — so a recorded path reads as if the
+current working directory were the repo root.
+
+Not in scope: rewriting the historical baselines (`v0.14.x`–`v0.16.0`), which
+stand as captures of what was measured at the time.
+
+## Findings
+
+### F1. There is no single root cause — the two surfaces are independent bugs
+
+The issue thread (2026-08-21 scope note) states that `ltl` "absolutizes input
+file paths and renders them in the file legend", making the benchmark TSV and
+the regression legend two surfaces of one root cause. **This is incorrect**,
+and it matters because it implies the `ltl` fix resolves both.
+
+`abs_path()` had exactly one caller in `ltl`: the `FILES` row of the
+`benchmark-data` `-V` section (`print_verbose_output`). The file legend
+(`print_summary_table`, the `foreach my $in_file (@files_processed)` loop that
+emits `[%s] %-${filename_max_length}s`) has never called it — it renders
+`@files_processed`, which holds whatever the caller passed.
+
+So the absolute paths in the regression references came from
+`capture-regression.sh` itself, which built its log paths as
+`"$REPO_DIR/logs/..."`. The two bugs share a symptom, not a cause:
+
+| Surface | Absolutized by | Needs `ltl` change |
+|---|---|---|
+| Benchmark TSV `FILES` row | `ltl` (`abs_path`) | Yes |
+| Regression file legend | `capture-regression.sh` (`$REPO_DIR/...`) | No |
+
+Consequence: the legend half is a pure harness fix. Only the TSV half required
+touching production code.
+
+### F2. Only the 8 `hl-*` references carry a path
+
+`COMMON` (38 scenarios) passes `-osum`, which suppresses the summary table and
+with it the file legend. `HL_COMMON` (the 8 numeric-highlight scenarios from
+#312) deliberately omits `-osum` so the HIGHLIGHTED row is part of the captured
+surface — and the legend comes with it. `grep -l` for the absolute path across
+`tests/reference-output/` returns those 8 and nothing else.
+
+`ACCESS_LOG` is a `mktemp` path that varies per run, but it appears only in
+`-osum` scenarios, so it never reaches a captured legend.
+
+### F3. The rebaseline changes more than the path text
+
+`shorten_filename()` truncates to a computed width, so the two forms differ in
+rendering, not just content — the absolute form is elided in the middle, the
+relative form fits whole and is padded:
+
+```
+-  4xx    4   [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...rver-access_log-Windchill_Navigate.2026-01-25.log [1]
++  4xx    4   [√] logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log                       [1]
+```
+
+A rebaseline was therefore required, not a search-and-replace of the path
+string.
+
+### F4. `-V` is the extraction surface for path assertions, not the legend
+
+Reading paths out of the rendered summary block is unsound: the legend is
+ANSI-coloured, contains non-ASCII (`√`, which silently flips `grep` to binary
+mode), is column-padded, and is truncated by `shorten_filename()` — it can only
+ever confirm the first and last ~50 characters of a path.
+
+`-V format-detection` emits the untruncated value as a plain key:
+
+```
+file: logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log
+```
+
+Verification of this fix asserts on `-V benchmark-data`'s `FILES` row and
+`-V format-detection`'s `file:` key. `file:` (`format-detection`) and
+`drift_file:` (`index-read-back`) already echoed the caller's path verbatim and
+inherit the fix with no change.
+
+## Fix
+
+1. **`ltl`** — `FILES` emits `join(';', @files_processed)`; `abs_path()` and its
+   sole-purpose `use Cwd` import removed.
+2. **`tests/baseline/run-benchmark.sh`** — `cd "$REPO_DIR"`, `LOGS_DIR="logs"`.
+   `$LTL`/`$RESULTS_DIR` stay absolute and are unaffected by the `cd`; neither
+   is recorded in output.
+3. **`tests/capture-regression.sh`** / **`tests/validate-regression.sh`** —
+   `cd "$REPO_DIR"` and repo-relative log vars, applied in lockstep so captured
+   and validated invocations match. The "known acceptable failure" header note
+   in `validate-regression.sh` is removed: any diff is now a regression.
+4. **`tests/reference-output/`** — the 8 `hl-*` references rebaselined.
+
+## Contract
+
+`ltl` reports the paths it was given. It has no notion of a repo root, and
+acquiring one would be wrong for a tool whose users analyse logs anywhere on
+disk. Portability of recorded output is therefore the caller's responsibility:
+harnesses that commit their output run from the repo root and pass
+repo-relative paths.
+
+Any harness added later whose captured output includes a file path — the
+rendered legend, a `FILES` row, or a `-V` `file:` key — follows the same rule.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `FILES` row, relative path in | `logs/AccessLogs/...` |
+| `FILES` row, absolute path in | absolute preserved (caller's choice) |
+| Benchmark TSV from repo root | `logs/AccessLogs/...` |
+| Benchmark TSV invoked from `/tmp` | identical — CWD-independent |
+| Rebaseline scope | exactly the 8 predicted files; all 18 changed lines are legend lines |
+| `validate-regression.sh` from repo root | 46 passed, 0 failed |
+| `validate-regression.sh` from `/tmp` | 46 passed, 0 failed |
+
+The suite was run from a worktree whose path differs from the checkout where
+the references were originally captured, so portability is demonstrated across
+both a foreign CWD and a foreign checkout.
+
+Completion gate: all 23 `tests/validate-*.sh` exit 0 with assertions confirmed
+executed; `validate-statistics.sh` reports 0 T3/T4 on all three layers.
+Benchmark `single-day-access-log-standard` against `v0.16.0` shows no metric
+worse by more than 5% (sole `REGRESS` is +0.2% on a rollup of items below the
+noise floor).

--- a/ltl
+++ b/ltl
@@ -29,7 +29,6 @@ use Devel::Size qw(total_size);
 # Proc::ProcessTable is loaded conditionally in get_memory_usage() based on platform
 # On Windows, Win32::API calls K32GetProcessMemoryInfo directly (kernel32.dll)
 use List::Util qw(min max);
-use Cwd qw(abs_path);
 use File::Glob qw(bsd_glob);
 use File::Spec;
 use Text::CSV;
@@ -14019,14 +14018,14 @@ sub print_verbose_output {
     print "=== benchmark-data ===\n";
     print "version\t$version_number\n";
 
-    # File metadata
+    # File metadata. Paths are recorded exactly as the caller supplied them,
+    # so a caller passing repo-relative paths gets a portable record; callers
+    # that want absolute paths pass absolute paths.
     my $total_file_size = 0;
-    my @abs_paths;
     for my $f (@files_processed) {
         $total_file_size += (-s $f) // 0;
-        push @abs_paths, abs_path($f);
     }
-    print "FILES\t" . join(';', @abs_paths) . "\t$total_file_size\n";
+    print "FILES\t" . join(';', @files_processed) . "\t$total_file_size\n";
 
     print "lines_read\t$total_lines_read\n";
     print "lines_included\t$total_lines_included\n";

--- a/tests/baseline/run-benchmark.sh
+++ b/tests/baseline/run-benchmark.sh
@@ -17,9 +17,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LTL="$SCRIPT_DIR/../../ltl"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LTL="$REPO_DIR/ltl"
 RESULTS_DIR="$SCRIPT_DIR/results"
-LOGS_DIR="$SCRIPT_DIR/../../logs"
+
+# Run from the repo root and glob the logs relatively, so the paths handed to
+# ltl — and recorded verbatim in the benchmark TSV's FILES rows — are
+# repo-relative and the baseline stays portable across machines (#209).
+cd "$REPO_DIR"
+LOGS_DIR="logs"
 
 # Default label is timestamp
 LABEL="$(date +%Y%m%d-%H%M%S)"

--- a/tests/capture-regression.sh
+++ b/tests/capture-regression.sh
@@ -16,6 +16,12 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LTL="$REPO_DIR/ltl"
 REF_DIR="${1:-$SCRIPT_DIR/reference-output}"
 
+# Run from the repo root so the log paths handed to ltl below are
+# repo-relative. ltl records paths verbatim and the file legend renders them,
+# so relative paths keep the captured references portable across checkouts
+# (#209). Everything else here is absolute and unaffected by the cd.
+cd "$REPO_DIR"
+
 # Common options: suppress progress, summary table, and limit top messages
 COMMON="--disable-progress -ni -osum -n 1"
 
@@ -38,17 +44,17 @@ derive_sampled_access_log "$ACCESS_LOG"
 # and one histogram, so the slice carries the whole rendered surface; its
 # runs take `-bs 1` so the 7-minute span yields seven timeline rows of
 # heatmap cells (tests/HARNESS-DESIGN.md section Invocation coherence).
-SCRIPT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+SCRIPT_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 # Issue #235 — additional fixtures for the extended heatmap/histogram tests
 # below. APACHE_LOG is the canonical clean Apache HTTP2 access log; it ships
 # bytes + microsecond-%D durations and is small (~100 KB), keeping capture
 # time tight.
-APACHE_LOG="$REPO_DIR/logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
+APACHE_LOG="logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
 # Issue #312 — numeric-highlight rendering fixtures. PLOT_LOG has sparse metric
 # presence (durationMS/count on 220 of 2,992 lines); DPM5K_LOG is the
 # deterministic 5k-line ScriptLog slice with durationMS on every line.
-PLOT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.GetComplexPlotByIndex.log"
-DPM5K_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+PLOT_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.GetComplexPlotByIndex.log"
+DPM5K_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 
 # Verify test files exist
 for f in "$ACCESS_LOG" "$SCRIPT_LOG" "$APACHE_LOG" "$PLOT_LOG" "$DPM5K_LOG"; do

--- a/tests/reference-output/hl-filelegend-two-files-w160.txt
+++ b/tests/reference-output/hl-filelegend-two-files-w160.txt
@@ -3012,8 +3012,8 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -hdmin 10
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-04-10 06:00 and 2025-12-15 23:57
   ─────────────────────────────────────────   
-  ERROR-HL                                1      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...mThingworxLogs/ScriptLog-DPMExtended-clean-5k.log [1]
-  ERROR                                  88      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...ThingworxLogs/ScriptLog.GetComplexPlotByIndex.log [1]
+  ERROR-HL                                1      [√] logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log                            [1]
+  ERROR                                  88      [√] logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.GetComplexPlotByIndex.log                           [1]
   WARN                                 6016   
   INFO-HL                                 2      Log Formats
   INFO                                 1885   

--- a/tests/reference-output/hl-hbmin-w160.txt
+++ b/tests/reference-output/hl-hbmin-w160.txt
@@ -51,7 +51,7 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41
   ─────────────────────────────────────────   
-  4xx                                     4      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...rver-access_log-Windchill_Navigate.2026-01-25.log [1]
+  4xx                                     4      [√] logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log                       [1]
   3xx                                     7   
   2xx-HL                                113      Log Formats
   2xx                                   553   

--- a/tests/reference-output/hl-hcmin-plotlog-w160.txt
+++ b/tests/reference-output/hl-hcmin-plotlog-w160.txt
@@ -27,7 +27,7 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -ic -hcmi
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-12-15 00:00 and 2025-12-15 23:57
   ─────────────────────────────────────────   
-  ERROR                                  66      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...ThingworxLogs/ScriptLog.GetComplexPlotByIndex.log [1]
+  ERROR                                  66      [√] logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.GetComplexPlotByIndex.log                           [1]
   WARN                                 1044   
   INFO-HL                                45      Log Formats
   INFO                                 1837   

--- a/tests/reference-output/hl-hdmin-w160.txt
+++ b/tests/reference-output/hl-hdmin-w160.txt
@@ -51,7 +51,7 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41
   ─────────────────────────────────────────   
-  4xx                                     4      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...rver-access_log-Windchill_Navigate.2026-01-25.log [1]
+  4xx                                     4      [√] logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log                       [1]
   3xx-HL                                  1   
   3xx                                     6      Log Formats
   2xx-HL                                153   

--- a/tests/reference-output/hl-heatmap-hdmin-w160.txt
+++ b/tests/reference-output/hl-heatmap-hdmin-w160.txt
@@ -16,7 +16,7 @@ command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-04-10 06:00 and 2025-04-10 06:07
   ─────────────────────────────────────────   
-  ERROR                                  23      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...mThingworxLogs/ScriptLog-DPMExtended-clean-5k.log [1]
+  ERROR                                  23      [√] logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log                            [1]
   WARN-HL                               498   
   WARN                                 4474      Log Formats
   INFO-HL                                 4   

--- a/tests/reference-output/hl-histogram-hdmin-w160.txt
+++ b/tests/reference-output/hl-histogram-hdmin-w160.txt
@@ -67,7 +67,7 @@ command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41
   ─────────────────────────────────────────   
-  4xx                                     4      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...rver-access_log-Windchill_Navigate.2026-01-25.log [1]
+  4xx                                     4      [√] logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log                       [1]
   3xx-HL                                  1   
   3xx                                     6      Log Formats
   2xx-HL                                153   

--- a/tests/reference-output/hl-regex-hdmin-w160.txt
+++ b/tests/reference-output/hl-regex-hdmin-w160.txt
@@ -51,7 +51,7 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41
   ─────────────────────────────────────────   
-  4xx                                     4      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...rver-access_log-Windchill_Navigate.2026-01-25.log [1]
+  4xx                                     4      [√] logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log                       [1]
   3xx                                     7   
   2xx-HL                                 19      Log Formats
   2xx                                   647   

--- a/tests/reference-output/hl-regex-only-w160.txt
+++ b/tests/reference-output/hl-regex-only-w160.txt
@@ -51,7 +51,7 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41
   ─────────────────────────────────────────   
-  4xx                                     4      [√] /Users/gregeva/Documents/GitHub/logtimeline/logs...rver-access_log-Windchill_Navigate.2026-01-25.log [1]
+  4xx                                     4      [√] logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log                       [1]
   3xx                                     7   
   2xx-HL                                 34      Log Formats
   2xx                                   632   

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -5,16 +5,10 @@
 # Re-runs the same ltl commands as capture-regression.sh and diffs against
 # the stored reference output. Any difference is a regression.
 #
-# Known acceptable failure — capture-location dependency (#209): ltl
-# absolutizes input file paths and renders them in the file legend, so the
-# stored references embed the absolute paths of the checkout where they
-# were captured. Run from any other location, the legend-bearing scenarios
-# fail with diffs on exactly the `[√] /abs/path...` legend lines. Those
-# legend-line diffs are the ONLY acceptable differences; any other diff
-# line is a real regression. The durable fix (relative path emission in
-# ltl + this harness passing repo-relative paths) is #209's scope; until
-# it lands, references are fully reproducible only from the capture
-# checkout, and rebaselining stays a per-release activity.
+# The references are reproducible from any checkout: ltl renders input paths
+# in the file legend exactly as it received them, and this harness passes
+# repo-relative log paths from the repo root, so no absolute path reaches
+# the captured output (#209).
 
 set -euo pipefail
 
@@ -22,6 +16,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LTL="$REPO_DIR/ltl"
 REF_DIR="${1:-$SCRIPT_DIR/reference-output}"
+
+# Run from the repo root so the log paths handed to ltl below are
+# repo-relative; must match capture-regression.sh, which captured the
+# references the same way.
+cd "$REPO_DIR"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
@@ -46,17 +45,17 @@ derive_sampled_access_log "$ACCESS_LOG"
 # and one histogram, so the slice carries the whole rendered surface; its
 # runs take `-bs 1` so the 7-minute span yields seven timeline rows of
 # heatmap cells (tests/HARNESS-DESIGN.md section Invocation coherence).
-SCRIPT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+SCRIPT_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 # Issue #235 — additional fixtures for the extended heatmap/histogram tests
 # below. APACHE_LOG is the canonical clean Apache HTTP2 access log; it ships
 # bytes + microsecond-%D durations and is small (~100 KB), keeping capture
 # time tight.
-APACHE_LOG="$REPO_DIR/logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
+APACHE_LOG="logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
 # Issue #312 — numeric-highlight rendering fixtures. PLOT_LOG has sparse metric
 # presence (durationMS/count on 220 of 2,992 lines); DPM5K_LOG is the
 # deterministic 5k-line ScriptLog slice with durationMS on every line.
-PLOT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.GetComplexPlotByIndex.log"
-DPM5K_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+PLOT_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog.GetComplexPlotByIndex.log"
+DPM5K_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 
 # Strip ANSI escape codes and non-deterministic lines (timing, memory) from stdin
 strip_nondeterministic() {


### PR DESCRIPTION
Fixes #209.

`ltl` now records input file paths exactly as the caller supplied them, and the harnesses that commit their output pass repo-relative paths from the repo root — so a recorded path reads as if CWD were the repo root.

## Correction to the issue thread

The 2026-08-21 scope note says `ltl` "absolutizes input file paths and renders them in the file legend", making the benchmark TSV and the regression legend two surfaces of one root cause. That is not accurate, and it changes the shape of the fix.

`abs_path()` had exactly one caller: the `FILES` row of the `benchmark-data` `-V` section. The file legend has never called it — it renders `@files_processed`, i.e. whatever the caller passed. The absolute paths in the references came from `capture-regression.sh` building `"$REPO_DIR/logs/..."`.

| Surface | Absolutized by | Needs `ltl` change |
|---|---|---|
| Benchmark TSV `FILES` row | `ltl` (`abs_path`) | Yes |
| Regression file legend | `capture-regression.sh` | No |

Two independent bugs sharing a symptom. Only the TSV half touches production code.

## Changes

- **`ltl`** — `FILES` emits `@files_processed` verbatim; `abs_path()` and its sole-purpose `use Cwd` import removed.
- **`tests/baseline/run-benchmark.sh`** — `cd "$REPO_DIR"`, `LOGS_DIR="logs"`.
- **`tests/capture-regression.sh`** / **`tests/validate-regression.sh`** — same `cd` plus repo-relative log vars, in lockstep. The "known acceptable failure" header note is removed: any diff is now a regression.
- **`tests/reference-output/`** — 8 `hl-*` references rebaselined. `shorten_filename()` renders the absolute (elided) and relative (padded) forms differently, so this is a rebaseline, not a string substitution. All 18 changed lines are legend lines.
- **`features/209-benchmark-tsv-absolute-paths.md`** — findings, contract, verification.

Only the 8 `hl-*` scenarios are affected because they omit `-osum` and so keep the summary block that carries the legend; the other 38 suppress it.

## Verification

| Check | Result |
|---|---|
| `FILES`, relative in | `logs/AccessLogs/...` |
| `FILES`, absolute in | absolute preserved (caller's choice) |
| Benchmark TSV invoked from `/tmp` | identical — CWD-independent |
| Rebaseline scope | exactly the 8 predicted files, legend lines only |
| `validate-regression.sh` from repo root | 46 passed, 0 failed |
| `validate-regression.sh` from `/tmp` | 46 passed, 0 failed |

Run from a worktree whose path differs from the original capture checkout, so portability holds across both a foreign CWD and a foreign checkout.

Assertions were read from `-V benchmark-data` (`FILES`) and `-V format-detection` (`file:`) rather than the rendered legend, which is ANSI-coloured, non-ASCII, padded and truncated. `file:` and `drift_file:` already echoed the caller's path and inherit the fix unchanged.

## Completion gate

- All 23 `tests/validate-*.sh` exit 0, assertions confirmed executed (format-detection 192, explain 148, heatmap-palette 85, …). `validate-statistics.sh`: 0 T3/T4 across all three layers.
- Benchmark `single-day-access-log-standard` vs `v0.16.0`: no metric worse by >5%. Sole `REGRESS` is +0.2% on a rollup of sub-noise-floor items. (The −23% timing improvements are 0.17.0 cycle work, not this change.)

Historical baselines (`v0.14.x`–`v0.16.0`) are left untouched as captures of what was measured at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
