### PR TITLE
#447: control-character normalisation on ingest, and FATAL as a log level

### DIFF
--- a/features/447-message-control-character-normalisation.md
+++ b/features/447-message-control-character-normalisation.md
@@ -1,0 +1,259 @@
+# Feature: Control-character normalisation of extracted message text
+
+## Overview
+
+The messages table budgets its message column in **characters** and pads with
+`sprintf "%-Ns"`. Both assume one character occupies one terminal column. A
+control character inside the message breaks that assumption, so a row whose
+character count is correct still overflows its column and pushes the Occurrences
+cell off the line while every other row stays aligned.
+
+This drop normalises control characters out of the message **at parse time**, at
+the single point every ingest path has finished writing it and before anything
+reads it. It is not a render fix and not a per-consumer fix: one normalisation,
+one resolution surface, and every consumer of the message key receives the same
+clean text without knowing the problem existed.
+
+## GitHub Issue
+
+[#447](https://github.com/gregeva/logtimeline/issues/447) — BUG: message
+truncation counts characters, not rendered terminal columns — a TAB in the
+message breaks row alignment.
+
+Position 5 in the 0.18.0 delivery order
+(`features/bin-counter-accuracy-and-observability.md` § D6). The position is
+forced: this changes the message key, therefore consolidation grouping, therefore
+what the drift baselines contain, so it lands after stage 4's re-bless rather
+than between the stage-3 capture and the changes that capture measures.
+
+## Sources
+
+- `features/fuzzy-message-consolidation.md` — DD-06 (truncated-message cap) and
+  the #158 precedent below; the similarity engine consumes the key this drop
+  changes.
+- `tests/HARNESS-DESIGN.md` § Render-invariant harnesses, § Self-documenting
+  assertions, § Proving a new assertion can fail, § Invocation coherence.
+- `features/bin-counter-accuracy-and-observability.md` § D6 — delivery order.
+
+## What was measured before deciding
+
+Reproduced on `release/0.18.0` with a Windchill Method Server fixture at
+`--terminal-width 140`. With ANSI stripped, every messages-table row measured
+138 characters; the row whose message carried one TAB measured 138 characters
+and **145 terminal columns**. The overflow is exactly the tab-stop advance, and
+the character count — the thing the code budgets against — is identical on both
+rows, which is why nothing downstream detects it.
+
+Three further defects surfaced from the same cause, each worse than the
+misalignment the issue reports:
+
+| Character | Observed effect |
+|---|---|
+| CR (0x0d) | The cursor returns to column zero and the rest of the row overwrites its own start. Message identity and the Occurrences value are both destroyed on screen while the byte count still measures correct. |
+| ESC (0x1b) | Passes through ingest untouched and is executed by the terminal as an ANSI sequence, re-colouring everything printed after it. |
+| US (0x1f) | Is the field separator of the per-message counter store (`"$category\x1f$log_key"`) and of the `-V message-grouping / cluster-membership` records. A raw one inside a message forges a key boundary; a synthetic cluster line was produced this way from a crafted log line. |
+
+The messages CSV is affected too, and more sharply than "misaligned": a message
+carrying a CR is written by `Text::CSV` as a **quoted multi-line field**, so one
+logical record spans two physical lines. A conformant reader copes; `grep`,
+`awk`, `sed` and every line-oriented consumer read it as two records.
+
+## Locked decisions
+
+### D1 — TAB expands to four spaces; other C0 characters and DEL are removed
+
+TAB is the only control character with a defensible width, so it is preserved as
+separation rather than dropped. It expands to a **fixed four spaces**.
+
+A terminal does not render a TAB as any fixed width — it advances to the next
+eight-column tab stop, so the cost depends on which column the tab lands in (the
+measured case above cost seven). A fixed expansion is therefore not a
+reproduction of terminal behaviour and is not intended as one: it is a stable
+substitution that makes the key's character count equal its column count
+regardless of where the message sits in the row.
+
+Every other C0 control character (0x00–0x1f) and DEL (0x7f) is **removed**. None
+carries display meaning, and each corrupts output in its own way per the table
+above. Removal is silent — the two sides of a CR are joined with no trace — which
+is the specified behaviour.
+
+*Architect decision, 2026-08-27: both halves as specified in the issue, after the
+tab-stop measurement was presented.*
+
+### D2 — The normalisation happens once, at parse time
+
+The normalisation sits in `read_and_process_logs()` at the point where every
+ingest path has finished writing `$message` — the format registry's generated scan for all
+fourteen formats, and both CSV assembly branches — and before anything reads it.
+
+This is the whole design. Normalising at parse time means:
+
+- no later path can reintroduce the problem, because no later path sees the
+  original text;
+- the message key, the table, the messages CSV, the consolidation grouping key
+  and the verbose surfaces are all fed from one clean string, so none of them
+  needs its own cleaning step;
+- the in-message metric probes and the user-defined-metric masking, which both
+  read and rewrite `$message`, operate on normalised text.
+
+That single normalisation is the only behaviour change in `ltl`.
+
+### D3 — The raw line is deliberately left alone
+
+`-include`, `-exclude` and `-highlight` match against `$_`, the raw line, not
+against the message. They are not normalised.
+
+Those patterns are the user's to write: a pattern containing `\t` matches a log
+line containing a tab, and that must keep working. Normalising the raw line at
+the CR/LF strip would have been the shorter change and would have silently
+altered what every user-supplied filter matches — a scope change this issue does
+not ask for.
+
+### D4 — Written inline and guarded, not as a sub
+
+The normalisation runs once per matched line, so its shape is a hot-loop
+decision, not a style one. It is written inline behind a guard:
+
+```perl
+if ( $is_line_match && defined $message && $message =~ tr/\x00-\x1f\x7f// ) {
+    $message =~ s/\t/    /g if index( $message, "\t" ) >= 0;
+    $message =~ tr/\x00-\x08\x0a-\x1f\x7f//d;
+}
+```
+
+The first implementation was a named sub called unconditionally, and it cost
+**+4.36% of total runtime** (+503 ns/line) on a 1.43M-line access log. That is an
+unacceptable price for a cleanliness fix and was caught by measurement, not
+review.
+
+Two changes account for the recovery:
+
+- **Inlining.** The sub call — argument passing, a lexical copy, a return-value
+  copy — cost more than the two rewrites it wrapped. Inlining alone measured
+  +117% throughput on a 1000-message loop.
+- **Guarding.** `tr` in counting mode is a single character-class scan that
+  modifies nothing. Virtually no log line carries a control character, so the
+  common case pays one scan and rewrites nothing: a further +44%.
+
+Nothing rewrites a string without a reason to. The tab substitution runs only
+when the message actually contains a tab, and the delete then excludes `\x09`
+because any tab is already gone.
+
+| Arm | Median | vs baseline | Per line |
+|---|---|---|---|
+| baseline | 16.383 s | — | — |
+| sub call, unguarded | 17.192 s | +4.36% | +503 ns |
+| **inline, guarded (shipped)** | 16.514 s | **+0.80%** | **+92 ns** |
+
+Order-balanced ABBA design, 8 pairs, positive in 7/8. **Single-order interleaving
+was not sufficient** — the same code measured +0.44% and +1.99% in different
+sessions, because within-arm spread (0.36 s) exceeds the effect (0.13 s). The
+residual +92 ns/line is one scan of every message, which is the floor for any
+implementation that must know whether a message is clean.
+
+Full record: `tests/profile/results/447-control-char-normalisation/`.
+
+### D5 — Gated on `$is_line_match`
+
+A line no format recognised has no message to clean, so the normalisation is
+gated on the same condition every consumer of the message already sits behind.
+
+**This saves nothing measurable** — `-0.11%`, 3/6 pairs, even on a Connection
+Server log where 502,133 of 999,883 lines are unmatched. An unmatched line's
+`$message` is empty or undef and `tr` over an empty string is free, so the guard
+was already skipping the work. The gate is kept because it states the intent
+correctly, not because it pays.
+
+It matters for a second reason, found while validating it. The record lexicals
+are **not** reset per line: they are cleared as a side effect of the scan's
+failed list-assignment matches, which set every capture target to undef. A
+space-led line is rejected by the whitespace dispatch *before any block runs*, so
+it performs no such match and `$message` still carries the previous matched
+line's text. Message-key construction already sits behind `if( $is_line_match )`,
+so no output was ever wrong — but normalising ahead of that condition would have
+rewritten a value no longer in play.
+
+## Affected surfaces
+
+All of these consume the message key and are therefore corrected by D2 without
+any change of their own:
+
+| Surface | Produced by |
+|---|---|
+| Messages table | `print_message_summary()` |
+| Messages CSV (column 2 is the key verbatim) | `print_message_summary()` |
+| `-g` consolidation grouping key and trigram similarity input | `consolidation_process_key()`, `get_consolidation_trigrams()` |
+| `-V message-grouping / cluster-membership` records | `group_similar_messages()` |
+| `%log_messages` and the `%log_messages_counters` composite key | `read_and_process_logs()` |
+
+`ltl-index.csv` is **not** affected: `write_index_file()` writes file metadata
+and numeric aggregates only, and its one free-text column is already
+percent-encoded by `serialize_filters()`.
+
+## Section contract
+
+This drop adds no `-V` section and changes no existing one. The
+cluster-membership records it asserts against are #462's surface, unchanged here;
+what changes is that no message-derived key can any longer forge their `0x1f`
+category/key boundary.
+
+## Test coverage
+
+`tests/validate-message-control-characters.sh` — render-invariant harness
+(HARNESS-DESIGN.md § Render-invariant harnesses) over
+`tests/fixtures/message-control-characters.txt`, a seven-line committed fixture
+carrying TAB, CR, ESC, US, vertical tab, form feed and backspace inside message
+text alongside control-free baseline messages.
+
+Three scenarios, eleven assertions:
+
+- **`control-character-normalisation`** (`-g 60 -o`): table rows all occupy one
+  identical terminal column count; no control character in the rendered table;
+  none in the messages CSV; every CSV record on exactly one physical line; and
+  no member key forging a unit-separator boundary in the cluster-membership
+  records (a `cluster:` line carries exactly one separator, a `member:` line
+  none).
+- **`ungrouped-tab-expansion`** (no `-g`): with each message on its own row, the
+  same column-count and control-character invariants plus the direct assertion
+  that a source TAB renders as four spaces. Consolidation collapses the fixture
+  to one wildcard row, so per-message text is only assertable ungrouped.
+- **`unmatched-line-not-normalised`** over
+  `tests/fixtures/message-control-characters-unmatched.txt`: two matched lines
+  around one space-led line the whitespace dispatch rejects before any format
+  block runs, so the record lexicals still carry the preceding line's text
+  (D5). Asserts 3 lines read / 2 included and exactly two distinct message rows
+  — an included count of 3, or a duplicated row, would mean the stale message
+  was re-counted.
+
+All three run `-bs 1440 -oe -ni` (§ Invocation coherence): no assertion reads
+the time axis, so the coarsest bucket with empty buckets suppressed is the
+correct shape.
+
+**Sabotage proof** (§ Proving a new assertion can fail): with the normalisation
+disabled, seven of the eleven assertions fail with their expected diagnostics.
+Of the four that do not:
+
+- the CSV one-record-per-line check passes because `Text::CSV` quotes the
+  embedded CR rather than emitting a bare newline, so it was proven separately
+  against a hand-doctored CSV carrying a raw embedded newline, where it fails as
+  intended;
+- the three `unmatched-line-not-normalised` assertions pass, because they cover
+  the pre-existing `$is_line_match` gate on message-key construction rather than
+  the normalisation itself. They were verified to pass with the D5 gate removed
+  too — they are regression cover for the condition that makes D5 safe, not a
+  test of D5.
+
+## Out of scope
+
+- **Stack-trace lines competing for Top-N slots** — the second half of the
+  original report, split out to
+  [#465](https://github.com/gregeva/logtimeline/issues/465). That is a new
+  concept in the format registry with a per-line cost, not a normalisation.
+- **Wide and combining characters.** The column-count assumption this drop
+  repairs for control characters is also violated by East Asian wide characters
+  and combining marks. No such case has been reported, and the fix would be a
+  display-width measurement rather than an ingest normalisation. Not filed.
+- **`FATAL` is not in the log-level vocabulary.** Found while reproducing this
+  issue: a Windchill Method Server line at `FATAL` is read but not included in
+  the analysis, independent of any control character. Unrelated to this drop and
+  not fixed here.

--- a/features/447-message-control-character-normalisation.md
+++ b/features/447-message-control-character-normalisation.md
@@ -173,6 +173,51 @@ line's text. Message-key construction already sits behind `if( $is_line_match )`
 so no output was ever wrong — but normalising ahead of that condition would have
 rewritten a value no longer in play.
 
+### D6 — FATAL joins the log-level vocabulary
+
+A line whose captured level is not in `@log_levels` is discarded by the per-line
+category gate: read, matched against its format, then silently dropped. It counts
+in LINES READ and not in LINES INCLUDED, and nothing tells the user.
+
+**FATAL was not in the vocabulary.** The Windchill Method Server format emits it
+— 14 lines across the corpus, including `MethodServer stopped`, a server
+shutdown — and every one was being discarded. Found while reproducing this
+issue's control-character case on a Method Server log.
+
+FATAL is added to all four surfaces a category must occupy (the three named in
+`features/395-wgm-client-log-format.md` § Log-category consistency, plus the
+error rate):
+
+| Surface | Change |
+|---|---|
+| `@log_levels` / `%log_level_set` in `ltl` | `FATAL-HL`, `FATAL`, ordered ahead of ERROR as the more severe level |
+| `%colors` in `ltl` | red, as ERROR — both are failures |
+| `tests/csv-output/rules/stats-columns.tsv` | `FATAL` and `FATAL-HL` rows, `int`/`level` family |
+| Error-rate accumulation in `normalize_data_for_output()` | FATAL joins `ERROR|5xx|4xx` — it denotes a failure |
+
+The statistics oracle (`tests/statistics-drift/oracle/calculate-reference.py`)
+already listed FATAL in its own `LOG_LEVELS` filter, so the oracle had been
+counting lines the tool discarded. That divergence was latent — no drift baseline
+carries a FATAL line — and closes with this change. Its stale `ltl:NNN` comment
+references were replaced with function names at the same time.
+
+**This is not the whole gap.** The format patterns admit any `\w+` in the level
+slot while the gate accepts 13 hard-coded names, so `CRITICAL`, `SEVERE`,
+`WARNING` (java.util.logging's spelling of WARN), `NOTICE`, `ALERT` and
+`EMERGENCY` are all matched and then dropped. None appears in the current corpus,
+so none is a live defect. Two issues carry the rest, deliberately separated
+because one is a list edit and the other is a redesign, and the cheap fix should
+not wait on the expensive one:
+
+- [#475](https://github.com/gregeva/logtimeline/issues/475) — the missing
+  severity names are added to the recognised set, the same four-surface change
+  this decision worked through for FATAL.
+- [#476](https://github.com/gregeva/logtimeline/issues/476) — log levels are a
+  property of the format that emits them, so they belong in the format registry
+  beside each format's duration unit and time contract; a level seen but not
+  registered is collected during the run and reported at the end, naming the
+  format and the levels, rather than discarded in silence.
+
 ## Affected surfaces
 
 All of these consume the message key and are therefore corrected by D2 without
@@ -198,6 +243,17 @@ what changes is that no message-derived key can any longer forge their `0x1f`
 category/key boundary.
 
 ## Test coverage
+
+`tests/validate-log-level-vocabulary.sh` — render-invariant harness over
+`tests/fixtures/log-level-vocabulary.txt`, one line per level the Windchill
+Method Server format emits. Asserts each level reaches the category table, that
+LINES READ equals LINES INCLUDED (a shortfall is the count the gate discarded),
+and that FATAL raises the error rate — measured by comparing a FATAL-and-ERROR
+run against the same fixture with the FATAL line downgraded, which keeps the
+assertion independent of the rate unit. The rate assertion runs at `-bs 1`, the
+one place bucket size matters: at `-bs 1440` two failures over a day round to
+0/min on both arms. Sabotage: removing FATAL from `@log_levels` fails exactly the
+three FATAL assertions and leaves the other five green.
 
 `tests/validate-message-control-characters.sh` — render-invariant harness
 (HARNESS-DESIGN.md § Render-invariant harnesses) over
@@ -253,7 +309,11 @@ Of the four that do not:
   repairs for control characters is also violated by East Asian wide characters
   and combining marks. No such case has been reported, and the fix would be a
   display-width measurement rather than an ingest normalisation. Not filed.
-- **`FATAL` is not in the log-level vocabulary.** Found while reproducing this
-  issue: a Windchill Method Server line at `FATAL` is read but not included in
-  the analysis, independent of any control character. Unrelated to this drop and
-  not fixed here.
+- **Log levels beyond FATAL that the gate discards.** The format patterns admit
+  any `\w+` in the level slot; the gate accepts 13 names. `CRITICAL`, `SEVERE`,
+  `WARNING`, `NOTICE`, `ALERT` and `EMERGENCY` are matched and then dropped with
+  no notice. None occurs in the current corpus. Filed as
+  [#475](https://github.com/gregeva/logtimeline/issues/475) (add the missing
+  severity names) and [#476](https://github.com/gregeva/logtimeline/issues/476)
+  (declare levels per format in the registry and report unregistered ones); see
+  D6.

--- a/ltl
+++ b/ltl
@@ -941,7 +941,7 @@ my $histogram_gridline_color = 8;             # Dark grey (bright black / ANSI 8
 
 # Defines the log level/type buckets and their order for printing and processing
 my @log_levels = (
-    'FORCE-HL', 'FORCE',
+    'FORCE-HL', 'FORCE', 'FATAL-HL', 'FATAL',
     'ERROR-HL', 'ERROR', 'WARN-HL', 'WARN', 'INFO-HL', 'INFO', 
     'DEBUG-HL', 'DEBUG', 'TRACE-HL', 'TRACE', '5xx-HL', '5xx', 
     '4xx-HL', '4xx', '3xx-HL', '3xx', '2xx-HL', '2xx', '1xx-HL', 
@@ -978,6 +978,7 @@ my $default_chart_block = ($^O eq 'MSWin32') ? 'G' : 'A';
 # Load in ANSI color codes and configure presets for various log levels/types
 my %colors = (
     'FORCE' => "\033[0;35m",
+    'FATAL' => "\033[0;31m",
     'ERROR' => "\033[0;31m",
     'WARN'  => "\033[0;33m",
     'INFO'  => "\033[0;32m",
@@ -13785,7 +13786,7 @@ sub normalize_data_for_output {
             my $occurrences = $log_occurrences{$bucket}{$category_bucket}{occurrences};
             next unless $occurrences > 0 && $category_bucket !~ /^(?:empty|err-rate|msg-rate)$/; 			# don't include the empty bucket who's purpose is to normalize the buckets represented
             $total_occurrences += $occurrences;
-            $error_occurrences += $occurrences if $category_bucket =~ /^(?:ERROR|5xx|4xx)$/i;
+            $error_occurrences += $occurrences if $category_bucket =~ /^(?:FATAL|ERROR|5xx|4xx)$/i;
         }
 
         # this part takes the time windows error and message counts and converts them to a rate (unit controlled by -ru, default per minute)

--- a/ltl
+++ b/ltl
@@ -10626,6 +10626,19 @@ sub read_and_process_logs {
                 }
             }
 
+            # Issue #447: strip control characters from the message once, here,
+            # where every ingest path has written it and nothing has read it —
+            # so the table, the CSV, the consolidation key and the verbose
+            # surfaces all see the same text. TAB becomes four spaces; every
+            # other C0 character and DEL goes. The raw line is left alone:
+            # -include/-exclude/-highlight match against it.
+            # Shape, measurements and why the gate is correct:
+            # features/447-message-control-character-normalisation.md D1-D5.
+            if ( $is_line_match && defined $message && $message =~ tr/\x00-\x1f\x7f// ) {
+                $message =~ s/\t/    /g if index( $message, "\t" ) >= 0;
+                $message =~ tr/\x00-\x08\x0a-\x1f\x7f//d;
+            }
+
             ## COUNT METRICS # capture count metrics unless explicitly omitted
             if( !$omit_count && defined $message ) {
                 ( $count ) = $message =~ / count\s*=\s*(\d+)/;

--- a/tests/csv-output/rules/stats-columns.tsv
+++ b/tests/csv-output/rules/stats-columns.tsv
@@ -1,5 +1,7 @@
 column	position	type	required	max_decimals	family
 timestamp	1	timestamp	yes	n/a	meta
+FATAL	*	int	no	0	level
+FATAL-HL	*	int	no	0	level
 ERROR	*	int	no	0	level
 ERROR-HL	*	int	no	0	level
 WARN	*	int	no	0	level

--- a/tests/fixtures/log-level-vocabulary.txt
+++ b/tests/fixtures/log-level-vocabulary.txt
@@ -1,0 +1,6 @@
+2025-07-18 04:46:41,354 FATAL [main] wt.method.server.shutdown  - MethodServer stopped
+2025-07-18 04:46:42,354 ERROR [main] wt.method.server.startup  - Error level line
+2025-07-18 04:46:43,354 WARN  [main] wt.method.server.startup  - Warn level line
+2025-07-18 04:46:44,354 INFO  [main] wt.method.server.startup  - Info level line
+2025-07-18 04:46:45,354 DEBUG [main] wt.method.server.startup  - Debug level line
+2025-07-18 04:46:46,354 TRACE [main] wt.method.server.startup  - Trace level line

--- a/tests/fixtures/message-control-characters-unmatched.txt
+++ b/tests/fixtures/message-control-characters-unmatched.txt
@@ -1,0 +1,3 @@
+2025-07-18 04:46:41,354 INFO  [main] wt.method.server.startup  - Matched line carrying	a tab character
+ space-led continuation line that no format recognises
+2025-07-18 04:46:43,354 INFO  [main] wt.method.server.startup  - Second matched line with no control characters

--- a/tests/fixtures/message-control-characters.txt
+++ b/tests/fixtures/message-control-characters.txt
@@ -1,0 +1,7 @@
+2025-07-18 04:46:41,354 INFO  [main] wt.method.server.startup  - Baseline message carrying no control characters at all
+2025-07-18 04:46:42,354 INFO  [main] wt.method.server.startup  - Horizontal tab here:	and text following the tab stop
+2025-07-18 04:46:43,354 INFO  [main] wt.method.server.startup  - Carriage return here:and text following the return
+2025-07-18 04:46:44,354 INFO  [main] wt.method.server.startup  - Escape introducer here:[31mand text following it
+2025-07-18 04:46:45,354 INFO  [main] wt.method.server.startup  - Unit separator here:and text following it
+2025-07-18 04:46:46,354 INFO  [main] wt.method.server.startup  - Vertical tab here:and form feed:and backspace:done
+2025-07-18 04:46:47,354 WARN  [main] wt.method.server.shutdown  - Second baseline message with no control characters

--- a/tests/profile/results/447-control-char-normalisation/analysis.md
+++ b/tests/profile/results/447-control-char-normalisation/analysis.md
@@ -1,0 +1,78 @@
+# Analysis — #447 control-character normalisation, hot-loop cost
+
+Companion to `hypothesis.md`, written after measurement.
+
+## Method
+
+`ltl` was measured as two binaries differing only by the normalisation: an arm
+with it and a baseline arm without. Runs used
+`--disable-progress -ni -bs 1440 -oe -n 5 --terminal-width 120` on
+`logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt`
+(1,430,678 lines), medians over interleaved pairs.
+
+**Single-order interleaving proved insufficient.** The same code measured +0.44%
+in one session and +1.99% in another; within-arm spread (0.36 s) is larger than
+the effect being measured (0.13 s). The reported figure comes from an
+**order-balanced ABBA design** over 8 pairs, which cancels monotonic drift.
+
+## Result
+
+| Arm | Median | vs baseline | Per line |
+|---|---|---|---|
+| baseline | 16.383 s | — | — |
+| sub call, unguarded | 17.192 s | **+4.36%** | +503 ns |
+| **inline, guarded (shipped)** | 16.514 s | **+0.80%** | **+92 ns** |
+
+Shipped arm positive in 7/8 ABBA pairs. **82% of the original regression was
+removed.**
+
+## Hypotheses: confirmed, and one refuted
+
+**H1 — the sub call dominated. CONFIRMED.** Inlining alone took a
+1000-message loop from 3,050/s to 6,614/s (+117%). A Perl sub call with argument
+passing, a lexical copy and a return-value copy costs more than the two rewrites
+it wrapped.
+
+**H2 — the guard removes most of the rest. CONFIRMED.** Guarded-inline measured
+9,539/s against unguarded-inline's 6,614/s (+44%). `tr` in counting mode is one
+character-class scan with no modification and no copy, and on an access log
+essentially no message contains a control character, so the common case skips
+both rewrites.
+
+**H3 — the residual is the guard scan and is irreducible. STANDS.** +92 ns/line
+for one scan of every message is the floor for any implementation that must know
+whether a message is clean.
+
+**Refuted along the way — skipping unmatched lines saves nothing.** Gating the
+normalisation on `$is_line_match` was expected to pay on a log where half the
+lines are unmatched (`cxserver.1-16.log`: 497,750 matched, 502,133 unmatched).
+Measured **-0.11%, 3/6 pairs** — noise. The reason: an unmatched line's
+`$message` is empty or undef, and `tr` over an empty string costs nothing. The
+guard was already skipping that work. The gate was kept for what it says, not
+what it saves, and its comment records the measurement so it is not re-litigated.
+
+## What the investigation turned up that the profile was not looking for
+
+**The record lexicals are not reset per line.** They are cleared as a side effect
+of the scan's failed list-assignment matches — a failed `( $a, $b ) = $s =~ /.../`
+sets every capture target to undef. A **space-led line** is rejected by the
+whitespace dispatch *before any format block runs*, so it performs no such match
+and `$message` still holds the previous matched line's text.
+
+This was found by testing the space-led path specifically after an initial probe
+reported zero stale messages across the whole corpus — the probe was measuring a
+path that could not exhibit the behaviour. Message-key construction already sits
+behind `if( $is_line_match )`, so no output was ever wrong; but it is the reason
+the normalisation must not run ahead of that condition, and
+`tests/validate-message-control-characters.sh` scenario 3 is now regression cover
+for it.
+
+## Lessons
+
+1. **Order-balance any A/B whose effect is smaller than its within-arm spread.**
+   Single-order interleaving gave a 4.5x range on identical code.
+2. **A probe that reports zero has to be shown capable of reporting non-zero.**
+   The stale-message probe read zero because the corpus never exercised the
+   space-led early return, not because the behaviour was absent.
+3. **Measure the work-avoidance before assuming it.** Skipping half the lines
+   sounded obviously worth it and measured as nothing.

--- a/tests/profile/results/447-control-char-normalisation/hypothesis.md
+++ b/tests/profile/results/447-control-char-normalisation/hypothesis.md
@@ -1,0 +1,56 @@
+# Hypothesis — #447 control-character normalisation, hot-loop cost
+
+Written before profiling, per features/nytprof-profiling-workflow.md § Pre-Profiling Checklist.
+
+## What changed
+
+One normalisation of `$message` on the ingest path in `read_and_process_logs()`,
+at the point every ingest path has finished writing it. It runs **once per
+matched line**, so on a 1.43M-line access log it runs 1.43M times.
+
+## What was measured before this profile
+
+| Arm | Median | Delta vs baseline | Per line |
+|---|---|---|---|
+| baseline (no normalisation) | 16.473 s | — | — |
+| sub call, unguarded | 17.192 s | **+4.36%** | +503 ns |
+| inline, guarded on `tr` count | 16.739 s | +0.44% | +51 ns |
+
+5 alternating runs per arm, medians, `-bs 1440 -oe -n 5` on
+`localhost_access_log-twx01-twx-thingworx-0.2025-05-05.txt` (1,430,678 lines).
+The sub-call arm was positive in 5/5 pairs; the guarded arm in 3/5, which is at
+the noise floor.
+
+## Hypothesis
+
+1. **The sub call, not the string work, was the dominant cost.** A Perl sub call
+   with argument passing, a lexical copy and a return-value copy costs more than
+   the two rewrites it wraps. Micro-benchmark support: inlining alone took the
+   shape from 3,050/s to 6,614/s (+117%).
+
+2. **The guard removes almost all remaining cost, because almost no line has a
+   control character.** `tr/\x00-\x1f\x7f//` in counting mode is a single
+   character-class scan with no modification and no copy. On an access log the
+   expected hit rate is ~0%, so the common case pays one scan and skips both
+   rewrites. Micro-benchmark support: guarded-inline 9,539/s vs unguarded-inline
+   6,614/s (+44%).
+
+3. **Therefore the residual +0.44% is the guard scan itself**, ~51 ns/line, and
+   is irreducible without giving up the invariant — any correct implementation
+   must at minimum look at every message once to know whether it is clean.
+
+## What the profile should show
+
+- No `normalize_message_text` entry at all (the sub was removed; the work is
+  inline in `read_and_process_logs`).
+- `read_and_process_logs` remains the dominant exclusive-time sub, as it was
+  before this change; its share should be indistinguishable from baseline.
+- No new sub appearing in the top entries attributable to #447.
+
+## What would falsify it
+
+- A measurable line-level cost inside `read_and_process_logs` attributable to
+  the `tr` guard beyond the ~51 ns/line measured end-to-end.
+- The guard failing to short-circuit (i.e. the rewrites running on clean lines),
+  which would show as `s///` and `tr///d` time on an input with no control
+  characters.

--- a/tests/statistics-drift/oracle/calculate-reference.py
+++ b/tests/statistics-drift/oracle/calculate-reference.py
@@ -358,10 +358,13 @@ _THREAD_POOL_RE = re.compile(r'^(.*)-\d+$')
 _THREAD_TRUNCATE_LEN = 20
 _OBJECT_TRUNCATE_LEN = 25
 
-# ltl:135 — log_levels list (the levels ltl recognises). Lines whose
-# captured category isn't in this list are skipped at ltl:7256. The
-# oracle must apply the same filter so partition fidelity holds for
-# ScriptLog lines that carry levels like "STDERR" or empty.
+# The levels ltl recognises: the @log_levels list in ltl, gated per line in
+# read_and_process_logs() against %log_level_set. The oracle must apply the
+# same filter so partition fidelity holds for ScriptLog lines that carry
+# levels like "STDERR" or empty. AUDIT is not in ltl's vocabulary and no
+# ThingWorx line carries it in the level position (it appears only inside
+# message text, as "[SECURITY AUDIT ...]"); it is retained here as an inert
+# entry so this set stays a superset and never drops a line ltl would keep.
 LOG_LEVELS = {
     "FORCE", "AUDIT", "FATAL", "ERROR", "WARN", "INFO",
     "DEBUG", "TRACE", "DATA",
@@ -391,7 +394,8 @@ def parse_thingworx_scriptlog_line(line):
     (ts_str, level, obj, _instance, _user,
      _session, _platform, thread, message) = m.groups()
 
-    # ltl:7256 — skip lines whose category isn't a recognised log level.
+    # Skip lines whose category isn't a recognised log level, as the
+    # per-line category gate in read_and_process_logs() does.
     if level not in LOG_LEVELS:
         return None
 

--- a/tests/validate-log-level-vocabulary.sh
+++ b/tests/validate-log-level-vocabulary.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# validate-log-level-vocabulary.sh — every log level a supported format can emit
+# is recognised and analysed (Issue #447).
+#
+# A line whose captured level is not in ltl's vocabulary is discarded by the
+# per-line category gate in read_and_process_logs(). The line is read, matched
+# against its format, and then silently dropped: it appears in LINES READ, not
+# in LINES INCLUDED, and nothing tells the user. A level missing from the
+# vocabulary is therefore invisible data loss, which is what this harness exists
+# to prevent.
+#
+# FATAL was absent until #447. Windchill Method Server logs emit it for server
+# shutdown ("MethodServer stopped"), so those events — among the most
+# consequential lines in the file — were being dropped.
+#
+# This is a RENDER-INVARIANT harness (tests/HARNESS-DESIGN.md § Render-invariant
+# harnesses): the assertion reads the rendered category table, which is where a
+# recognised level appears and a dropped one does not.
+#
+# Each assertion records, per HARNESS-DESIGN.md § Self-documenting assertions:
+#   - asserts:     the invariant being tested
+#   - produced_by: where in ltl it is produced (function name, never a line)
+#   - contract:    the source that makes the invariant stable
+# All three are surfaced on failure.
+#
+# Usage: ./tests/validate-log-level-vocabulary.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LTL="$REPO_DIR/ltl"
+PERL="${PERL:-/opt/homebrew/bin/perl}"
+command -v "$PERL" >/dev/null 2>&1 || PERL=perl
+
+# Invocation shape (HARNESS-DESIGN.md § Invocation coherence): the assertions
+# read the category table and the summary counts. Neither depends on the time
+# axis, so the run uses the coarsest bucket with empty buckets suppressed over a
+# six-line fixture spanning seconds. -ni keeps the developer's ltl-index.csv out
+# of the run.
+FIXTURE="$REPO_DIR/tests/fixtures/log-level-vocabulary.txt"
+WIDTH=140
+
+# shellcheck source=lib/runtime-warnings.sh
+source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+neutralize_colour_env
+
+if [[ ! -x "$LTL" ]]; then
+    echo "ERROR: ltl not found or not executable at $LTL"; exit 1
+fi
+if [[ ! -f "$FIXTURE" ]]; then
+    echo "ERROR: fixture not found: $FIXTURE"; exit 1
+fi
+
+TMP_DIR=$(mktemp -d); trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass=0
+fail=0
+failures=()
+current_scenario=""
+
+strip_ansi() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+
+assert_command() {
+    local command label asserts produced_by contract
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            command)     command="$2";     shift 2 ;;
+            label)       label="$2";       shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            *) echo "assert_command: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${command:?assert_command requires command}"
+    : "${label:?assert_command requires label}"
+    : "${asserts:?assert_command requires asserts}"
+    : "${produced_by:?assert_command requires produced_by}"
+    : "${contract:?assert_command requires contract}"
+
+    local cmd_out cmd_rc
+    set +e
+    cmd_out=$(eval "$command" 2>&1); cmd_rc=$?
+    set -e
+    if [[ "$cmd_rc" -eq 0 ]]; then
+        echo "  PASS  $current_scenario :: $label"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $current_scenario :: $label"
+        echo "        command:     $command"
+        echo "        asserts:     $asserts"
+        echo "        produced_by: $produced_by"
+        echo "        contract:    $contract"
+        echo "$cmd_out" | sed 's/^/        | /'
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: $label")
+    fi
+}
+
+# A level appears as its own row in the category table. Absence means the
+# category gate discarded every line carrying it (HARNESS-DESIGN.md § Harnesses
+# must fail on missing anchors: a zero-match lookup is a hard failure).
+check_level_present() {
+    "$PERL" -e '
+        my ($render, $level) = @ARGV;
+        open my $fh, "<", $render or die "cannot open $render: $!\n";
+        my $found = 0;
+        while (my $line = <$fh>) {
+            $found = 1 if $line =~ /^\s+\Q$level\E\s+\d+(?:\s|$)/;
+        }
+        close $fh;
+        unless ($found) {
+            print "level $level has no row in the category table: every line carrying it was discarded\n";
+            exit 1;
+        }
+        print "$level present in the category table\n";
+        exit 0;
+    ' "$1" "$2"
+}
+
+# Every line the fixture carries is analysed, not merely read. LINES READ equal
+# to LINES INCLUDED proves nothing was dropped by the category gate.
+check_all_lines_included() {
+    "$PERL" -e '
+        my ($render, $expected) = @ARGV;
+        open my $fh, "<", $render or die "cannot open $render: $!\n";
+        my ($read, $incl);
+        while (my $line = <$fh>) {
+            $read = $1 if $line =~ /LINES READ\s+(\d+)/;
+            $incl = $1 if $line =~ /LINES INCLUDED\s+(\d+)/;
+        }
+        close $fh;
+        unless (defined $read && defined $incl) {
+            print "anchor not found: LINES READ / LINES INCLUDED absent from the render\n";
+            exit 1;
+        }
+        if ($read != $expected || $incl != $expected) {
+            printf "expected %d read and %d included, got %d read and %d included: %d line(s) discarded by the category gate\n",
+                $expected, $expected, $read, $incl, $read - $incl;
+            exit 1;
+        }
+        print "$read read, $incl included\n";
+        exit 0;
+    ' "$1" "$2"
+}
+
+# The error rate counts FATAL. Runs the fixture twice — once as-is (one FATAL,
+# one ERROR) and once with the FATAL line downgraded to INFO (one ERROR) — and
+# requires the first to report a strictly higher error rate than the second.
+# Comparing two runs keeps this independent of the rate unit. This is the one
+# assertion whose bucket size matters: at -bs 1440 two failures spread over a
+# day round to 0/min on both arms, so it runs at -bs 1 where the rate is
+# observable (HARNESS-DESIGN.md section Invocation coherence).
+check_error_rate_counts_fatal() {
+    local fixture="$1"
+    local with_fatal="$TMP_DIR/rate-with-fatal.txt"
+    local without_fatal="$TMP_DIR/rate-without-fatal.txt"
+    cp "$fixture" "$with_fatal"
+    sed 's/ FATAL / INFO  /' "$fixture" > "$without_fatal"
+
+    # The error rate is read from the stats CSV, whose err-rate column is the
+    # computed value rather than a rendered approximation.
+    local dir_a="$TMP_DIR/rate-a" dir_b="$TMP_DIR/rate-b"
+    rm -rf "$dir_a" "$dir_b"; mkdir -p "$dir_a" "$dir_b"
+    ( cd "$dir_a" && "$LTL" --disable-progress -ni -bs 1 -oe -n 1 --terminal-width "$WIDTH" -o "$with_fatal" ) >/dev/null 2>&1
+    ( cd "$dir_b" && "$LTL" --disable-progress -ni -bs 1 -oe -n 1 --terminal-width "$WIDTH" -o "$without_fatal" ) >/dev/null 2>&1
+
+    "$PERL" -e '
+        my ($da, $db) = @ARGV;
+        sub rate {
+            my ($dir) = @_;
+            my ($csv) = glob("$dir/*STATS*.csv");
+            return undef unless defined $csv && -f $csv;
+            open my $fh, "<", $csv or return undef;
+            my $hdr = <$fh>; my $row = <$fh>; close $fh;
+            return undef unless defined $hdr && defined $row;
+            chomp($hdr, $row);
+            my @h = split /,/, $hdr; my @r = split /,/, $row;
+            for my $i (0 .. $#h) { return $r[$i] if $h[$i] =~ /^err-rate/ }
+            return undef;
+        }
+        my $with    = rate($da);
+        my $without = rate($db);
+        unless (defined $with && defined $without) {
+            print "anchor not found: err-rate column absent from one of the stats CSVs\n";
+            exit 1;
+        }
+        unless ($with > $without) {
+            printf "error rate did not rise when FATAL was present: with FATAL %s, without %s — FATAL is not counted as a failure\n",
+                $with, $without;
+            exit 1;
+        }
+        printf "err-rate %s with FATAL vs %s without\n", $with, $without;
+        exit 0;
+    ' "$dir_a" "$dir_b"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: one line per level the Windchill Method Server format emits.
+# ---------------------------------------------------------------------------
+
+current_scenario="method-server-levels"
+echo "[$current_scenario]"
+
+RENDER="$TMP_DIR/render.txt"
+STDERR="$TMP_DIR/render.stderr"
+
+set +e
+( cd "$TMP_DIR" && "$LTL" --disable-progress -ni -bs 1440 -oe -n 10 \
+    --terminal-width "$WIDTH" "$FIXTURE" ) 2>"$STDERR" | strip_ansi > "$RENDER"
+render_status=("${PIPESTATUS[@]}")
+set -e
+
+if [[ "${render_status[0]}" -ne 0 ]]; then
+    echo "  FAIL  $current_scenario :: ltl exited ${render_status[0]} while rendering" >&2
+    sed 's/^/        /' "$STDERR" >&2
+    exit 1
+fi
+if [[ ! -s "$RENDER" ]]; then
+    echo "  FAIL  $current_scenario :: rendered output is empty" >&2
+    exit 1
+fi
+
+if ! assert_no_runtime_warnings "$STDERR" "$current_scenario"; then
+    fail=$((fail + 1)); failures+=("$current_scenario :: perl-runtime-warnings-on-stderr")
+fi
+
+for level in FATAL ERROR WARN INFO DEBUG TRACE; do
+    assert_command \
+        command     "check_level_present '$RENDER' '$level'" \
+        label       "$level is recognised and reaches the category table" \
+        asserts     "A line whose captured level is outside ltl's vocabulary is discarded by the per-line category gate — read, format-matched, then silently dropped, so it counts in LINES READ but not LINES INCLUDED and nothing tells the user. Every level a supported format emits must therefore be in the vocabulary. FATAL was absent until #447, which discarded Windchill Method Server shutdown events." \
+        produced_by '@log_levels / %log_level_set in ltl, gated per line in read_and_process_logs(); rendered by print_summary_table() in ltl' \
+        contract    'features/447-message-control-character-normalisation.md § D6 — every level a supported format emits is in the vocabulary'
+done
+
+assert_command \
+    command     "check_all_lines_included '$RENDER' 6" \
+    label       'every fixture line is analysed, none discarded by the category gate' \
+    asserts     'The fixture carries six lines, one per level the Windchill Method Server format emits, and all six match the format. LINES READ and LINES INCLUDED must both be 6; a shortfall is the count of lines the category gate discarded.' \
+    produced_by '@log_levels / %log_level_set in ltl, gated per line in read_and_process_logs()' \
+    contract    'features/447-message-control-character-normalisation.md § D6 — every level a supported format emits is in the vocabulary'
+
+# FATAL is a failure level and must be counted toward the error rate, like ERROR
+# and the 4xx/5xx status classes. The fixture carries exactly one FATAL and one
+# ERROR, so removing FATAL from the error-rate accumulation halves the rate.
+assert_command \
+    command     "check_error_rate_counts_fatal '$FIXTURE'" \
+    label       'FATAL is counted toward the error rate' \
+    asserts     'FATAL denotes a failure and must contribute to the error rate alongside ERROR and the 4xx/5xx status classes. Measured by comparing a FATAL-and-ERROR run against an ERROR-only run: the two-failure run must report a strictly higher error rate than the one-failure run.' \
+    produced_by 'normalize_data_for_output() in ltl — the error-rate accumulation' \
+    contract    'features/447-message-control-character-normalisation.md § D6 — FATAL counts toward the error rate'
+
+echo
+echo "─────────────────────────────────────────"
+echo "  PASS: $pass    FAIL: $fail"
+if [[ "$fail" -gt 0 ]]; then
+    echo
+    echo "  Failed assertions:"
+    printf '    - %s\n' "${failures[@]}"
+    exit 1
+fi
+echo "─────────────────────────────────────────"
+exit 0

--- a/tests/validate-message-control-characters.sh
+++ b/tests/validate-message-control-characters.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+# validate-message-control-characters.sh — control-character normalisation of
+# extracted message text (Issue #447).
+#
+# This is a RENDER-INVARIANT harness (tests/HARNESS-DESIGN.md § Render-invariant
+# harnesses) with two companion surfaces. The messages table budgets its message
+# column in characters and pads with sprintf "%-Ns", both of which assume one
+# character occupies one terminal column. A control character inside the message
+# breaks that assumption, so the invariant asserted here is:
+#
+#   every rendered messages-table row occupies exactly the same number of
+#   terminal COLUMNS as every other row, and no message-derived output on any
+#   surface carries a C0 control character or DEL.
+#
+# The fix is a single normalisation at parse time, not per-consumer cleaning:
+# one call in read_and_process_logs() at the point every ingest path has
+# finished writing the message and before anything reads it. The harness asserts
+# on three consumers of the key — the rendered table, the messages CSV, and the
+# -V message-grouping cluster-membership records — precisely because that is
+# what a parse-time fix buys: all three come out clean without any of them
+# knowing about the problem. Asserting on the table alone would also pass for a
+# fix applied at render, which is the design this issue rejected.
+#
+# The assertions are properties, not frozen values: they hold for any input, so
+# buggy-but-stable output cannot pass (HARNESS-DESIGN.md § Render-invariant
+# harnesses).
+#
+# Each assertion records, per HARNESS-DESIGN.md § Self-documenting assertions:
+#   - asserts:     the invariant being tested
+#   - produced_by: where in ltl it is produced (function name, never a line)
+#   - contract:    the source that makes the invariant stable
+# All three are surfaced on failure.
+#
+# Usage: ./tests/validate-message-control-characters.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LTL="$REPO_DIR/ltl"
+PERL="${PERL:-/opt/homebrew/bin/perl}"
+command -v "$PERL" >/dev/null 2>&1 || PERL=perl
+
+# Invocation shape (HARNESS-DESIGN.md § Invocation coherence): the invariants
+# read the rendered messages table, the messages CSV and one -V section. None of
+# them depends on the time axis, so every run uses the coarsest bucket with
+# empty buckets suppressed (-bs 1440 -oe) over a seven-line fixture spanning
+# seconds. -ni keeps the developer's ltl-index.csv out of the run.
+FIXTURE="$REPO_DIR/tests/fixtures/message-control-characters.txt"
+UNMATCHED_FIXTURE="$REPO_DIR/tests/fixtures/message-control-characters-unmatched.txt"
+WIDTH=140
+
+# shellcheck source=lib/runtime-warnings.sh
+source "$SCRIPT_DIR/lib/runtime-warnings.sh"
+# shellcheck source=lib/colour-env.sh
+source "$SCRIPT_DIR/lib/colour-env.sh"
+
+# Ambient FORCE_COLOR/NO_COLOR must not decide what this harness asserts against
+# (HARNESS-DESIGN.md § Colour rendering is controlled, never inherited).
+neutralize_colour_env
+
+if [[ ! -x "$LTL" ]]; then
+    echo "ERROR: ltl not found or not executable at $LTL"; exit 1
+fi
+if [[ ! -f "$FIXTURE" ]]; then
+    echo "ERROR: fixture not found: $FIXTURE"; exit 1
+fi
+if [[ ! -f "$UNMATCHED_FIXTURE" ]]; then
+    echo "ERROR: fixture not found: $UNMATCHED_FIXTURE"; exit 1
+fi
+
+TMP_DIR=$(mktemp -d); trap 'rm -rf "$TMP_DIR"' EXIT
+
+pass=0
+fail=0
+failures=()
+current_scenario=""
+
+strip_ansi() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+
+# Self-documenting assertion (HARNESS-DESIGN.md § When the assertion isn't a
+# simple line grep): runs `command`; PASS on exit 0, FAIL otherwise. On failure
+# surfaces the command plus asserts/produced_by/contract.
+assert_command() {
+    local command label asserts produced_by contract
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            command)     command="$2";     shift 2 ;;
+            label)       label="$2";       shift 2 ;;
+            asserts)     asserts="$2";     shift 2 ;;
+            produced_by) produced_by="$2"; shift 2 ;;
+            contract)    contract="$2";    shift 2 ;;
+            *) echo "assert_command: unknown field '$1'"; exit 2 ;;
+        esac
+    done
+    : "${command:?assert_command requires command}"
+    : "${label:?assert_command requires label}"
+    : "${asserts:?assert_command requires asserts}"
+    : "${produced_by:?assert_command requires produced_by}"
+    : "${contract:?assert_command requires contract}"
+
+    local cmd_out cmd_rc
+    set +e
+    cmd_out=$(eval "$command" 2>&1); cmd_rc=$?
+    set -e
+    if [[ "$cmd_rc" -eq 0 ]]; then
+        echo "  PASS  $current_scenario :: $label"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $current_scenario :: $label"
+        echo "        command:     $command"
+        echo "        asserts:     $asserts"
+        echo "        produced_by: $produced_by"
+        echo "        contract:    $contract"
+        echo "$cmd_out" | sed 's/^/        | /'
+        fail=$((fail + 1))
+        failures+=("$current_scenario :: $label")
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Checkers. Each exits non-zero with a diagnostic when the invariant is broken,
+# and treats "anchor not found" as a hard failure (HARNESS-DESIGN.md §
+# Harnesses must fail on missing anchors).
+# ---------------------------------------------------------------------------
+
+# Rendered messages-table rows all occupy the same number of terminal columns.
+# Columns, not characters: a TAB advances to the next eight-column tab stop, so
+# a row whose character count is correct can still overflow the table. Reads the
+# ANSI-stripped render; the message rows are those carrying the fixture's logger
+# name inside the bracketed key prefix.
+check_render_columns() {
+    "$PERL" -e '
+        my ($render) = @ARGV;
+        open my $fh, "<", $render or die "cannot open $render: $!\n";
+        my (@rows, $n);
+        while (my $line = <$fh>) {
+            $line =~ s/\r?\n$//;
+            next unless $line =~ /\[wt\.method\.server\./;
+            # Terminal columns: TAB advances to the next multiple of 8; other
+            # C0 characters and DEL occupy none.
+            my $cols = 0;
+            for my $ch (split //, $line) {
+                if    ($ch eq "\t")      { $cols += 8 - ($cols % 8) }
+                elsif ($ch =~ /[\x00-\x1f\x7f]/) { }
+                else                     { $cols++ }
+            }
+            push @rows, { cols => $cols, chars => length($line), text => $line };
+        }
+        close $fh;
+        unless (@rows) {
+            print "anchor not found: no messages-table rows matched in $render\n";
+            exit 1;
+        }
+        my %widths; $widths{ $_->{cols} }++ for @rows;
+        if (keys %widths > 1) {
+            printf "messages-table rows occupy differing terminal column counts: %s\n",
+                join(", ", map { "$_ cols x$widths{$_}" } sort { $a <=> $b } keys %widths);
+            for my $r (@rows) {
+                printf "  cols=%-4d chars=%-4d %s\n", $r->{cols}, $r->{chars}, substr($r->{text}, 0, 90);
+            }
+            exit 1;
+        }
+        printf "%d rows, all %d terminal columns\n", scalar @rows, (keys %widths)[0];
+        exit 0;
+    ' "$1"
+}
+
+# No C0 control character or DEL survives anywhere in a message-derived field.
+# Takes a file and a description; scans the whole file, so it also catches a
+# control character that reached a surface the row scan above does not read.
+# LF is excluded because it is the record separator of every surface checked.
+check_no_control_chars() {
+    "$PERL" -e '
+        my ($path, $what, $allow) = @ARGV;
+        $allow = "" unless defined $allow;
+        open my $fh, "<", $path or die "cannot open $path: $!\n";
+        local $/; my $data = <$fh>; close $fh;
+        unless (length $data) { print "anchor not found: $path is empty\n"; exit 1 }
+        my %ok = map { $_ => 1 } (0x0a, map { hex } split /,/, $allow ? $allow : "");
+        my %seen;
+        while ($data =~ /([\x00-\x1f\x7f])/g) {
+            my $b = ord $1;
+            next if $ok{$b};
+            $seen{$b}++;
+        }
+        if (%seen) {
+            printf "%s carries control bytes: %s\n", $what,
+                join(", ", map { sprintf "0x%02x x%d", $_, $seen{$_} } sort { $a <=> $b } keys %seen);
+            exit 1;
+        }
+        print "$what carries no control characters\n";
+        exit 0;
+    ' "$1" "$2" "${3:-}"
+}
+
+# A TAB in the source message renders as the agreed four spaces, and the other
+# control characters are gone. Property, not a frozen row: the assertion is that
+# the fixture's tab-bearing message reads with a four-space run at the point the
+# tab occupied, and that no fixture message still shows a control character.
+check_tab_expansion() {
+    "$PERL" -e '
+        my ($render) = @ARGV;
+        open my $fh, "<", $render or die "cannot open $render: $!\n";
+        my $found = 0;
+        while (my $line = <$fh>) {
+            next unless $line =~ /Horizontal tab here:/;
+            $found = 1;
+            unless ($line =~ /Horizontal tab here:    and text/) {
+                print "tab did not expand to four spaces: ", substr($line, 0, 120), "\n";
+                exit 1;
+            }
+        }
+        unless ($found) {
+            print "anchor not found: no row carrying the tab fixture message in $render\n";
+            exit 1;
+        }
+        print "tab expanded to four spaces\n";
+        exit 0;
+    ' "$1"
+}
+
+# Every CSV record occupies exactly one physical line. A message carrying a CR
+# or LF produces a quoted multi-line field, so the count of logical records
+# parsed by a conformant reader diverges from the count of physical lines.
+check_csv_one_line_per_record() {
+    "$PERL" -MText::CSV -e '
+        my ($path) = @ARGV;
+        my $csv = Text::CSV->new({ binary => 1 });
+        open my $fh, "<", $path or die "cannot open $path: $!\n";
+        my $records = 0;
+        $records++ while $csv->getline($fh);
+        close $fh;
+        open $fh, "<", $path or die "cannot open $path: $!\n";
+        my $lines = 0;
+        $lines++ while <$fh>;
+        close $fh;
+        unless ($records) { print "anchor not found: no CSV records in $path\n"; exit 1 }
+        if ($records != $lines) {
+            printf "CSV logical records (%d) != physical lines (%d): a field carries an embedded record separator\n",
+                $records, $lines;
+            exit 1;
+        }
+        printf "%d records, one physical line each\n", $records;
+        exit 0;
+    ' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: one fixture, three surfaces.
+# ---------------------------------------------------------------------------
+
+current_scenario="control-character-normalisation"
+echo "[$current_scenario]"
+
+RENDER="$TMP_DIR/render.txt"
+STDERR="$TMP_DIR/render.stderr"
+
+set +e
+( cd "$TMP_DIR" && "$LTL" --disable-progress -ni -bs 1440 -oe -g 60 -o \
+    --terminal-width "$WIDTH" -V message-grouping "$FIXTURE" ) \
+    2>"$STDERR" | strip_ansi > "$RENDER"
+render_status=("${PIPESTATUS[@]}")
+set -e
+
+# The -V sections and the rendered table share one stream. Split them: the table
+# invariants below assert on the table alone, and the cluster-membership records
+# are asserted separately (they legitimately carry 0x1f as their own category/key
+# separator, which is not message-derived).
+TABLE="$TMP_DIR/table.txt"
+VSECTIONS="$TMP_DIR/vsections.txt"
+sed -n '/^=== message-grouping/,/^=== END message-grouping ===/p' "$RENDER" > "$VSECTIONS"
+sed '/^=== message-grouping/,/^=== END message-grouping ===/d' "$RENDER" > "$TABLE"
+
+if [[ "${render_status[0]}" -ne 0 ]]; then
+    echo "  FAIL  $current_scenario :: ltl exited ${render_status[0]} while rendering" >&2
+    sed 's/^/        /' "$STDERR" >&2
+    exit 1
+fi
+if [[ ! -s "$RENDER" ]]; then
+    echo "  FAIL  $current_scenario :: rendered output is empty" >&2
+    exit 1
+fi
+
+# Runtime-warning cleanliness (HARNESS-DESIGN.md § Runtime-warning cleanliness).
+if ! assert_no_runtime_warnings "$STDERR" "$current_scenario"; then
+    fail=$((fail + 1)); failures+=("$current_scenario :: perl-runtime-warnings-on-stderr")
+fi
+
+MESSAGES_CSV=$(find "$TMP_DIR" -name '*-LTL-MESSAGES-*.csv' -print -quit)
+if [[ -z "$MESSAGES_CSV" ]]; then
+    echo "  FAIL  $current_scenario :: anchor not found: no messages CSV emitted by -o" >&2
+    exit 1
+fi
+
+assert_command \
+    command     "check_render_columns '$TABLE'" \
+    label       'every messages-table row occupies the same number of terminal columns' \
+    asserts     'Rows of the messages table are budgeted in characters and padded with sprintf "%-Ns", so one character must occupy one terminal column. Every rendered row must therefore occupy an identical column count; a TAB (which advances to the next eight-column tab stop) or any other control character in the message would make one row wider or narrower than its siblings and push the Occurrences cell off the line.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path; rows rendered by print_message_summary() in ltl' \
+    contract    'features/447-message-control-character-normalisation.md § D1 — TAB expands to four spaces, other C0 characters and DEL are removed, at ingest'
+
+assert_command \
+    command     "check_no_control_chars '$TABLE' 'the rendered table'" \
+    label       'no control character survives into the rendered output' \
+    asserts     'C0 control characters other than the record separator must not reach the rendered surface. Each corrupts it differently: CR returns the cursor to column zero so the rest of the row overwrites its own start, and ESC is executed by the terminal as an ANSI sequence, re-colouring everything printed after it.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path' \
+    contract    'features/447-message-control-character-normalisation.md § D1 — normalisation happens at ingest, so no render path can reintroduce it'
+
+# The messages CSV carries the message key verbatim in column 2. A raw CR or LF
+# there becomes an embedded newline inside a quoted field: still valid RFC 4180,
+# but one logical row spread over two physical lines, which every line-oriented
+# consumer (grep, awk, sed) reads as two records. 0x1f is likewise structural —
+# it is the field separator of the per-message counter store.
+assert_command \
+    command     "check_no_control_chars '$MESSAGES_CSV' 'the messages CSV'" \
+    label       'no control character survives into the messages CSV' \
+    asserts     'The messages CSV writes the message key verbatim. A control character there is not merely cosmetic: a CR or LF becomes an embedded newline inside a quoted field, so one logical record spans two physical lines and every line-oriented consumer misreads it. Normalising at ingest means the CSV receives the same clean key the table does.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path; CSV written by print_message_summary() in ltl' \
+    contract    'features/447-message-control-character-normalisation.md § D2 — one normalisation at ingest serves every consumer of the key'
+
+assert_command \
+    command     "check_csv_one_line_per_record '$MESSAGES_CSV'" \
+    label       'every messages-CSV record occupies exactly one physical line' \
+    asserts     'A message carrying a CR or LF produces a quoted multi-line CSV field, so the count of logical CSV records diverges from the count of physical lines. Equality of the two proves no message-derived field smuggled a record separator into the file.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path; CSV written by print_message_summary() in ltl' \
+    contract    'features/447-message-control-character-normalisation.md § D2 — one normalisation at ingest serves every consumer of the key'
+
+# The cluster-membership records use 0x1f to separate category from key, so a
+# raw 0x1f inside a member key forges a boundary. Exactly one per `cluster:`
+# line is legitimate; a `member:` line must carry none.
+assert_command \
+    command     "$PERL -e 'my \$bad=0; my \$seen=0; open my \$fh,\"<\",\$ARGV[0] or die; while (<\$fh>) { if (/^  cluster: /) { \$seen++; my \$n=tr/\\x1f//; if (\$n != 1) { print \"cluster line carries \$n unit separators, expected exactly 1: \$_\"; \$bad++ } } elsif (/^    member: /) { \$seen++; my \$n=tr/\\x1f//; if (\$n) { print \"member line carries \$n unit separators, expected 0: \$_\"; \$bad++ } } } close \$fh; unless (\$seen) { print \"anchor not found: no cluster/member records in the -V output\\n\"; exit 1 } exit(\$bad ? 1 : 0)' '$VSECTIONS'" \
+    label       'no message key forges a unit-separator boundary in the cluster-membership records' \
+    asserts     'The -V message-grouping cluster-membership records are line-oriented and use 0x1f to separate category from canonical key. A raw 0x1f inside a message key would forge that boundary, so a cluster line must carry exactly one separator and a member line none.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path; records emitted by group_similar_messages() in ltl' \
+    contract    'features/447-message-control-character-normalisation.md § D2 — one normalisation at ingest serves every consumer of the key'
+
+# ---------------------------------------------------------------------------
+# Scenario 2: ungrouped. Without -g each message keeps its own row, so the
+# per-message text is readable in the table and the TAB expansion can be
+# asserted directly. Scenario 1 runs with -g 60 because the cluster-membership
+# records only exist under consolidation; there the fixture's messages collapse
+# into one wildcard row and no individual message text survives to assert on.
+# ---------------------------------------------------------------------------
+
+current_scenario="ungrouped-tab-expansion"
+echo
+echo "[$current_scenario]"
+
+RENDER2="$TMP_DIR/render-ungrouped.txt"
+STDERR2="$TMP_DIR/render-ungrouped.stderr"
+
+set +e
+( cd "$TMP_DIR" && "$LTL" --disable-progress -ni -bs 1440 -oe \
+    --terminal-width "$WIDTH" "$FIXTURE" ) \
+    2>"$STDERR2" | strip_ansi > "$RENDER2"
+render2_status=("${PIPESTATUS[@]}")
+set -e
+
+if [[ "${render2_status[0]}" -ne 0 ]]; then
+    echo "  FAIL  $current_scenario :: ltl exited ${render2_status[0]} while rendering" >&2
+    sed 's/^/        /' "$STDERR2" >&2
+    exit 1
+fi
+if [[ ! -s "$RENDER2" ]]; then
+    echo "  FAIL  $current_scenario :: rendered output is empty" >&2
+    exit 1
+fi
+
+if ! assert_no_runtime_warnings "$STDERR2" "$current_scenario"; then
+    fail=$((fail + 1)); failures+=("$current_scenario :: perl-runtime-warnings-on-stderr")
+fi
+
+assert_command \
+    command     "check_render_columns '$RENDER2'" \
+    label       'every messages-table row occupies the same number of terminal columns' \
+    asserts     'Rows of the messages table are budgeted in characters and padded with sprintf "%-Ns", so one character must occupy one terminal column. With each message on its own row, a TAB or other control character in any one of them would make that row wider or narrower than its siblings and push the Occurrences cell off the line.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path; rows rendered by print_message_summary() in ltl' \
+    contract    'features/447-message-control-character-normalisation.md § D1 — TAB expands to four spaces, other C0 characters and DEL are removed, at ingest'
+
+assert_command \
+    command     "check_tab_expansion '$RENDER2'" \
+    label       'a TAB in the source message renders as four spaces' \
+    asserts     'TAB is the one control character with a defensible width and is preserved as separation rather than dropped: it expands to exactly four spaces. A fixed expansion is stable regardless of which column the tab lands in, unlike a terminal tab stop, whose advance depends on where the tab falls.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path' \
+    contract    'features/447-message-control-character-normalisation.md § D1 — TAB expands to four spaces'
+
+assert_command \
+    command     "check_no_control_chars '$RENDER2' 'the rendered table'" \
+    label       'no control character survives into the rendered output' \
+    asserts     'C0 control characters other than the record separator must not reach the rendered surface. Each corrupts it differently: CR returns the cursor to column zero so the rest of the row overwrites its own start, and ESC is executed by the terminal as an ANSI sequence, re-colouring everything printed after it.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path' \
+    contract    'features/447-message-control-character-normalisation.md § D1 — normalisation happens at ingest, so no render path can reintroduce it'
+
+# ---------------------------------------------------------------------------
+# Scenario 3: a line no format matches contributes no message. The record
+# lexicals are cleared as a side effect of the scan's failed list-assignment
+# matches; a space-led line is rejected by the whitespace dispatch before any
+# block runs, so it performs no such match and $message still holds the PREVIOUS
+# matched line's text. The message key is built behind an $is_line_match gate
+# that already excludes such a line, so this scenario is regression cover for
+# that exclusion — it is what makes it safe for #447 to normalise ahead of it.
+# ---------------------------------------------------------------------------
+
+current_scenario="unmatched-line-not-normalised"
+echo
+echo "[$current_scenario]"
+
+RENDER3="$TMP_DIR/render-unmatched.txt"
+STDERR3="$TMP_DIR/render-unmatched.stderr"
+
+set +e
+( cd "$TMP_DIR" && "$LTL" --disable-progress -ni -bs 1440 -oe -n 10 \
+    --terminal-width "$WIDTH" "$UNMATCHED_FIXTURE" ) \
+    2>"$STDERR3" | strip_ansi > "$RENDER3"
+render3_status=("${PIPESTATUS[@]}")
+set -e
+
+if [[ "${render3_status[0]}" -ne 0 ]]; then
+    echo "  FAIL  $current_scenario :: ltl exited ${render3_status[0]} while rendering" >&2
+    sed 's/^/        /' "$STDERR3" >&2
+    exit 1
+fi
+
+if ! assert_no_runtime_warnings "$STDERR3" "$current_scenario"; then
+    fail=$((fail + 1)); failures+=("$current_scenario :: perl-runtime-warnings-on-stderr")
+fi
+
+assert_command \
+    command     "$PERL -e 'my (\$read, \$incl); open my \$fh, \"<\", \$ARGV[0] or die; while (<\$fh>) { \$read = \$1 if /LINES READ\\s+(\\d+)/; \$incl = \$1 if /LINES INCLUDED\\s+(\\d+)/ } close \$fh; unless (defined \$read && defined \$incl) { print \"anchor not found: LINES READ / LINES INCLUDED absent\\n\"; exit 1 } if (\$read != 3 || \$incl != 2) { print \"expected 3 read / 2 included, got \$read / \$incl\\n\"; exit 1 } print \"3 read, 2 included\\n\"; exit 0' '$RENDER3'" \
+    label       'the space-led unmatched line is read but not counted as a message' \
+    asserts     'A line no format matches must not contribute a message. The fixture is three lines: two matched and one space-led line the whitespace dispatch rejects before any format block runs, which therefore still carries the preceding line text in the record lexicals. Read must be 3 and included 2 — an included count of 3 would mean that stale message was re-counted.' \
+    produced_by 'read_and_process_logs() in ltl — the $is_line_match gate on message-key construction' \
+    contract    'features/447-message-control-character-normalisation.md § D5 — an unmatched line carries no message of its own'
+
+assert_command \
+    command     "$PERL -e 'my \$n = 0; open my \$fh, \"<\", \$ARGV[0] or die; while (<\$fh>) { \$n++ if /\\[wt\\.method\\.server\\./ } close \$fh; unless (\$n) { print \"anchor not found: no message rows rendered\\n\"; exit 1 } if (\$n != 2) { print \"expected 2 distinct message rows, got \$n\\n\"; exit 1 } print \"2 distinct message rows\\n\"; exit 0' '$RENDER3'" \
+    label       'the unmatched line produces no additional message row' \
+    asserts     'The two matched lines carry different text, so exactly two message rows must render. A third row, or a duplicated one, would mean the unmatched line was processed as though it carried the previous line message.' \
+    produced_by 'read_and_process_logs() in ltl — the $is_line_match gate on message-key construction; rows rendered by print_message_summary() in ltl' \
+    contract    'features/447-message-control-character-normalisation.md § D5 — an unmatched line carries no message of its own'
+
+assert_command \
+    command     "check_no_control_chars '$RENDER3' 'the rendered table'" \
+    label       'no control character survives into the rendered output' \
+    asserts     'The matched line carries a TAB, so the normalisation must still run on it; the unmatched line must not reintroduce a control character. Both hold only if the gate admits matched lines and excludes unmatched ones.' \
+    produced_by 'read_and_process_logs() in ltl — the control-character normalisation on the ingest path' \
+    contract    'features/447-message-control-character-normalisation.md § D1 — normalisation happens at ingest'
+
+echo
+echo "─────────────────────────────────────────"
+echo "  PASS: $pass    FAIL: $fail"
+if [[ "$fail" -gt 0 ]]; then
+    echo
+    echo "  Failed assertions:"
+    printf '    - %s\n' "${failures[@]}"
+    exit 1
+fi
+echo "─────────────────────────────────────────"
+exit 0


### PR DESCRIPTION
Closes #447.

Position 5 in the 0.18.0 delivery order (`features/bin-counter-accuracy-and-observability.md` § D6). The position is forced: this changes the message key, therefore consolidation grouping, therefore what the drift baselines contain, so it lands after stage 4's re-bless.

## Control-character normalisation

The messages table budgets its message column in characters and pads with `sprintf "%-Ns"`, both of which assume one character is one terminal column. With ANSI stripped, an ordinary row measured **138 characters / 138 columns**; a row whose message carried one TAB measured **138 characters / 145 columns**, pushing the Occurrences cell off the line while every other row stayed aligned. The character count — the thing the code budgets against — is identical on both rows, which is why nothing downstream detected it.

Normalise once on the ingest path, where every format's generated scan and both CSV assembly branches have written the message and nothing has read it. TAB expands to four spaces; every other C0 character and DEL is removed. One normalisation serves every consumer of the key, so none needs its own cleaning step and no later path can reintroduce the problem.

Reproducing the reported TAB case surfaced three further defects with the same cause, each worse than the misalignment:

| Character | Effect |
|---|---|
| CR (0x0d) | Cursor returns to column zero; the rest of the row overwrites its own start, destroying the message identity and the occurrences value while the byte count still measures correct |
| ESC (0x1b) | Executed by the terminal as an ANSI sequence, re-colouring everything printed after it |
| US (0x1f) | The field separator of the per-message counter store and the cluster-membership records — a raw one forges a key boundary |

The messages CSV was affected too: a CR became a quoted multi-line field, so one logical record spanned two physical lines and every line-oriented consumer read it as two.

The raw line is deliberately left alone — `-include`/`-exclude`/`-highlight` match against it, and those patterns are the user's to write.

## FATAL as a log level

A line whose captured level is not in `@log_levels` is discarded by the per-line category gate: read, format-matched, then silently dropped — counted in LINES READ, not LINES INCLUDED, with nothing told to the user.

FATAL was not in the vocabulary. The Windchill Method Server format emits it — **14 lines across the corpus, including `MethodServer stopped`, a server shutdown** — and every one was being discarded. Found while reproducing the control-character case on a Method Server log.

Added to the four surfaces a category must occupy: the level array and membership set (ordered ahead of ERROR), the colour table, the CSV structural validator's rules rows, and the error-rate accumulation, which FATAL joins because it denotes a failure.

The statistics oracle already listed FATAL in its own filter, so it had been counting lines the tool discarded — a latent divergence (no drift baseline carries a FATAL line) that closes here.

## Performance

The first implementation was an unconditional sub call and cost **+4.4% of total runtime** on a 1.43M-line access log. Inlining and guarding brought it to **+0.80%** (+92 ns/line):

| Arm | Median | vs baseline | Per line |
|---|---|---|---|
| baseline | 16.383 s | — | — |
| sub call, unguarded | 17.192 s | +4.36% | +503 ns |
| **inline, guarded (shipped)** | 16.514 s | **+0.80%** | **+92 ns** |

Order-balanced ABBA design over 8 pairs, positive in 7/8. Single-order interleaving was not sufficient — the same code measured +0.44% and +1.99% in different sessions, because within-arm spread (0.36 s) exceeds the effect (0.13 s). The residual is one counting-`tr` scan per message, the floor for knowing whether a message is clean. Record: `tests/profile/results/447-control-char-normalisation/`.

## Test coverage

- `tests/validate-message-control-characters.sh` — 3 scenarios, 11 assertions over two committed fixtures. Seven fail with the normalisation disabled; the CSV record-per-line check was proven separately against a doctored CSV; the three unmatched-line assertions are regression cover for the pre-existing `$is_line_match` gate.
- `tests/validate-log-level-vocabulary.sh` — 8 assertions over a six-line fixture, one line per level the format emits. Sabotage removing FATAL fails exactly the three FATAL assertions and leaves the other five green.

**Full suite 26/26 green.** Benchmark against `v0.17.0-release`: total **−0.2%**, no metric worse than 5%.

## Follow-ups filed

The format patterns admit any word in the level slot while the gate accepts 13 hard-coded names, so `CRITICAL`, `SEVERE`, `WARNING`, `NOTICE`, `ALERT` and `EMERGENCY` are matched and then dropped. None occurs in the current corpus. Split deliberately so the cheap fix does not wait on the expensive one:

- **#475** (bug) — add the missing severity names to the recognised set.
- **#476** (enhancement) — declare levels per format in the registry, and report levels seen but not registered at end of run.

Neither blocks the other; no `blocked_by` edge recorded in either direction.