### PR TITLE
Rank -so metrics by the operand actually requested (#428)

### DIFF
--- a/ltl
+++ b/ltl
@@ -9758,31 +9758,31 @@ sub adapt_to_command_line_options {
         iqr skewness kurtosis bimodality_coef
     );
 
-    if( $sort_type =~ /^duration|time$/i ) {
+    if( $sort_type =~ /^(?:duration|time)$/i ) {
         $sort_key = "total_duration_num";
     } elsif( $sort_type =~ /^min$/i ) {
         $sort_key = "min";
-    } elsif( $sort_type =~ /^mean|avg$/i ) {
+    } elsif( $sort_type =~ /^(?:mean|avg)$/i ) {
         $sort_key = "mean";
     } elsif( $sort_type =~ /^max$/i ) {
         $sort_key = "max";
-    } elsif( $sort_type =~ /^std_dev|stddev$/i ) {
+    } elsif( $sort_type =~ /^(?:std_dev|stddev)$/i ) {
         $sort_key = "std_dev";
-    } elsif( $sort_type =~ /^occurrences|total$/i ) {
+    } elsif( $sort_type =~ /^(?:occurrences|total)$/i ) {
         $sort_key = "occurrences";
-    } elsif( $sort_type =~ /^bytes|size$/i ) {
+    } elsif( $sort_type =~ /^(?:bytes|size)$/i ) {
         $sort_key = "total_bytes";
     } elsif( $sort_type =~ /^impact$/i ) {
         $sort_key = "impact";
     } elsif( $sort_type =~ /^cv$/i ) {
         $sort_key = "cv";
-    } elsif( $sort_type =~ /^count_occurrences|count_total$/i ) {
+    } elsif( $sort_type =~ /^(?:count_occurrences|count_total)$/i ) {
         $sort_key = "count_occurrences";
-    } elsif( $sort_type =~ /^count|count_sum$/i ) {
+    } elsif( $sort_type =~ /^(?:count|count_sum)$/i ) {
         $sort_key = "count_sum";
     } elsif( $sort_type =~ /^count_min$/i ) {
         $sort_key = "count_min";
-    } elsif( $sort_type =~ /^count_mean|count_avg$/i ) {
+    } elsif( $sort_type =~ /^(?:count_mean|count_avg)$/i ) {
         $sort_key = "count_mean";
     } elsif( $sort_type =~ /^count_max$/i ) {
         $sort_key = "count_max";
@@ -12259,6 +12259,34 @@ sub calculate_all_statistics {
             # #417 sub-stage boundary: per-category population (walk/sort denominator).
             $stats_population_messages += scalar keys %{$log_messages{$category}};
 
+            # Two -so operands name a mean that no earlier stage has written onto
+            # the entry by the time the comparator runs (#428), so ranking on
+            # either compared undef against undef for every key and fell through
+            # to the string tiebreaker — a "top N" in lexicographic order.
+            # mean_bytes is only ever computed as a display local in the message
+            # summary, after selection; count_mean is written by the group-calc
+            # loop further down this sub, likewise after selection (and only for
+            # the keys that already survived it). Both are ratios of fields the
+            # read loop accumulates per key, so derive whichever one is being
+            # ranked on here: an O(n) pass ahead of the comparator rather than a
+            # division inside an O(n log n) comparison. Full precision, unlike the
+            # rounded display value — rounding at rank time would manufacture
+            # ties. A key with no observations of the underlying metric is left
+            # undef, which the comparator's // 0 handles.
+            if( $sort_key eq 'mean_bytes' ) {
+                foreach my $entry (values %{$log_messages{$category}}) {
+                    $entry->{mean_bytes} = ( defined $entry->{total_bytes} && $entry->{occurrences} )
+                        ? ( $entry->{total_bytes} / $entry->{occurrences} )
+                        : undef;
+                }
+            } elsif( $sort_key eq 'count_mean' ) {
+                foreach my $entry (values %{$log_messages{$category}}) {
+                    $entry->{count_mean} = ( defined $entry->{count_sum} && $entry->{count_occurrences} )
+                        ? ( $entry->{count_sum} / $entry->{count_occurrences} )
+                        : undef;
+                }
+            }
+
             # A calculated-statistic sort key is exactly a key of the #305
             # group registry (%STAT_FIELD_GROUP covers the full 22-field
             # duration ladder); available-value sort keys (occurrences,
@@ -13420,9 +13448,9 @@ sub normalize_data_for_output {
 
         foreach my $category_bucket (keys %{$log_occurrences{$bucket}}) {
             my $occurrences = $log_occurrences{$bucket}{$category_bucket}{occurrences};
-            next unless $occurrences > 0 && $category_bucket !~ /^empty|err-rate|msg-rate$/; 			# don't include the empty bucket who's purpose is to normalize the buckets represented
+            next unless $occurrences > 0 && $category_bucket !~ /^(?:empty|err-rate|msg-rate)$/; 			# don't include the empty bucket who's purpose is to normalize the buckets represented
             $total_occurrences += $occurrences;
-            $error_occurrences += $occurrences if $category_bucket =~ /^ERROR|5xx|4xx$/i;
+            $error_occurrences += $occurrences if $category_bucket =~ /^(?:ERROR|5xx|4xx)$/i;
         }
 
         # this part takes the time windows error and message counts and converts them to a rate (unit controlled by -ru, default per minute)
@@ -13640,7 +13668,7 @@ sub normalize_data_for_output {
 
         # Scale the log message counts for printing the graph
         foreach my $category_bucket (keys %{$log_occurrences{$bucket}}) {
-            next if $category_bucket =~ /^(err|msg)-rate|empty$/;
+            next if $category_bucket =~ /^(?:(?:err|msg)-rate|empty)$/;
             my $occurrences = $log_occurrences{$bucket}{$category_bucket}{occurrences};
             next if !defined $occurrences;										                # skip scaling where varible was left or is undefined (ie; no error or message rate)
             my $scaled_occurrences = $max_total{occurrences} != 0 ? int(($occurrences / $max_total{occurrences}) * $occ_width + 0.5) : 0;
@@ -14311,7 +14339,7 @@ sub print_bar_graph {
                 } elsif ($col_id eq 'occurrences') {
                     # Print category-colored blocks
                     foreach my $category_bucket (@log_levels) {
-                        next unless $category_bucket !~ /^empty|err-rate|msg-rate$/;
+                        next unless $category_bucket !~ /^(?:empty|err-rate|msg-rate)$/;
                         if (exists $log_occurrences{$bucket}{$category_bucket}) {
                             my $scaled_occurrences = $log_occurrences{$bucket}{$category_bucket}{scaled_occurrences};
                             $scaled_occurrences = 0 if $scaled_occurrences < 0;


### PR DESCRIPTION
Fixes #428.

## What was wrong

Every alternation in the `-so` operand ladder in `adapt_to_command_line_options()` was
unanchored on the right. `/^mean|avg$/i` parses as `/(^mean)|(avg$)/` — "starts with `mean`"
OR "ends with `avg`", not "is exactly `mean` or `avg`". Longer operands were therefore
swallowed by shorter branches appearing earlier in the ladder and never reached their own.

| Operand | Resolved to | Should resolve to |
|---|---|---|
| `mean_bytes` | `mean` | `mean_bytes` |
| `count_mean` | `count_sum` | `count_mean` |
| `count_avg` | `mean` | `count_mean` |
| `count_min` | `count_sum` | `count_min` |
| `count_max` | `count_sum` | `count_max` |

Two distinct user-visible failures:

**Silent wrong-metric ranking** — `count_min` and `count_max` ranked by `count_sum`, a field
holding real values. The output looked entirely plausible with nothing signalling that the
requested metric was not the one used. This is the more dangerous case: no visible symptom.

**Ranking nothing** — `mean_bytes`, `count_mean` and `count_avg` resolved to keys holding no
value at comparator time, so `// 0` made every key compare equal and the displayed top N was
decided by the `$a cmp $b` tiebreaker: lexicographic order, not a ranking.

The issue as filed named two operands and attributed the cause to fields never stored on the
message entry. That turned out to be a contributing cause affecting two operands, not the
root cause affecting five. Issue body and title updated to match, with a comment recording
the change.

## Fix

1. Anchor every alternation in the ladder — `/^(?:mean|avg)$/i` and equivalents. This repairs
   resolution for all five. `count_min`, `count_max` and `count_avg` then rank correctly with
   no further change, because the fields they name are already on the entry at comparator time.
2. Derive `mean_bytes` and `count_mean` onto the entry immediately before the sort block.
   These two are the ones that genuinely have no stored field when the comparator runs:
   `mean_bytes` exists only as a display local in `print_message_summary()`, and `count_mean`
   is written by the group-calc loop *after* selection (and only for keys that already
   survived it). Derived once per key — O(n) ahead of the comparator rather than a division
   inside an O(n log n) comparison — at full precision, since the rounded display value would
   manufacture ties. Only the operand actually being ranked on is derived.

Also anchors four category-bucket alternations carrying the same shape (`/^empty|err-rate|msg-rate$/`
×2, `/^ERROR|5xx|4xx$/i`, `/^(err|msg)-rate|empty$/`). Those branches are prefix-distinct
across the real category vocabulary so none mis-resolves today — anchored as hygiene, no
behaviour change.

## No documentation change

The accepted operand set is unchanged, so `print_help()` and `docs/usage.md` need no edit:
every operand they already document now ranks as documented. `tests/validate-help-content.sh`
passes unchanged.

## Verification

Verified against independently computed population values from the MESSAGES CSV, not merely
"the order changed":

- `-so count_mean` descending now returns means 1289, 392, 101, 27, 23 — an exact match for
  the top 5 computed over all 2000 keys. Before the fix it returned six keys all holding
  `count_mean` = 0 while the population contained means up to 1289.
- `-so mean_bytes` returns 11835, 2417, 1503, 504, 0 descending, and selects a different set
  than `-so bytes`, as a mean must.
- `count_avg` now agrees with `count_mean`; `count_min`/`count_max` rank on their own columns.
- No runtime warnings across all 14 sort operands on both a count-bearing and a count-less
  fixture.

## Completion gate

- **All 23 `tests/validate-*.sh` harnesses pass** — 969 assertions, 0 failures, no silent
  skips beyond the 9 deliberate doc-example skips.
- **Benchmark** `single-day-access-log-standard` vs `v0.16.0`: no metric worse by more than
  5%. The two rows marked REGRESS are explicitly below the noise floor (8 ms, 190 KB). Gate
  TSV deleted, not a deliverable.

## Follow-ups filed

- #432 — `mean_bytes` is inconsistent with the UDM/`count_*` metric-first convention. Filed
  separately: a user-facing vocabulary change with a compatibility dimension should not ride
  on a bug fix.
- The no-data-anywhere case (every key legitimately ties, no notice emitted) remains #418's
  general resolution for all sort metrics; deliberately not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
