### PR TITLE
Regenerate the index-read-back fixture when it goes stale, and resolve the log corpus in one place (#436)

### DIFF
--- a/features/179-index-read-back.md
+++ b/features/179-index-read-back.md
@@ -323,13 +323,13 @@ Tests parse the `=== INDEX READ-BACK ===` section from `-V` output and assert sp
 
 The prebuilt `tests/fixtures/ltl-index-readback.csv` and the two 5k sample
 logs it describes are generated, gitignored artifacts. Both the harness and
-`tests/fixtures/regenerate-index-readback-fixtures.sh` resolve the log
-corpus through `LTL_LOGS_DIR`, defaulting to `logs/` under the repo root.
-The two must agree: the fixture records absolute `file_path` values, so a
-harness resolving the corpus differently from the script that built the
-fixture finds no matching rows. Setting `LTL_LOGS_DIR` lets a checkout with
-no corpus of its own — a second clone, a git worktree — run against the
-real one.
+`tests/fixtures/regenerate-index-readback-fixtures.sh` read `$LOGS_DIR`
+from `tests/lib/logs-dir.sh`, the one place the corpus location is resolved
+(`logs/` under the repo root, or `LTL_LOGS_DIR`). The two must agree: the
+fixture records absolute `file_path` values, so a harness resolving the
+corpus differently from the script that built the fixture finds no matching
+rows — which is why neither composes the path itself. See
+`tests/HARNESS-DESIGN.md` § *The log corpus is resolved, never composed*.
 
 Freshness is a precondition of every pre-seeded scenario, not a property
 that can be assumed. `read_index_file()` accepts a row only when both the

--- a/features/179-index-read-back.md
+++ b/features/179-index-read-back.md
@@ -319,6 +319,40 @@ Each scenario is a named test case with explicit setup, action, and assertions. 
 
 Tests parse the `=== INDEX READ-BACK ===` section from `-V` output and assert specific keys equal specific values. The format defined in **`-V` verbose output** above is the contract. Tests do not assert against rendered bar-graph output (that's the existing regression suite's job); they assert against the read-back section.
 
+### Fixture lifecycle: corpus location and freshness
+
+The prebuilt `tests/fixtures/ltl-index-readback.csv` and the two 5k sample
+logs it describes are generated, gitignored artifacts. Both the harness and
+`tests/fixtures/regenerate-index-readback-fixtures.sh` resolve the log
+corpus through `LTL_LOGS_DIR`, defaulting to `logs/` under the repo root.
+The two must agree: the fixture records absolute `file_path` values, so a
+harness resolving the corpus differently from the script that built the
+fixture finds no matching rows. Setting `LTL_LOGS_DIR` lets a checkout with
+no corpus of its own — a second clone, a git worktree — run against the
+real one.
+
+Freshness is a precondition of every pre-seeded scenario, not a property
+that can be assumed. `read_index_file()` accepts a row only when both the
+recorded `file_size` and `file_mtime` still match the file on disk, so a
+fixture that exists but no longer describes the logs drives every
+pre-seeded scenario down the "no usable entry" path — failing assertions
+that describe correct behaviour, and presenting as a functional break in
+the read-back path rather than as a fixture problem.
+
+The harness therefore treats staleness exactly as it treats absence: before
+any scenario runs, `fixture_staleness_reason()` compares each recorded
+size/mtime pair against the live logs and reports the first divergence;
+a non-empty reason regenerates the fixture, printing the reason so the
+repair is visible rather than silent. Three divergences are detected —
+no file row for the path (fixture built against a different corpus or in a
+checkout that resolved `LTL_LOGS_DIR` elsewhere), `file_size` drift (the
+sample was re-sliced), and `file_mtime` drift (the sample was rewritten,
+copied or touched without changing its length). Any touch of the sample
+logs invalidates the pair, including the regenerate script's own re-slice
+run from another checkout. The same check is asserted in the helper
+self-test, so a mismatch surfaces as one named assertion rather than as a
+broad failure across the pre-seeded scenarios.
+
 ### `-V` instrumentation as the validation surface
 
 The labels and structure defined in this document are the test contract. Without that level of detail in `-V`, scenarios like `multi-file-all-fresh-tier2-unfiltered` (which must assert "the global `duration_max` came from `<F1>`") are not assertable.

--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -436,6 +436,21 @@ Every harness invocation also passes `-ni` (`--no-index`) unless the index is th
 
 Precedent: #384 (2026-08-23) — ten new format-detection scenarios and the ad-hoc parity checks behind them ran multi-year fixtures at default (and hourly) buckets, building tens of thousands of empty buckets to assert a per-file selection that never reads a bucket. #399 (audit every test harness for invocation coherence) tracks the audit of every existing harness against this rule.
 
+## The log corpus is resolved, never composed
+
+Harnesses read their inputs from the log corpus: `logs/` under the repo root by default, or wherever `LTL_LOGS_DIR` points. A harness never builds that location itself — no `"$REPO_DIR/logs/..."`, no bare `logs/...` assumed relative to the repo root. It sources `tests/lib/logs-dir.sh` and reads `$LOGS_DIR`, or calls `resolve_log_path` for a path that arrives as data (a scenario-table column, a fixture-source list).
+
+Two reasons this is a rule and not a preference:
+
+1. **`logs/` is gitignored, so it exists only in the checkout that populated it.** A second clone or a git worktree has no corpus, and every harness that composes the repo-root path is unrunnable there — the failure is an unrelated-looking "file not found" or, worse, a pass. `LTL_LOGS_DIR` points such a checkout at the real corpus.
+2. **A partially-applied override is worse than none.** When only some call sites honour it, the harness finds its inputs through one path and silently skips the work gated on another. During #436 exactly this happened: `validate-statistics.sh` reported 18/18 passing while the L3 oracle was skipped on all 36 cells (`L3=N/A`), because one of two copies of the same path-resolution logic had been updated. The suite was green and proving materially less than it claimed.
+
+Consequences for harness authors:
+
+- **One resolution surface.** `resolve_log_path` is it. A new `if [[ "$logfile" = /* ]]` ladder is a review defect — that duplication is what produced the silent skip above.
+- **Verify an override end-to-end, not by exit code.** A harness that resolves its corpus correctly and one that quietly skips its most expensive layer both exit 0. Check the counters the run reports (`L3=OK`, assertion counts, scenario counts) against a known-good run on the default path.
+- **Where the recorded path is part of the assertion, keep it relative.** `validate-regression.sh`, `capture-regression.sh` and `tests/baseline/run-benchmark.sh` pass repo-relative paths so no absolute path reaches captured references or the benchmark TSV (#209). These run from the directory *containing* the corpus rather than resolving an absolute path, which keeps `logs/...` intact under an override; because the captured prefix is the literal string `logs/`, an overriding corpus directory must itself be named `logs`, and they fail fast when it is not.
+
 ## Runtime-warning cleanliness
 
 Every harness that invokes `ltl` MUST capture the invocation's stderr and fail the run if it contains a Perl runtime warning. A runtime warning (uninitialized value, substr outside of string, non-numeric argument, out-of-range date field, ...) is an unguarded data path — a bug that has not yet found the input that makes it fatal or wrong — and a harness that discards stderr certifies code it never looked at.

--- a/tests/baseline/run-benchmark.sh
+++ b/tests/baseline/run-benchmark.sh
@@ -21,11 +21,28 @@ REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LTL="$REPO_DIR/ltl"
 RESULTS_DIR="$SCRIPT_DIR/results"
 
-# Run from the repo root and glob the logs relatively, so the paths handed to
-# ltl — and recorded verbatim in the benchmark TSV's FILES rows — are
-# repo-relative and the baseline stays portable across machines (#209).
-cd "$REPO_DIR"
-LOGS_DIR="logs"
+# Glob the logs relatively and run from the directory that contains the
+# corpus, so the paths handed to ltl — and recorded verbatim in the
+# benchmark TSV's FILES rows — stay relative and the baseline remains
+# portable across machines (#209).
+#
+# The corpus is logs/ under the repo root unless LTL_LOGS_DIR names another
+# one, which lets a checkout with no corpus of its own (a second clone, a
+# git worktree) benchmark against the real logs (#436). Running from the
+# corpus's parent rather than the repo root keeps the recorded paths
+# relative either way, so an override does not reintroduce the absolute
+# paths #209 removed.
+if [[ -n "${LTL_LOGS_DIR:-}" ]]; then
+    if [[ ! -d "$LTL_LOGS_DIR" ]]; then
+        echo "ERROR: LTL_LOGS_DIR is not a directory: $LTL_LOGS_DIR" >&2
+        exit 1
+    fi
+    LOGS_DIR="$(basename "$LTL_LOGS_DIR")"
+    cd "$(cd "$(dirname "$LTL_LOGS_DIR")" && pwd)"
+else
+    cd "$REPO_DIR"
+    LOGS_DIR="logs"
+fi
 
 # Default label is timestamp
 LABEL="$(date +%Y%m%d-%H%M%S)"

--- a/tests/capture-regression.sh
+++ b/tests/capture-regression.sh
@@ -16,11 +16,28 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LTL="$REPO_DIR/ltl"
 REF_DIR="${1:-$SCRIPT_DIR/reference-output}"
 
-# Run from the repo root so the log paths handed to ltl below are
-# repo-relative. ltl records paths verbatim and the file legend renders them,
-# so relative paths keep the captured references portable across checkouts
-# (#209). Everything else here is absolute and unaffected by the cd.
-cd "$REPO_DIR"
+# Run from the directory containing the log corpus so the log paths handed
+# to ltl below stay relative. ltl records paths verbatim and the file legend
+# renders them, so relative paths keep the captured references portable
+# across checkouts (#209). That is the repo root unless LTL_LOGS_DIR names a
+# corpus elsewhere (#436); it must be named `logs` so the captured prefix is
+# unchanged. Must match validate-regression.sh, which replays these commands.
+# Everything else here is absolute and unaffected by the cd.
+if [[ -n "${LTL_LOGS_DIR:-}" ]]; then
+    if [[ ! -d "$LTL_LOGS_DIR" ]]; then
+        echo "ERROR: LTL_LOGS_DIR is not a directory: $LTL_LOGS_DIR" >&2
+        exit 1
+    fi
+    if [[ "$(basename "$LTL_LOGS_DIR")" != "logs" ]]; then
+        echo "ERROR: LTL_LOGS_DIR must be a directory named 'logs' for this harness;" >&2
+        echo "       the captured references embed the literal path prefix 'logs/'." >&2
+        echo "       Got: $LTL_LOGS_DIR" >&2
+        exit 1
+    fi
+    cd "$(cd "$(dirname "$LTL_LOGS_DIR")" && pwd)"
+else
+    cd "$REPO_DIR"
+fi
 
 # Common options: suppress progress, summary table, and limit top messages
 COMMON="--disable-progress -ni -osum -n 1"

--- a/tests/fixtures/regenerate-index-readback-fixtures.sh
+++ b/tests/fixtures/regenerate-index-readback-fixtures.sh
@@ -9,8 +9,11 @@
 #     ltl-index.csv fixture becomes incompatible
 #   - You need to refresh the fixtures for any other reason
 #
-# It is intentional that the fixtures (sample logs + prebuilt index CSV)
-# are checked into git, so test runs do not need to rebuild them.
+# The fixtures (sample logs + prebuilt index CSV) are gitignored, generated
+# artifacts. tests/validate-index-read-back.sh runs this script itself when
+# they are missing or when the index no longer describes the logs it was
+# built from, so a run repairs the previous run's damage rather than
+# failing assertions against correct code.
 #
 # Produces:
 #   - logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt
@@ -34,13 +37,20 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LTL="$REPO_DIR/ltl"
 
-# --- Source logs (production data in logs/) ---
-TOMCAT_SOURCE="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt"
-SCRIPT_SOURCE="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log"
+# Location of the log corpus. Defaults to logs/ under the repo root; set
+# LTL_LOGS_DIR to point a checkout that has no corpus of its own (a second
+# clone, a git worktree) at the real one. The prebuilt index records
+# absolute paths, so this script and tests/validate-index-read-back.sh must
+# resolve the logs the same way or the harness will regenerate on every run.
+LOGS_DIR="${LTL_LOGS_DIR:-$REPO_DIR/logs}"
+
+# --- Source logs (production data in the corpus) ---
+TOMCAT_SOURCE="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt"
+SCRIPT_SOURCE="$LOGS_DIR/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log"
 
 # --- Sample-log targets ---
-TOMCAT_SAMPLE="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
-SCRIPT_SAMPLE="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+TOMCAT_SAMPLE="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+SCRIPT_SAMPLE="$LOGS_DIR/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 
 # --- Prebuilt index target ---
 INDEX_FIXTURE="$SCRIPT_DIR/ltl-index-readback.csv"

--- a/tests/fixtures/regenerate-index-readback-fixtures.sh
+++ b/tests/fixtures/regenerate-index-readback-fixtures.sh
@@ -37,12 +37,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LTL="$REPO_DIR/ltl"
 
-# Location of the log corpus. Defaults to logs/ under the repo root; set
-# LTL_LOGS_DIR to point a checkout that has no corpus of its own (a second
-# clone, a git worktree) at the real one. The prebuilt index records
-# absolute paths, so this script and tests/validate-index-read-back.sh must
-# resolve the logs the same way or the harness will regenerate on every run.
-LOGS_DIR="${LTL_LOGS_DIR:-$REPO_DIR/logs}"
+# The prebuilt index records absolute paths, so this script and
+# tests/validate-index-read-back.sh must resolve the corpus the same way or
+# the harness will regenerate on every run — both read $LOGS_DIR from the
+# shared resolver.
+# shellcheck source=../lib/logs-dir.sh
+source "$REPO_DIR/tests/lib/logs-dir.sh"
 
 # --- Source logs (production data in the corpus) ---
 TOMCAT_SOURCE="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt"

--- a/tests/lib/csv-cache.sh
+++ b/tests/lib/csv-cache.sh
@@ -62,6 +62,9 @@ _CSV_CACHE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_CSV_CACHE_LIB_DIR/runtime-warnings.sh"
 _CSV_CACHE_TESTS_DIR="$(cd "$_CSV_CACHE_LIB_DIR/.." && pwd)"
 _CSV_CACHE_REPO_DIR="$(cd "$_CSV_CACHE_TESTS_DIR/.." && pwd)"
+
+# shellcheck source=logs-dir.sh
+source "$_CSV_CACHE_LIB_DIR/logs-dir.sh"
 _CSV_CACHE_DIR="$_CSV_CACHE_TESTS_DIR/.artifacts/csv"
 _CSV_CACHE_CLEANUP="$_CSV_CACHE_TESTS_DIR/cleanup-test-artifacts.sh"
 _CSV_CACHE_LTL="$_CSV_CACHE_REPO_DIR/ltl"
@@ -168,11 +171,7 @@ csv_cache_produce() {
     mkdir -p "$_CSV_CACHE_DIR"
 
     local abs_log
-    if [[ "$logfile" = /* ]]; then
-        abs_log="$logfile"
-    else
-        abs_log="$_CSV_CACHE_REPO_DIR/$logfile"
-    fi
+    abs_log="$(resolve_log_path "$logfile")"
 
     if [[ ! -f "$abs_log" ]]; then
         echo "csv-cache: logfile missing: $abs_log" >&2

--- a/tests/lib/fixtures.sh
+++ b/tests/lib/fixtures.sh
@@ -15,7 +15,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 
 _FIXTURES_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_FIXTURES_REPO_DIR="$(cd "$_FIXTURES_LIB_DIR/../.." && pwd)"
+
+# shellcheck source=logs-dir.sh
+source "$_FIXTURES_LIB_DIR/logs-dir.sh"
 
 # derive_sampled_access_log DEST
 #   Writes the deterministic sampled Tomcat 9 access-log fixture to DEST:
@@ -26,7 +28,7 @@ _FIXTURES_REPO_DIR="$(cd "$_FIXTURES_LIB_DIR/../.." && pwd)"
 #   Hard-fails if the corpus file is missing or the derivation is empty.
 derive_sampled_access_log() {
     local dest="$1"
-    local src="$_FIXTURES_REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt"
+    local src="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt"
     if [[ ! -f "$src" ]]; then
         echo "ERROR: fixture corpus file missing: $src" >&2
         return 1

--- a/tests/lib/logs-dir.sh
+++ b/tests/lib/logs-dir.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# logs-dir.sh — resolve the log corpus every harness reads from.
+#
+# The corpus is logs/ under the repo root unless LTL_LOGS_DIR names another
+# one. Harnesses hardcoding the repo-root path cannot run at all from a
+# checkout that has no corpus of its own — a second clone, or a git
+# worktree, where logs/ is gitignored and exists only in the original
+# checkout. The override points such a checkout at the real logs (#436).
+#
+# One resolution surface: every harness sources this and reads $LOGS_DIR
+# rather than composing "$REPO_DIR/logs" itself, so the corpus location is
+# defined once and an override cannot reach some harnesses but not others.
+#
+# This file is meant to be sourced, not executed directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "ERROR: logs-dir.sh is a library; source it, do not execute it." >&2
+    exit 2
+fi
+
+_LOGS_DIR_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_LOGS_DIR_REPO_DIR="$(cd "$_LOGS_DIR_LIB_DIR/../.." && pwd)"
+
+if [[ -n "${LTL_LOGS_DIR:-}" ]]; then
+    if [[ ! -d "$LTL_LOGS_DIR" ]]; then
+        echo "ERROR: LTL_LOGS_DIR is not a directory: $LTL_LOGS_DIR" >&2
+        exit 1
+    fi
+    LOGS_DIR="$(cd "$LTL_LOGS_DIR" && pwd)"
+else
+    LOGS_DIR="$_LOGS_DIR_REPO_DIR/logs"
+fi
+
+# resolve_log_path PATH
+#   Echoes the absolute location of a logfile named the way scenario tables
+#   and harness variables name them. An absolute path is returned unchanged;
+#   a logs/-prefixed path resolves against the corpus, so LTL_LOGS_DIR
+#   redirects it; any other relative path stays repo-relative.
+#
+#   One resolution surface: callers must not re-implement this test, or an
+#   override reaches some of them and not others — which shows up as a
+#   harness that still passes while silently skipping the work it gates
+#   (the L3 oracle skipped every scenario when only one of two copies of
+#   this logic had been updated).
+resolve_log_path() {
+    local logfile="$1"
+    case "$logfile" in
+        /*)      printf '%s' "$logfile" ;;
+        logs/*)  printf '%s' "$LOGS_DIR/${logfile#logs/}" ;;
+        *)       printf '%s' "$_LOGS_DIR_REPO_DIR/$logfile" ;;
+    esac
+}

--- a/tests/validate-csv-output.sh
+++ b/tests/validate-csv-output.sh
@@ -31,6 +31,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 HARNESS_DIR="$SCRIPT_DIR/csv-output"
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence): each
@@ -45,6 +48,7 @@ PROFILE_GENERATOR="$SCRIPT_DIR/profile/generate-profile-log.py"
 
 # shellcheck source=lib/csv-cache.sh
 source "$SCRIPT_DIR/lib/csv-cache.sh"
+
 
 # End-of-run cleanup runs only when standalone (CI unset). Trap covers
 # both clean exit and error paths.
@@ -97,7 +101,7 @@ fi
 APPLOG_HEAD="$SCRIPT_DIR/.artifacts/applicationlog-head-100k.log"
 if grep -q '@APPLOG_HEAD@' "$SCENARIOS_TSV"; then
     mkdir -p "$(dirname "$APPLOG_HEAD")"
-    head -100000 "$REPO_DIR/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log" > "$APPLOG_HEAD"
+    head -100000 "$LOGS_DIR/ThingworxLogs/ApplicationLog.2025-05-05.0.log" > "$APPLOG_HEAD"
     if [[ ! -s "$APPLOG_HEAD" ]]; then
         echo "ERROR: could not stage the ApplicationLog head fixture at $APPLOG_HEAD" >&2
         exit 1

--- a/tests/validate-doc-examples.sh
+++ b/tests/validate-doc-examples.sh
@@ -24,6 +24,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
+
 LTL="$REPO_DIR/ltl"
 EXTRACTOR="$SCRIPT_DIR/extract-doc-examples.pl"
 
@@ -66,10 +70,11 @@ FIXTURE_KEYS=(
     "app.log"
     "error.log"
 )
+# Paths within the log corpus ($LOGS_DIR), not the repo.
 FIXTURE_SOURCES=(
-    "logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
-    "logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log"
-    "logs/ThingworxLogs/ErrorLog.log"
+    "AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
+    "ThingworxLogs/ApplicationLog.2025-05-05.0.log"
+    "ThingworxLogs/ErrorLog.log"
 )
 FIXTURE_WINDOWS=(
     '\[25/Jan/2026:07:'          # one hour, 667 lines (the file's dense day)
@@ -258,7 +263,7 @@ run_doc_example() {
 # Build truncated fixtures (HARNESS-DESIGN.md Trap 9: transient artifacts
 # live under $TMP_DIR, never alongside deliverables).
 for i in "${!FIXTURE_KEYS[@]}"; do
-    src="${REPO_DIR}/${FIXTURE_SOURCES[$i]}"
+    src="${LOGS_DIR}/${FIXTURE_SOURCES[$i]}"
     if [[ ! -f "$src" ]]; then
         echo "ERROR: fixture source not found: $src"
         exit 1

--- a/tests/validate-duration-display.sh
+++ b/tests/validate-duration-display.sh
@@ -22,6 +22,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 CHECKER="$SCRIPT_DIR/duration-display/check-duration-cells.pl"
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence):
@@ -39,12 +42,13 @@ ACCESS_LOG="$REPO_DIR/tests/fixtures/tomcat-access-duration-spread.txt"
 # Apache HTTP2 access log: the %D trailing field is request duration in genuine
 # microseconds, so -du us resolves to a microsecond source (6 decimals). Used to
 # cover a non-ms resolved unit.
-APACHE_LOG="$REPO_DIR/logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
+APACHE_LOG="$LOGS_DIR/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
 PERL="${PERL:-/opt/homebrew/bin/perl}"
 command -v "$PERL" >/dev/null 2>&1 || PERL=perl
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 
 if [[ ! -x "$LTL" ]]; then
     echo "ERROR: ltl not found or not executable at $LTL"; exit 1

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -32,10 +32,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 
 # Temp dir for captured outputs; cleaned up on EXIT per HARNESS-DESIGN.md Trap 10.
 TMP_DIR=$(mktemp -d)
@@ -273,7 +277,7 @@ scenario_tomcat9_ms() {
     current_scenario="tomcat9-ms"
     echo "[$current_scenario]"
 
-    local log="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+    local log="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
     local out
     out=$(run_format_detection "$log")
     check_capture_warnings "$out"
@@ -305,7 +309,7 @@ scenario_tomcat_common() {
     # field). Derived on the fly from the canonical Tomcat 9 fixture by
     # stripping the trailing %D field, so the two scenarios cannot drift
     # apart and no near-duplicate corpus file is needed. Issue #345.
-    local src="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+    local src="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
     local log="$TMP_DIR/tomcat-access-common-5k.txt"
     awk '{NF=NF-1; print}' "$src" > "$log"
     if [[ ! -s "$log" ]]; then
@@ -347,7 +351,7 @@ scenario_jboss_enhanced() {
     # near-duplicate corpus file is needed. Lines with "-" bytes are excluded:
     # the match_type 9 regex requires numeric bytes, and such lines fall through
     # to match_type 3 by design. Issue #365.
-    local src="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+    local src="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
     local log="$TMP_DIR/jboss-enhanced-access.txt"
     awk '$(NF-1) ~ /^[0-9]+$/ {dur=$NF; $NF="\"-\" \"Jersey/2.37 (HttpUrlConnection 11.0.22)\" " dur; print}' "$src" > "$log"
     if [[ ! -s "$log" ]]; then
@@ -388,7 +392,7 @@ scenario_apache_httpd_us() {
     current_scenario="apache-httpd-us"
     echo "[$current_scenario]"
 
-    local log="$REPO_DIR/logs/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
+    local log="$LOGS_DIR/AccessLogs/ApacheHTTP2Server-access_log-Windchill_Navigate.2026-01-25.log"
     local out
     # Run with -du us per the documented workaround. Apache HTTP %D is
     # microseconds; without -du us, durations are 1000x off.
@@ -412,7 +416,7 @@ scenario_codebeamer() {
     current_scenario="codebeamer"
     echo "[$current_scenario]"
 
-    local log="$REPO_DIR/logs/Codebeamber/codebeamer_access_log.2025-10-29.txt"
+    local log="$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt"
     local out
     out=$(run_format_detection "$log")
     check_capture_warnings "$out"
@@ -440,7 +444,7 @@ scenario_thingworx_standard() {
     current_scenario="thingworx-standard"
     echo "[$current_scenario]"
 
-    local log; log=$(head_slice "$REPO_DIR/logs/ThingworxLogs/ApplicationLog.2025-05-05.0.log" ApplicationLog.2025-05-05.0.log)
+    local log; log=$(head_slice "$LOGS_DIR/ThingworxLogs/ApplicationLog.2025-05-05.0.log" ApplicationLog.2025-05-05.0.log)
     local out
     out=$(run_format_detection "$log")
     check_capture_warnings "$out"
@@ -462,7 +466,7 @@ scenario_thingworx_with_metrics() {
     current_scenario="thingworx-with-metrics"
     echo "[$current_scenario]"
 
-    local log; log=$(head_slice "$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log" ScriptLog-DPMExtended-clean.log)
+    local log; log=$(head_slice "$LOGS_DIR/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean.log" ScriptLog-DPMExtended-clean.log)
     local out
     out=$(run_format_detection "$log")
     check_capture_warnings "$out"
@@ -484,7 +488,7 @@ scenario_tw_edge_c_sdk() {
     current_scenario="tw-edge-c-sdk"
     echo "[$current_scenario]"
 
-    local log; log=$(head_slice "$REPO_DIR/logs/UDM/rea-assets-5402_-TW_SSL_READ-Read_0_bytes-trace_logs.log" tw-edge-c-sdk-trace.log)
+    local log; log=$(head_slice "$LOGS_DIR/UDM/rea-assets-5402_-TW_SSL_READ-Read_0_bytes-trace_logs.log" tw-edge-c-sdk-trace.log)
     local out
     out=$(run_format_detection "$log")
     check_capture_warnings "$out"
@@ -506,7 +510,7 @@ scenario_csv_with_udm() {
     current_scenario="csv-with-udm"
     echo "[$current_scenario]"
 
-    local log; log=$(head_slice "$REPO_DIR/logs/UDM/results_data_idonly-timestampMs.csv" results_data_idonly-timestampMs.csv)
+    local log; log=$(head_slice "$LOGS_DIR/UDM/results_data_idonly-timestampMs.csv" results_data_idonly-timestampMs.csv)
     local out
     # CSV detection requires at least one -udm flag for the CSV path to
     # be reached; otherwise ltl treats every CSV line as unmatched log content.
@@ -667,7 +671,7 @@ scenario_scan_telemetry() {
     # four non-ancestors in the static order, so the first match promotes
     # it to the front (exactly one promotion), after which every line hits
     # the front block and no further promotion occurs.
-    local log="$REPO_DIR/logs/Codebeamber/codebeamer_access_log.2025-10-29.txt"
+    local log="$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt"
     local out
     out=$(run_format_detection "$log")
     check_capture_warnings "$out"
@@ -817,7 +821,7 @@ scenario_scan_telemetry_nomatch() {
     # sampling threshold, so exactly one sampled timing must be recorded;
     # 20 codebeamer lines appended after them prove failed attempts and
     # matches coexist in one file's counters.
-    local src="$REPO_DIR/logs/Codebeamber/codebeamer_access_log.2025-10-29.txt"
+    local src="$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt"
     local log="$TMP_DIR/scan-nomatch-mixed.txt"
     {
         for i in $(seq 1 300); do echo "junk unmatched line $i without any timestamp"; done
@@ -894,7 +898,7 @@ scenario_unit_ambiguity_warning() {
     # check_capture_warnings stays clean. The Tomcat file's name does not
     # carry the producer's stem, so the group default holds by its standing
     # credit (basis default).
-    local tomcat="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+    local tomcat="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
     local out
     out=$(run_format_detection "$tomcat")
     check_capture_warnings "$out"
@@ -925,7 +929,7 @@ scenario_unit_ambiguity_warning() {
     # Contracted absence 2: a format outside any variant group (codebeamer)
     # never triggers the note.
     local out_cb
-    out_cb=$(run_format_detection "$REPO_DIR/logs/Codebeamber/codebeamer_access_log.2025-10-29.txt")
+    out_cb=$(run_format_detection "$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt")
     check_capture_warnings "$out_cb"
 
     assert_absent "$out_cb.stderr" \

--- a/tests/validate-heatmap-palette.sh
+++ b/tests/validate-heatmap-palette.sh
@@ -24,6 +24,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence):
 # every assertion reads the -V heatmap-palette section - the resolved
@@ -31,11 +34,12 @@ LTL="$REPO_DIR/ltl"
 # heatmap cell. The 5k ScriptLog slice (durationMS, bytes and count on
 # every line, so each -hm metric resolves) at `-bs 1440 -oe -n 1 -osum`
 # produces the identical section.
-SCRIPT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+SCRIPT_LOG="$LOGS_DIR/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 SHAPE="-bs 1440 -oe -n 1 -osum"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 
 if [[ ! -x "$LTL" ]]; then
     echo "ERROR: ltl not found or not executable at $LTL"

--- a/tests/validate-help-content.sh
+++ b/tests/validate-help-content.sh
@@ -24,15 +24,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 USAGE_MD="$REPO_DIR/docs/usage.md"
 # Test log: tiny clean access log (~83 KB). Per repo memory
 # (feedback_test_logs.md) avoid the corrupt 2025-03-21 file; Codebeamer's
 # log is the smallest clean fixture available.
-TEST_LOG="$REPO_DIR/logs/Codebeamber/codebeamer_access_log.2025-10-29.txt"
+TEST_LOG="$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 
 # Temp dir for captured outputs; cleaned up on EXIT (HARNESS-DESIGN.md Trap 10).
 TMP_DIR=$(mktemp -d)

--- a/tests/validate-histogram-bin-counters.sh
+++ b/tests/validate-histogram-bin-counters.sh
@@ -15,10 +15,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence):
 # every assertion here reads the -V section's contract surface - which
@@ -29,7 +33,7 @@ source "$SCRIPT_DIR/lib/runtime-warnings.sh"
 # `-bs 1440 -oe` keeps the timeline to the one bucket the per-time-bucket
 # partition assertions need. -osum/-hst stay OFF: the summary table and the
 # per-bucket statistics demand are what activate the consumers under test.
-ACCESS_LOG="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+ACCESS_LOG="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
 SHAPE="-bs 1440 -oe"
 
 if [[ ! -x "$LTL" ]]; then

--- a/tests/validate-index-read-back.sh
+++ b/tests/validate-index-read-back.sh
@@ -24,11 +24,18 @@ LTL="$REPO_DIR/ltl"
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
 
+# Location of the log corpus. Defaults to logs/ under the repo root; set
+# LTL_LOGS_DIR to point a checkout that has no corpus of its own (a second
+# clone, a git worktree) at the real one. The fixture records absolute
+# paths, so this harness and the regenerate script must resolve the logs
+# the same way or the recorded rows will not match the files under test.
+LOGS_DIR="${LTL_LOGS_DIR:-$REPO_DIR/logs}"
+
 # 5k-line samples of real production logs, sliced from the middle of the
 # corresponding logs/<source>/ files. See docs/test-logs.md and
 # tests/fixtures/regenerate-index-readback-fixtures.sh for derivation.
-ACCESS_LOG="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
-SCRIPT_LOG="$REPO_DIR/logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
+ACCESS_LOG="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+SCRIPT_LOG="$LOGS_DIR/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k.log"
 
 # Prebuilt ltl-index.csv covering both ACCESS_LOG and SCRIPT_LOG with file
 # rows + unfiltered selection rows + filtered (-dmin=50) selection rows.
@@ -49,16 +56,87 @@ if [[ ! -x "$LTL" ]]; then
     exit 1
 fi
 
+# Report why the prebuilt index no longer describes the sample logs, or
+# nothing when it still does.
+#
+# The fixture records each log's file_size and file_mtime as they were at
+# generation time, and ltl rejects an index row whose recorded pair no
+# longer matches the file on disk (read_index_file(): the row is fresh only
+# when $size_match && $mtime_match). A fixture that exists but has gone
+# stale therefore sends every pre-seeded scenario down the "no usable
+# entry" path and fails assertions that describe correct behaviour, so
+# staleness has to be treated exactly as absence is.
+#
+# Three ways the fixture stops describing the logs, all caught here:
+#   - no row for the path   fixture generated against a different corpus,
+#                           or in a checkout that resolved LTL_LOGS_DIR
+#                           elsewhere (rows carry absolute paths)
+#   - file_size differs     the sample log was re-sliced
+#   - file_mtime differs    the sample log was rewritten, copied or touched
+#                           without changing its length
+#
+# Usage: reason=$(fixture_staleness_reason)   # empty when fresh
+fixture_staleness_reason() {
+    [[ -f "$INDEX_FIXTURE" ]] || { echo "fixture does not exist"; return 0; }
+    perl -MText::CSV -e '
+        use POSIX qw(strftime);
+        my ($fixture, @logs) = @ARGV;
+        my $csv = Text::CSV->new({binary => 1, eol => $/});
+        open my $fh, "<", $fixture or do { print "fixture is unreadable"; exit 0 };
+        my (%ci, $header, %file_row);
+        while (my $r = $csv->getline($fh)) {
+            if (!$header) { $header = $r; $ci{$r->[$_]} = $_ for 0..$#$r; next; }
+            next unless ($r->[$ci{entry_type}] // "") eq "file";
+            $file_row{ $r->[$ci{file_path}] // "" } = $r;
+        }
+        close $fh;
+        for my $log (@logs) {
+            my $r = $file_row{$log};
+            if (!$r) { print "fixture has no file row for $log"; exit 0 }
+            my @st = stat($log);
+            if (!@st) { print "cannot stat $log"; exit 0 }
+            my $size      = $st[7];
+            my $mtime     = strftime("%Y-%m-%dT%H:%M:%S", gmtime($st[9]));
+            my $rec_size  = $r->[$ci{file_size}]  // "";
+            my $rec_mtime = $r->[$ci{file_mtime}] // "";
+            if ($rec_size ne "$size") {
+                print "file_size drift for $log (fixture $rec_size, on disk $size)"; exit 0;
+            }
+            if ($rec_mtime ne $mtime) {
+                print "file_mtime drift for $log (fixture $rec_mtime, on disk $mtime)"; exit 0;
+            }
+        }
+    ' "$INDEX_FIXTURE" "$ACCESS_LOG" "$SCRIPT_LOG"
+}
+
 # The sample logs and prebuilt index are gitignored derived artifacts. If
-# any are missing, run the regenerate script to produce them, then check
-# again. If they are still missing the script itself failed (typically
-# because the source logs in logs/ are not present locally) — hard-fail
-# with a clear diagnostic.
+# any are missing — or the index no longer describes the logs it was built
+# from — run the regenerate script to produce them, then check again. If
+# they are still missing the script itself failed (typically because the
+# source logs in logs/ are not present locally) — hard-fail with a clear
+# diagnostic.
+#
+# Regenerating on staleness is what makes one run repair the previous run's
+# damage instead of reporting 29 failures against correct code (#436): any
+# touch of the sample logs, including the regenerate script's own re-slice
+# from another checkout, invalidates the recorded size/mtime pair.
 REGENERATE_SCRIPT="$SCRIPT_DIR/fixtures/regenerate-index-readback-fixtures.sh"
+regenerate_reason=""
 if [[ ! -f "$ACCESS_LOG" || ! -f "$SCRIPT_LOG" || ! -f "$INDEX_FIXTURE" ]]; then
-    echo "Fixtures missing; running $REGENERATE_SCRIPT to generate them..."
+    regenerate_reason="fixtures missing"
+else
+    stale_reason=$(fixture_staleness_reason)
+    [[ -n "$stale_reason" ]] && regenerate_reason="fixture is stale: $stale_reason"
+fi
+if [[ -n "$regenerate_reason" ]]; then
+    echo "Regenerating fixtures ($regenerate_reason); running $REGENERATE_SCRIPT..."
     if ! "$REGENERATE_SCRIPT"; then
         echo "ERROR: $REGENERATE_SCRIPT failed; cannot run this harness" >&2
+        exit 1
+    fi
+    stale_reason=$(fixture_staleness_reason)
+    if [[ -n "$stale_reason" ]]; then
+        echo "ERROR: fixture still stale after regenerate: $stale_reason" >&2
         exit 1
     fi
 fi
@@ -417,6 +495,13 @@ helper_self_test() {
         label       'fixture seeds at least one file row and one selection row' \
         asserts     'The prebuilt fixture must carry both row kinds (file rows and selection rows) so scenarios exercising either tier have something to match against' \
         produced_by 'tests/fixtures/regenerate-index-readback-fixtures.sh (produces tests/fixtures/ltl-index-readback.csv)' \
+        contract    'features/179-index-read-back.md section Validation - Test scenarios; fixture invariant'
+
+    assert_command \
+        command     '[[ -z "$(fixture_staleness_reason)" ]]' \
+        label       'fixture describes the sample logs on disk (fresh size + mtime)' \
+        asserts     'Every pre-seeded scenario depends on ltl accepting the fixture rows as fresh, which it does only when each recorded file_size and file_mtime still matches the live log; asserting freshness here names the fixture as the fault when the logs have moved under it, instead of letting it surface as a broad functional break across every pre-seeded scenario' \
+        produced_by 'fixture_staleness_reason() in tests/validate-index-read-back.sh, compared against the freshness gate in read_index_file() in ltl' \
         contract    'features/179-index-read-back.md section Validation - Test scenarios; fixture invariant'
 
     # Test delete_index_rows: remove all selection rows.

--- a/tests/validate-index-read-back.sh
+++ b/tests/validate-index-read-back.sh
@@ -24,12 +24,11 @@ LTL="$REPO_DIR/ltl"
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
 
-# Location of the log corpus. Defaults to logs/ under the repo root; set
-# LTL_LOGS_DIR to point a checkout that has no corpus of its own (a second
-# clone, a git worktree) at the real one. The fixture records absolute
-# paths, so this harness and the regenerate script must resolve the logs
-# the same way or the recorded rows will not match the files under test.
-LOGS_DIR="${LTL_LOGS_DIR:-$REPO_DIR/logs}"
+# The fixture records absolute paths, so this harness and the regenerate
+# script must resolve the corpus the same way or the recorded rows will not
+# match the files under test — both read $LOGS_DIR from lib/logs-dir.sh.
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 
 # 5k-line samples of real production logs, sliced from the middle of the
 # corresponding logs/<source>/ files. See docs/test-logs.md and

--- a/tests/validate-numeric-criteria-notices.sh
+++ b/tests/validate-numeric-criteria-notices.sh
@@ -21,16 +21,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 # Boundary fixture: exactly one line lacks a duration value (BD-dur-missing),
 # one lacks bytes (BD-bytes-missing), one lacks count (BD-count-missing);
 # every other line carries all three metrics.
 BOUNDARY_FIXTURE="$REPO_DIR/tests/fixtures/numeric-highlight-boundary.txt"
 # Access log on which every line carries a duration value.
-ACCESS_LOG="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+ACCESS_LOG="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
 
 if [[ ! -x "$LTL" ]]; then
     echo "ERROR: ltl not found or not executable at $LTL"; exit 1

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -17,10 +17,28 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LTL="$REPO_DIR/ltl"
 REF_DIR="${1:-$SCRIPT_DIR/reference-output}"
 
-# Run from the repo root so the log paths handed to ltl below are
-# repo-relative; must match capture-regression.sh, which captured the
-# references the same way.
-cd "$REPO_DIR"
+# Run from the directory containing the log corpus so the log paths handed
+# to ltl below stay relative; must match capture-regression.sh, which
+# captured the references the same way. That is the repo root unless
+# LTL_LOGS_DIR names a corpus elsewhere (#436), in which case its parent
+# serves the same role — the reference output embeds the literal prefix
+# `logs/`, so an overriding corpus directory has to be named `logs` for the
+# captured paths to match.
+if [[ -n "${LTL_LOGS_DIR:-}" ]]; then
+    if [[ ! -d "$LTL_LOGS_DIR" ]]; then
+        echo "ERROR: LTL_LOGS_DIR is not a directory: $LTL_LOGS_DIR" >&2
+        exit 1
+    fi
+    if [[ "$(basename "$LTL_LOGS_DIR")" != "logs" ]]; then
+        echo "ERROR: LTL_LOGS_DIR must be a directory named 'logs' for this harness;" >&2
+        echo "       the reference output embeds the literal path prefix 'logs/'." >&2
+        echo "       Got: $LTL_LOGS_DIR" >&2
+        exit 1
+    fi
+    cd "$(cd "$(dirname "$LTL_LOGS_DIR")" && pwd)"
+else
+    cd "$REPO_DIR"
+fi
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -22,14 +22,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence): the
 # -V runtime-config section echoes the resolved options, so -bs/-dmp/-mdm on
 # each run ARE the subject; the 741-line, 4-hour fixture is already minimal.
-TEST_LOG="$REPO_DIR/logs/Codebeamber/codebeamer_access_log.2025-10-29.txt"
+TEST_LOG="$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/tests/validate-statistics-demand.sh
+++ b/tests/validate-statistics-demand.sh
@@ -18,15 +18,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
 LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence): the
 # demand registry is driven by which consumers are active (summary table,
 # CSV, sort field, heatmap), so display options are the subject and none is
 # suppressed; the 5k, 4-minute slice is already minimal.
-ACCESS_LOG="$REPO_DIR/logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
+ACCESS_LOG="$LOGS_DIR/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt"
 
 if [[ ! -x "$LTL" ]]; then
     echo "ERROR: ltl not found or not executable at $LTL"

--- a/tests/validate-statistics.sh
+++ b/tests/validate-statistics.sh
@@ -51,6 +51,9 @@ SCENARIOS_TSV="$HARNESS_DIR/scenarios.tsv"
 ENGINE="$HARNESS_DIR/compare-statistics-drift.pl"
 BASELINES_DIR="$HARNESS_DIR/baselines"
 
+# shellcheck source=lib/logs-dir.sh
+source "$SCRIPT_DIR/lib/logs-dir.sh"
+
 # shellcheck source=lib/csv-cache.sh
 source "$SCRIPT_DIR/lib/csv-cache.sh"
 
@@ -181,11 +184,7 @@ oracle_json_for_logfile() {
     fi
     mkdir -p "$ORACLE_CACHE_DIR"
     local abs_log
-    if [[ "$logfile" = /* ]]; then
-        abs_log="$logfile"
-    else
-        abs_log="$REPO_DIR/$logfile"
-    fi
+    abs_log="$(resolve_log_path "$logfile")"
     if ! python3 "$ORACLE_SCRIPT" \
             --log "$abs_log" \
             --bucket-size-seconds "$bs_sec" \
@@ -224,11 +223,7 @@ pa_capture_for_scenario() {
         return 0
     fi
     local abs_log
-    if [[ "$logfile" = /* ]]; then
-        abs_log="$logfile"
-    else
-        abs_log="$REPO_DIR/$logfile"
-    fi
+    abs_log="$(resolve_log_path "$logfile")"
     local tmp
     tmp="$(mktemp)"
     # shellcheck disable=SC2086  # word-splitting on $options is intentional


### PR DESCRIPTION
Fixes #436.

## The reported bug

`tests/fixtures/ltl-index-readback.csv` records each sample log's `file_size` and `file_mtime`, and `read_index_file()` accepts an index row only when both still match the file on disk. The harness guard tested the fixture for existence but never for freshness, so a fixture that no longer described the logs drove every pre-seeded scenario down the "no usable entry" path — failing assertions against entirely correct code, and presenting as a functional break in the read-back path rather than as a fixture problem. Reproduced here: `touch`ing the two sample logs took the harness from 58 passed to 30 passed / 28 failed.

`fixture_staleness_reason()` now detects three divergences and regenerates, printing the reason so the repair is visible:

- no file row for the path — fixture built against a different corpus or checkout
- `file_size` drift — the sample was re-sliced
- `file_mtime` drift — the sample was rewritten, copied or touched without changing its length

Steady state regenerates nothing, so there is no per-run cost. The same check is asserted in the helper self-test, so a mismatch surfaces as one named assertion instead of a broad failure across every pre-seeded scenario.

## The corpus sweep

`logs/` is gitignored and exists only in the checkout that populated it, so sixteen harnesses and helpers that composed `"$REPO_DIR/logs/..."` for themselves were unrunnable from a second clone or a git worktree. `tests/lib/logs-dir.sh` is now the one resolution surface — `$LOGS_DIR` (default `logs/` under the repo root, or `LTL_LOGS_DIR`) plus `resolve_log_path` for paths arriving as data, such as scenario-table columns.

**A partially-applied override is worse than none, and this nearly shipped as one.** `validate-statistics.sh` carried a second copy of the same path-resolution ladder for the oracle. With only `csv-cache.sh` converted it reported 18/18 scenarios passing while the L3 oracle silently skipped all 36 cells — `L3=N/A`, against `36 L3=OK` on the default path. A green suite proving materially less than it claimed. Both copies now call `resolve_log_path`, and verification checks that counter rather than the exit code.

Where the recorded path is itself part of the assertion — `capture-regression.sh` and `validate-regression.sh`, whose reference output embeds the literal `logs/` prefix, and `run-benchmark.sh`, whose TSV `FILES` rows must stay portable (#209) — paths stay relative. Those run from the directory *containing* the corpus rather than resolving an absolute path, and reject an overriding corpus directory not named `logs`, since the captured prefix would otherwise stop matching. Noted on #209.

## Verification

Completion gate run on `92b51f2`, both ways, with a cold cache:

| | result |
|---|---|
| Full 23-harness suite, default path | matches baseline |
| Full 23-harness suite, no `logs/` in the checkout, via `LTL_LOGS_DIR` | matches baseline |
| `L3=OK` count, both paths | 36 / 36 |
| Benchmark vs `v0.16.0` | nothing worse by >5%; recorded path stays relative |

Three harnesses fail on both paths — `validate-explain` (145/3), `validate-format-detection` (191/1), `validate-format-registry` (21/1). All pre-existing and unrelated: confirmed by stashing this work and reproducing identical counts and assertions on a pristine tree. They are not addressed here.

## Release notes

No bullet: the change is confined to `tests/` and `features/` and alters nothing a user of `ltl` observes.
