### PR TITLE
Neutralise ambient colour environment in every harness (#438)

### DIFF
--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -476,6 +476,24 @@ fi
 
 The rule exists because the `udm-counting` csv-output scenario exercised the exact code path of a per-message uninitialized-division bug and emitted 125 warnings on every run — invisibly, because no harness read stderr (Issue #326). The sweep that brought every harness under the check was Issue #341.
 
+## Colour rendering is controlled, never inherited
+
+`ltl` decides whether to emit ANSI from two environment variables, checked in this order by `help_ansi_enabled()`: `FORCE_COLOR` (npm/chalk convention) turns ANSI on, then `NO_COLOR` (no-color.org) turns it off, then `-t STDOUT` decides. That precedence is deliberate and is not a harness concern. What *is* a harness concern is that both variables arrive from whatever shell launched the suite.
+
+A harness never inherits them. It sources `tests/lib/colour-env.sh` and calls `neutralize_colour_env` once at start-up, before any `ltl` invocation; a scenario that asserts on colour then pins **both** variables through `with_ascii_colour` / `with_ansi_colour` rather than setting the one it happens to be naming.
+
+Two reasons this is a rule and not a preference:
+
+1. **Setting one variable does not control the mode.** The ASCII scenario in `validate-explain.sh` ran `NO_COLOR=1 "$LTL" --explain mean` — correct in a bare shell, and wrong in a terminal exporting `FORCE_COLOR`, where `FORCE_COLOR` wins the precedence and ANSI is emitted anyway. The scenario asserted on plain text and silently became a test of precedence it never intended to run. A colour-mode assertion controls both sides of the switch or it controls neither.
+2. **The result must not depend on who launched the suite.** Release step 11 requires every `tests/validate-*.sh` to exit 0. With the variables inherited, the same commit was green from one terminal and red from another — `validate-explain.sh` 148/0 or 145/3, `validate-format-detection.sh` 192/0 or 191/1, `validate-format-registry.sh` 22/0 or 21/1 — with the failures reading as broken `--explain` rendering and broken `-lf` validation rather than as an environment artifact. The `produced_by` lines pointed into `help_ansi_enabled()`, `bs_bold()` and `bs_underline()`, and the misdirection cost an investigation during #436 before the three were established as pre-existing.
+
+Consequences for harness authors:
+
+- **The guard is applied to every harness, not to the ones observed failing.** Any harness matching an anchored pattern against `ltl` output is exposed: `print_usage()` renders its banner with ANSI wrapping under `FORCE_COLOR`, so an anchored `^Error: Unknown log format ...` stops matching — which is exactly how `validate-format-detection.sh` and `validate-format-registry.sh` failed without either one testing colour. A guard applied to the three known failures leaves the same latent inconsistency in the other twenty, and the next one surfaces as another misattributed investigation. Same reasoning as § *The log corpus is resolved, never composed*: a partially-applied environment override is worse than none.
+- **One neutralisation surface.** `tests/lib/colour-env.sh` is it. A bare `unset FORCE_COLOR` or an inline `NO_COLOR=1` prefix on an `ltl` invocation is a review defect — that per-call-site handling is what produced the original failure.
+- **Verify against a hostile environment, not a clean one.** A harness that inherits the ambient and one that neutralises it both pass from a shell where neither variable is set. The check is `FORCE_COLOR=3 CI=1 ./tests/validate-xxx.sh` against `env -u FORCE_COLOR -u NO_COLOR CI=1 ./tests/validate-xxx.sh`: the two runs must report identical counts.
+- **Colour-adjacent surfaces are not all gated by `help_ansi_enabled()`.** ASCII-mode output still carries SGR 0/90/109 sequences from other colour paths; the bold/underline assertions match SGR 1/22/4/24 specifically. An assertion that greps for "any escape sequence" will misfire — match the codes the scenario is actually about.
+
 ## Self-documenting assertions
 
 **Every assertion must answer three questions at the moment of failure, without the reader leaving the harness output:**

--- a/tests/lib/colour-env.sh
+++ b/tests/lib/colour-env.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# colour-env.sh — shared ambient-colour-environment guard for test harnesses
+# (tests/HARNESS-DESIGN.md § Colour rendering is controlled, never inherited,
+# issue #438).
+#
+# `ltl` decides whether to emit ANSI from two environment variables, checked
+# in this precedence order by help_ansi_enabled():
+#
+#     FORCE_COLOR (npm/chalk convention)  -> ANSI on
+#     NO_COLOR    (no-color.org)          -> ANSI off
+#     -t STDOUT                           -> ANSI iff stdout is a terminal
+#
+# That precedence is deliberate and is not what this library changes. The
+# problem it solves is that a harness inherits both variables from whatever
+# shell launched it, so the output it asserts against depends on the
+# operator's terminal rather than on the scenario. A harness asserting on
+# plain text with `NO_COLOR=1 "$LTL" ...` gets ANSI anyway when the launching
+# environment exports FORCE_COLOR — the assertion silently tests precedence
+# it never meant to test, and the same commit is green or red depending on
+# who ran it.
+#
+# The guard: neutralise both variables at harness start, so the harness
+# begins from the documented non-TTY default (ANSI off) regardless of the
+# launching shell. A scenario that cares about colour then sets BOTH sides
+# explicitly via the helpers below, never just the one it is naming.
+#
+# Public interface:
+#   neutralize_colour_env
+#       Unsets FORCE_COLOR and NO_COLOR in the harness's own environment.
+#       Called once at harness start, before any ltl invocation.
+#
+#   with_ascii_colour CMD [ARG...]
+#       Runs CMD with NO_COLOR=1 and FORCE_COLOR removed — ANSI off.
+#
+#   with_ansi_colour CMD [ARG...]
+#       Runs CMD with FORCE_COLOR=1 and NO_COLOR removed — ANSI on.
+#
+# Both helpers set the full pair, so neither depends on the ambient state
+# having been neutralised first; the assertion means the same thing whether
+# the harness is run from a bare shell, a CI runner, or a colour-forcing
+# terminal.
+#
+# This file is meant to be sourced, not executed directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "ERROR: colour-env.sh is a library; source it, do not execute it." >&2
+    exit 2
+fi
+
+# Remove both colour variables from the harness's environment, so every
+# ltl invocation that does not explicitly ask for a colour mode renders in
+# the non-TTY default. Safe under `set -u`: `unset` on an unset name is a
+# no-op and does not error.
+neutralize_colour_env() {
+    unset FORCE_COLOR
+    unset NO_COLOR
+    return 0
+}
+
+# Run a command with ANSI rendering forced OFF (both sides pinned).
+with_ascii_colour() {
+    NO_COLOR=1 env -u FORCE_COLOR "$@"
+}
+
+# Run a command with ANSI rendering forced ON (both sides pinned).
+with_ansi_colour() {
+    FORCE_COLOR=1 env -u NO_COLOR "$@"
+}

--- a/tests/validate-csv-input.sh
+++ b/tests/validate-csv-input.sh
@@ -19,6 +19,13 @@ LTL="$(cd "$SCRIPT_DIR/.." && pwd)/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/tests/validate-csv-output.sh
+++ b/tests/validate-csv-output.sh
@@ -49,6 +49,14 @@ PROFILE_GENERATOR="$SCRIPT_DIR/profile/generate-profile-log.py"
 # shellcheck source=lib/csv-cache.sh
 source "$SCRIPT_DIR/lib/csv-cache.sh"
 
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
+
 
 # End-of-run cleanup runs only when standalone (CI unset). Trap covers
 # both clean exit and error paths.

--- a/tests/validate-distribution-shape.sh
+++ b/tests/validate-distribution-shape.sh
@@ -55,6 +55,13 @@ GENERATOR="$SCRIPT_DIR/distribution-shape/generate-anchor.py"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 ONLY_ANCHOR=""
 while [[ $# -gt 0 ]]; do

--- a/tests/validate-doc-examples.sh
+++ b/tests/validate-doc-examples.sh
@@ -33,6 +33,13 @@ EXTRACTOR="$SCRIPT_DIR/extract-doc-examples.pl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Temp dir for per-test stdout/stderr captures; cleaned up on EXIT per
 # HARNESS-DESIGN.md Trap 10.

--- a/tests/validate-duration-display.sh
+++ b/tests/validate-duration-display.sh
@@ -48,6 +48,13 @@ command -v "$PERL" >/dev/null 2>&1 || PERL=perl
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 
 if [[ ! -x "$LTL" ]]; then

--- a/tests/validate-explain.sh
+++ b/tests/validate-explain.sh
@@ -28,6 +28,13 @@ EXPLAIN_MD="$REPO_DIR/docs/explain/statistics.md"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Temp dir for captured outputs (HARNESS-DESIGN.md Trap 10).
 TMP_DIR=$(mktemp -d)
@@ -700,7 +707,7 @@ scenario_table_border_alignment() {
         # apples-to-apples.
         local raw="$TMP_DIR/border-align-$topic.raw"
         set +e
-        FORCE_COLOR=1 "$LTL" --explain "$topic" > "$raw" 2>"$raw.stderr"
+        with_ansi_colour "$LTL" --explain "$topic" > "$raw" 2>"$raw.stderr"
         set -e
         check_stderr_warnings "$raw.stderr"
 
@@ -847,7 +854,7 @@ scenario_ascii_and_ansi_modes() {
     echo "[$current_scenario]"
     local out_ascii="$TMP_DIR/mode-ascii.raw"
     set +e
-    NO_COLOR=1 "$LTL" --explain mean > "$out_ascii" 2>"$out_ascii.stderr"
+    with_ascii_colour "$LTL" --explain mean > "$out_ascii" 2>"$out_ascii.stderr"
     set -e
     check_stderr_warnings "$out_ascii.stderr"
 
@@ -893,7 +900,7 @@ scenario_ascii_and_ansi_modes() {
     echo "[$current_scenario]"
     local out_ansi="$TMP_DIR/mode-ansi.raw"
     set +e
-    FORCE_COLOR=1 "$LTL" --explain mean > "$out_ansi" 2>"$out_ansi.stderr"
+    with_ansi_colour "$LTL" --explain mean > "$out_ansi" 2>"$out_ansi.stderr"
     set -e
     check_stderr_warnings "$out_ansi.stderr"
 

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -39,6 +39,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 
 # Temp dir for captured outputs; cleaned up on EXIT per HARNESS-DESIGN.md Trap 10.

--- a/tests/validate-format-registry.sh
+++ b/tests/validate-format-registry.sh
@@ -33,6 +33,13 @@ FIXTURES="$REPO_DIR/tests/fixtures/format-detection"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Temp dir for captured outputs; cleaned up on EXIT per HARNESS-DESIGN.md Trap 10.
 TMP_DIR=$(mktemp -d)

--- a/tests/validate-heatmap-palette.sh
+++ b/tests/validate-heatmap-palette.sh
@@ -39,6 +39,13 @@ SHAPE="-bs 1440 -oe -n 1 -osum"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 
 if [[ ! -x "$LTL" ]]; then

--- a/tests/validate-help-content.sh
+++ b/tests/validate-help-content.sh
@@ -36,6 +36,13 @@ TEST_LOG="$LOGS_DIR/Codebeamber/codebeamer_access_log.2025-10-29.txt"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 
 # Temp dir for captured outputs; cleaned up on EXIT (HARNESS-DESIGN.md Trap 10).

--- a/tests/validate-help-layout.sh
+++ b/tests/validate-help-layout.sh
@@ -35,6 +35,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 if [[ ! -x "$LTL" ]]; then
     echo "ERROR: ltl not found or not executable at $LTL"

--- a/tests/validate-histogram-bin-counters.sh
+++ b/tests/validate-histogram-bin-counters.sh
@@ -22,6 +22,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence):

--- a/tests/validate-histogram-ticks.sh
+++ b/tests/validate-histogram-ticks.sh
@@ -26,6 +26,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 # shellcheck source=lib/fixtures.sh
 source "$SCRIPT_DIR/lib/fixtures.sh"
 

--- a/tests/validate-index-read-back.sh
+++ b/tests/validate-index-read-back.sh
@@ -23,6 +23,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # The fixture records absolute paths, so this harness and the regenerate
 # script must resolve the corpus the same way or the recorded rows will not

--- a/tests/validate-numeric-criteria-notices.sh
+++ b/tests/validate-numeric-criteria-notices.sh
@@ -28,6 +28,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Boundary fixture: exactly one line lacks a duration value (BD-dur-missing),
 # one lacks bytes (BD-bytes-missing), one lacks count (BD-count-missing);

--- a/tests/validate-profile-render.sh
+++ b/tests/validate-profile-render.sh
@@ -44,6 +44,13 @@ command -v "$PERL" >/dev/null 2>&1 || PERL=perl
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 WIDTH=120
 

--- a/tests/validate-profile.sh
+++ b/tests/validate-profile.sh
@@ -43,6 +43,13 @@ GENERATOR="$SCRIPT_DIR/profile/generate-profile-log.py"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 PRODUCED_BY='emit_profile_verbose() in ltl (sample counts accumulated in read_and_process_logs() via fold_epoch(); included on the all-filters-passed path, dropped on the excluded-weekday path).'
 CONTRACT='Issue #256 + tests/HARNESS-DESIGN.md reserved-names list. The profile section name and field names (profile_active, mode, period_seconds, included_weekdays, samples_included, samples_dropped) are stability-contracted; renames are breaking. Expected values come from the generator manifest, the single source of truth for the fixture.'

--- a/tests/validate-recursive-file-selection.sh
+++ b/tests/validate-recursive-file-selection.sh
@@ -31,6 +31,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Committed fixture tree. Empty files with numeric extensions: .888 matches,
 # .123 and .000 are non-matching siblings at each level, so filtering is

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -42,6 +42,13 @@ fi
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 # shellcheck source=lib/fixtures.sh
 source "$SCRIPT_DIR/lib/fixtures.sh"
 TMP_DIR=$(mktemp -d)

--- a/tests/validate-runtime-config.sh
+++ b/tests/validate-runtime-config.sh
@@ -29,6 +29,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence): the
 # -V runtime-config section echoes the resolved options, so -bs/-dmp/-mdm on

--- a/tests/validate-statistics-demand.sh
+++ b/tests/validate-statistics-demand.sh
@@ -25,6 +25,13 @@ LTL="$REPO_DIR/ltl"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 # Invocation shape (tests/HARNESS-DESIGN.md section Invocation coherence): the
 # demand registry is driven by which consumers are active (summary table,

--- a/tests/validate-statistics.sh
+++ b/tests/validate-statistics.sh
@@ -57,6 +57,14 @@ source "$SCRIPT_DIR/lib/logs-dir.sh"
 # shellcheck source=lib/csv-cache.sh
 source "$SCRIPT_DIR/lib/csv-cache.sh"
 
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
+
 # End-of-run cleanup runs only when standalone (CI unset).
 trap csv_cache_maybe_cleanup EXIT
 

--- a/tests/validate-udm-counting.sh
+++ b/tests/validate-udm-counting.sh
@@ -30,6 +30,13 @@ FIXTURE="$REPO_DIR/tests/fixtures/udm-counting-tokens.txt"
 
 # shellcheck source=lib/runtime-warnings.sh
 source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts
+# against (tests/HARNESS-DESIGN.md section Colour rendering is controlled,
+# never inherited; issue #438).
+neutralize_colour_env
 
 if [[ ! -x "$LTL" ]]; then
     echo "ERROR: ltl not found or not executable at $LTL"


### PR DESCRIPTION
Closes #438.

`FORCE_COLOR` and `NO_COLOR` arrived from the launching shell, so what a harness asserted against depended on the operator's terminal. With `FORCE_COLOR` exported, the suite reported `validate-explain.sh` 145/3, `validate-format-detection.sh` 191/1 and `validate-format-registry.sh` 21/1 on a tree that is green from a bare shell.

## Two distinct failures, one cause

- **`validate-explain.sh`** ran `NO_COLOR=1 "$LTL" --explain mean`. `FORCE_COLOR` is checked first by `help_ansi_enabled()`, so ANSI was emitted anyway and the scenario silently tested precedence instead of plain text.
- **The two format harnesses do not test colour at all.** They match an anchored `^Error: Unknown log format ...`; under `FORCE_COLOR`, `print_usage()` wraps its banner in ANSI and the anchor stops matching.

That second case is why the guard is applied to all 23 harnesses rather than the three observed failing: any anchored match against `ltl` output is exposed, and a partially-applied environment override leaves the same latent inconsistency the corpus work removed (HARNESS-DESIGN § *The log corpus is resolved, never composed*).

## Changes

- **`tests/lib/colour-env.sh`** (new) — `neutralize_colour_env` called once at start-up, plus `with_ascii_colour` / `with_ansi_colour`, which pin **both** variables so a colour-mode scenario controls both sides of the switch. Modelled on `lib/runtime-warnings.sh`.
- **All 23 harnesses** source it and neutralise at start-up, including the two that reach the shared libs via `csv-cache.sh`.
- **`validate-explain.sh`** — the three colour-intentional call sites use the helpers.
- **`tests/HARNESS-DESIGN.md`** — new § *Colour rendering is controlled, never inherited*.

## Validation

All 23 harnesses exit 0 and report **byte-identical counts (870 passed, 0 failed)** under `FORCE_COLOR=3` and under a neutralised environment — verified by comparing the counts, not the exit codes, so a silently-skipped scenario could not pass as green.

**Sabotage check:** pointing the ASCII scenario at `with_ansi_colour` reproduces the original three failures exactly, and reverting returns 148/0 — the assertions still genuinely test colour behaviour (HARNESS-DESIGN § *Proving a new assertion can fail*).

`ltl` is unmodified, so the benchmark half of the completion gate does not apply; the suite half ran in full.

## Note for future harness authors

ASCII-mode output still carries SGR 0/90/109 from colour paths `help_ansi_enabled()` does not gate. The bold/underline assertions match SGR 1/22/4/24 specifically and are unaffected, but an assertion greping for "any escape sequence" would misfire. Recorded in the new design-doc section.