### PR TITLE
BUG: an unquoted glob pattern is consumed by the shell before -r can interpret it

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ When multiple files are specified, logtimeline processes them sequentially and c
 
 Glob expansion is performed internally by logtimeline rather than relying on the shell, ensuring consistent behavior across platforms — particularly on Windows where the shell does not expand wildcards. Only regular files are accepted; directories and other non-file entries in a glob result are silently skipped.
 
-That internal expansion only happens if the pattern actually reaches logtimeline. On macOS and Linux, an unquoted wildcard is expanded by the shell first, and logtimeline receives the list of names the shell matched in the current directory — or, in some shells, the command is refused outright when nothing matched there. It makes no difference for a single-level pattern, but it silently narrows a recursive sweep to whatever the shell already found. Put wildcard patterns in double quotes whenever you use `-r`: `ltl -r "logs/*.log"`.
+That internal expansion only happens if the pattern actually reaches logtimeline. On macOS and Linux, an unquoted wildcard is expanded by the shell first, and logtimeline receives the list of names the shell already matched — or, in some shells, the command is refused outright when the pattern matched nothing. It makes no difference for a single-level pattern, but it silently narrows a recursive sweep to whatever the shell already found. Put wildcard patterns in double quotes whenever you use `-r`: `ltl -r "logs/*.log"`.
 
 ## Options
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,8 @@ When multiple files are specified, logtimeline processes them sequentially and c
 
 Glob expansion is performed internally by logtimeline rather than relying on the shell, ensuring consistent behavior across platforms — particularly on Windows where the shell does not expand wildcards. Only regular files are accepted; directories and other non-file entries in a glob result are silently skipped.
 
+That internal expansion only happens if the pattern actually reaches logtimeline. On macOS and Linux, an unquoted wildcard is expanded by the shell first, and logtimeline receives the list of names the shell matched in the current directory — or, in some shells, the command is refused outright when nothing matched there. It makes no difference for a single-level pattern, but it silently narrows a recursive sweep to whatever the shell already found. Put wildcard patterns in double quotes whenever you use `-r`: `ltl -r "logs/*.log"`.
+
 ## Options
 
 ### Time & Buckets
@@ -102,7 +104,7 @@ These options control which metrics logtimeline extracts and computes during pro
 | `-os, --omit-stats` | Deprecated: use `-od, --omit-durations` to skip capturing durations, or `-hst, --hide-stats` to hide the statistics panel |
 | `-oe, --omit-empty` | Skip time buckets that contain zero log entries |
 | `-ni, --no-index` | Do not read or update `ltl-index.csv`, the per-directory index that records each analysed file and pre-seeds later runs; the run neither benefits from nor adds to it |
-| `-r, --recursive` | Match each file argument's filename pattern at every depth below its directory, instead of only directly inside it. `logs/access/*.log` becomes every `.log` file anywhere under `logs/access`; `*.log` recurses from the current directory. Subdirectories are entered whatever their own names are, shallower files are read before deeper ones, and a file reachable from two arguments is read once. Directory symlinks are not followed, and directories that cannot be read are skipped and reported at the end. |
+| `-r, --recursive` | Match each file argument's filename pattern at every depth below its directory, instead of only directly inside it. `"logs/access/*.log"` becomes every `.log` file anywhere under `logs/access`; `"*.log"` recurses from the current directory. Put the pattern in double quotes so your shell passes it through unchanged: an unquoted pattern is expanded, or rejected, by the shell before ltl sees it, and the sweep then covers only what the shell already matched. Subdirectories are entered whatever their own names are, shallower files are read before deeper ones, and a file reachable from two arguments is read once. Directory symlinks are not followed, and directories that cannot be read are skipped and reported at the end. |
 | `-or, --omit-rate` | Hide the error/message rate from the legend |
 | `-od, --omit-durations` | Suppress duration extraction and related columns (significantly reduces memory and processing time on large files) |
 | `-ob, --omit-bytes` | Suppress byte-size extraction and related columns |

--- a/features/420-recursive-file-selection.md
+++ b/features/420-recursive-file-selection.md
@@ -168,6 +168,11 @@ against the tiny fixture tree.
 `print_help()` and the options reference in `docs/usage.md` updated in the
 same commit — parity enforced by `tests/validate-help-content.sh`.
 
+The quoting a `-r` pattern needs in order to survive the shell, and the
+guidance the no-files failure carries when a sweep selects nothing, are owned
+by `features/445-unquoted-glob-consumed-by-shell-before-r.md`. Nothing there
+changes which files `-r` selects.
+
 ## Implementation notes
 
 - **N1 — The sweep is an explicit breadth-first queue, not `File::Find`.**

--- a/features/445-unquoted-glob-consumed-by-shell-before-r.md
+++ b/features/445-unquoted-glob-consumed-by-shell-before-r.md
@@ -135,3 +135,101 @@ Harnesses run on the final content: `validate-recursive-file-selection.sh`
 22 passed / 0 failed (17 before this change), `validate-help-content.sh` 11/0,
 `validate-help-layout.sh` 6/0, `validate-runtime-config.sh` 36/0,
 `validate-doc-examples.sh` 46 passed / 0 failed / 9 skipped.
+
+## Completion gate
+
+Run on `0d7fe5d` (`#445: restore release version for the completion gate`), the
+commit offered for merge. The branch was already sitting on the
+`release/0.18.0` tip (`ab6b1c8`), so the rebase was a no-op and no conflict
+arose. `$version_number` restored from `0.18.0-445` to `0.18.0` in the gated
+commit.
+
+Scope test: the diff touches `ltl` and `tests/validate-recursive-file-selection.sh`,
+so both halves of the gate are in force.
+
+### Harness suite — 27 of 27 exit 0
+
+| Harness | Summary line |
+|---|---|
+| `validate-csv-output` | CSV output integrity: 21 scenarios, 21 pass, 0 fail |
+| `validate-statistics` | Statistics drift: 21 scenarios, 21 pass, 0 fail |
+| `validate-csv-input` | CSV input robustness: 4 pass, 0 fail |
+| `validate-distribution-shape` | 8 passed, 0 failed |
+| `validate-doc-examples` | 46 passed, 0 failed, 9 skipped |
+| `validate-duration-display` | 21 passed, 0 failed |
+| `validate-explain` | 148 passed, 0 failed |
+| `validate-format-detection` | 192 passed, 0 failed |
+| `validate-format-registry` | 22 passed, 0 failed |
+| `validate-heatmap-palette` | 85 passed, 0 failed |
+| `validate-help-content` | 11 passed, 0 failed |
+| `validate-help-layout` | 6 passed, 0 failed |
+| `validate-histogram-bin-counters` | 84 passed, 0 failed |
+| `validate-histogram-ticks` | Total: 21, Passed: 21, Failed: 0 |
+| `validate-index-read-back` | 59 passed, 0 failed |
+| `validate-log-level-vocabulary` | PASS: 8, FAIL: 0 |
+| `validate-message-control-characters` | PASS: 11, FAIL: 0 |
+| `validate-message-grouping-notices` | 4 passed, 0 failed |
+| `validate-numeric-criteria-notices` | 10 passed, 0 failed |
+| `validate-profile-render` | 22 passed, 0 failed |
+| `validate-profile` | 50 passed, 0 failed |
+| `validate-recursive-file-selection` | 22 passed, 0 failed |
+| `validate-regression` | 71 passed, 0 failed, 0 skipped |
+| `validate-runtime-config` | 36 passed, 0 failed |
+| `validate-statistics-demand` | 75 passed, 0 failed |
+| `validate-udm-counting` | 28 passed, 0 failed |
+| `validate-udm-specs` | 43 passed, 0 failed |
+
+`validate-statistics`: zero T4 and zero T3 on every scenario, so nothing
+blocking. T2 advisories are present as usual (largest concentrations:
+`thingworx-bin-consolidated/messages` 176, `codebeamer-bin-consolidated/messages`
+84, `tomcat-default/messages` 76) together with 28 pre-registered `XFAIL`
+entries on the three `*-bin-consolidated` scenarios, which report
+`L3=OK-WITH-XFAIL`. None of these surfaces is touched by this change.
+
+`./tests/cleanup-test-artifacts.sh` run afterwards.
+
+### Before/after benchmark
+
+`single-day-access-log-standard`, run back-to-back on this machine: `445-before`
+on a worktree of `origin/release/0.18.0` (`ab6b1c8`), `445-after` on `0d7fe5d`.
+761,698 lines read and included on both sides.
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| `total` (elapsed) | 10.151 s | 9.861 s | −290 ms (−2.9%) |
+| `parse/read_files` | 9.990 s | 9.701 s | −289 ms (−2.9%) |
+| `finalize/calculate_statistics` | 151 ms | 151 ms | 0 |
+| `detect/registry_build` | 9 ms | 8 ms | −1 ms |
+| `detect/scan_sub_compile` | 4 ms | 5 ms | +1 ms |
+| `MEMORY/rss_peak` | 142.6 MB | 142.6 MB | +16 KB (0.0%) |
+
+One metric breached the 5% threshold and was investigated: `MEMORY/format_scan_subs`
+read +48 KB (+6.7%), and reproduced at +48 KB (+6.8%) on an immediate second
+before/after pair.
+
+**It is not a regression — the metric's run-to-run spread is wider than the
+delta.** `format_scan_subs` is not a structure size: it is the whole-process
+resident-set delta measured across the `eval` that compiles the generated scan
+sub, so it is quantized to the 16 KB page and it captures every page the
+allocator happens to fault in during that window, not the sub's own footprint.
+48 KB is exactly three pages.
+
+Five runs of each arm on the benchmark's own file and options, plus a control
+arm consisting of the release-branch `ltl` with 2,040 bytes of inert comment
+text inserted (the branch adds 1,330 bytes):
+
+| Arm | Samples (KB) | Median | Range |
+|---|---|---|---|
+| `release/0.18.0` | 768, 784, 784, 816, 816 | 784 KB | 768–816 KB |
+| this branch | 768, 768, 800, 800, 816 | 800 KB | 768–816 KB |
+| release + inert padding | 736, 784, 800, 816, 832 | 784 KB | 736–832 KB |
+
+Every sample from this branch falls inside the release branch's own range, and
+the inert-padding control spans a wider band than either. `format_scan_subs_compiled`
+is 1 on every run of every arm, so the compile work itself is unchanged. The
+single-sample-per-side benchmark pair cannot resolve a three-page difference in
+a metric that moves three to six pages between identical runs.
+
+`MEMORY/rss_peak`, which does account for the whole process, is flat (0.0% on
+the first pair, −0.3% on the second), and elapsed time improved on both pairs.
+Gate passed; both TSV pairs deleted.

--- a/features/445-unquoted-glob-consumed-by-shell-before-r.md
+++ b/features/445-unquoted-glob-consumed-by-shell-before-r.md
@@ -1,0 +1,121 @@
+# #445 — An unquoted glob pattern is consumed by the shell before `-r` sees it
+
+Owning doc for the quoting guidance around `-r`/`--recursive`: what the
+documentation teaches, and what the tool says when a recursive sweep selects
+nothing.
+
+## Requirement
+
+A wildcard pattern written without quotes is expanded — or, in zsh, rejected —
+by the shell before `ltl` starts. Two outcomes:
+
+- **Loud.** zsh aborts with `no matches found: access.log_2026-08-*` and `ltl`
+  never runs.
+- **Quiet, and the dangerous one.** When the pattern does match files in the
+  current directory, the shell hands `ltl` a narrowed literal list and the
+  recursive sweep covers only that. On the committed fixture tree,
+  `-r *.888` selects 2 files where `-r '*.888'` selects 8 — same exit status,
+  no warning.
+
+There is no run-time evidence to detect this from: after the shell has run,
+what arrives is a list of literal names, which is exactly what a legitimate
+`ltl -r access.log` looks like. So no warning can fire on a successful run.
+
+What was asked for, both with zero false-positive risk: every documented `-r`
+example teaches the quoted form and says briefly why; and the failure the tool
+already prints when nothing matched points at quoting. Shipped release records
+carrying the unquoted example are corrected so it stops propagating.
+
+Related: **#420** (recursive file selection) owns the `-r` contract —
+`features/420-recursive-file-selection.md`. Its locked decisions cover pattern
+splitting, traversal order, symlinks and unreadable directories, and say
+nothing about shell interaction. Nothing here changes which files `-r`
+selects.
+
+## Decisions
+
+- **D1 — The guidance rides on the existing no-files failure, and nowhere
+  else.** The run has already stopped and the tool is already speaking, so
+  guidance there costs nothing and can mislead nobody. No new option, no new
+  notice, no check on a successful run.
+
+- **D2 — The guidance is conditional on `-r`.** Without `-r`, a pattern the
+  shell expanded selects exactly what `ltl` would have selected itself, so
+  quoting is not the explanation and the advice would misdirect. The
+  `-r`-less failure is unchanged.
+
+- **D3 — The failure carries the guidance as a hint line, not as a longer
+  error reason.** `print_usage()` takes an optional third argument, printed
+  unbolded on the lines after `Error:` and inside the same error block. The
+  `Error: unable to open any files` line is byte-identical to before, so the
+  harnesses anchored on it are unaffected.
+
+- **D4 — The "Files" section of `docs/usage.md` says why, not just what.**
+  That section already tells the reader glob expansion is internal and does
+  not rely on the shell, which is true and is exactly the property an unquoted
+  pattern defeats. A reader who stops there concludes quoting is unnecessary,
+  so the explanation belongs beside that claim rather than only in the `-r`
+  row.
+
+## What changed, by surface
+
+| Surface | Change |
+|---|---|
+| `print_help()` in `ltl` | The `-r, --recursive` row quotes both examples and adds the quoting sentence with its reason |
+| `docs/usage.md` options row | Same text, same commit (parity gate: `tests/validate-help-content.sh`) |
+| `docs/usage.md` § Files | A paragraph beside the internal-glob-expansion claim: what the shell does to an unquoted pattern first, why it does not matter for a single-level pattern, and why it does for `-r` |
+| `releases/v0.17.0.md` | The shipped `-r logs/access/*.log` example is now quoted |
+| `print_usage()` in `ltl` | Optional hint argument, printed after the `Error:` line |
+| The empty-`@in_files` guard in `adapt_to_command_line_options()` | Builds the hint when `-r` is set and hands it to `print_usage()` |
+
+## The failure message
+
+`ltl --disable-progress -ni -r 'no-such-*'` from a directory with no matches
+(exit 2):
+
+```
+Usage: ltl [-bs <N>] [-n <N>] [-i <regex>] [-e <regex>] [-h <regex>] [-st <time>] [-et <time>]
+           [-ov] [-or] [-ru <unit>] [-osum] [-so <field>] [-hm [metric]] [-hg [metric]] <logfile> ...
+
+Error: unable to open any files
+Hint: with -r, put the file pattern in double quotes - ltl -r "logs/*.log" - so
+      your shell passes it through unchanged. An unquoted pattern is expanded,
+      or rejected, by the shell before ltl ever sees it.
+
+Try 'ltl --help' for more information.
+```
+
+The same invocation without `-r` prints the identical block with no `Hint:`
+line.
+
+## Verification
+
+Scenario `no-match-quoting-guidance` in
+`tests/validate-recursive-file-selection.sh`, five assertions:
+
+| Assertion | What it holds to |
+|---|---|
+| a pattern matching nothing is a hard error (`with-r`, `without-r`) | exit 2 and `unable to open any files` on stderr, unchanged either way |
+| the `-r` no-match failure tells the user to quote the pattern | the hint is present |
+| the same failure without `-r` carries no quoting guidance | D2 |
+| a `-r` run that selected files carries no quoting guidance | D1 — zero false positives |
+
+Invocation shape: the assertion reads a diagnostic emitted while the file
+arguments are still being expanded, before a bucket, a table or a `-V` section
+exists, so the two runs carry no analysis options at all — the pattern is the
+whole input. The successful-run assertion reuses the stderr already captured by
+the preceding scenario rather than running `ltl` again.
+
+Each new assertion was proved able to fail (HARNESS-DESIGN.md § "Proving a new
+assertion can fail"):
+
+| Sabotage | Assertion that failed |
+|---|---|
+| Build the hint unconditionally instead of only under `-r` | the same failure without `-r` carries no quoting guidance |
+| Never build the hint | the `-r` no-match failure tells the user to quote the pattern |
+| Print the hint on the path taken when files *were* selected | a `-r` run that selected files carries no quoting guidance |
+
+Harnesses run on the final content: `validate-recursive-file-selection.sh`
+22 passed / 0 failed (17 before this change), `validate-help-content.sh` 11/0,
+`validate-help-layout.sh` 6/0, `validate-runtime-config.sh` 36/0,
+`validate-doc-examples.sh` 46 passed / 0 failed / 9 skipped.

--- a/features/445-unquoted-glob-consumed-by-shell-before-r.md
+++ b/features/445-unquoted-glob-consumed-by-shell-before-r.md
@@ -57,6 +57,22 @@ selects.
   so the explanation belongs beside that claim rather than only in the `-r`
   row.
 
+- **D5 — The quoting guidance and the quoted examples are scoped to `-r`, and
+  to nothing else.** This is what the issue's "What is wanted" section asks
+  for: every documented **`-r`** example teaches the quoted form. The
+  non-recursive glob example — `ltl logs/2025-05-*.txt`, in the examples block
+  of `print_help()` and in the synopsis of `docs/usage.md` — stays unquoted,
+  and so does any other example that does not pass `-r`. Without `-r`, a
+  pattern the shell expanded selects exactly the set `ltl` would have selected
+  itself, so there is no silent under-selection to guard against; and when the
+  pattern matches nothing, both sides fail loudly — zsh refuses the command
+  outright, and any shell that passes the pattern through unexpanded leaves
+  `ltl` to stop with `Error: unable to open any files`. Quoting is therefore
+  not the explanation for anything a reader of those examples can hit, and
+  quoting them would teach a remedy for a problem the example does not have.
+  Same reasoning as D2 (the failure-message hint fires only under `-r`),
+  applied to the documented examples rather than to the failure message.
+
 ## What changed, by surface
 
 | Surface | Change |

--- a/ltl
+++ b/ltl
@@ -57,7 +57,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0";
+my $version_number = "0.18.0-445";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );
@@ -5241,12 +5241,14 @@ sub print_title {
 }
 
 sub print_usage {
-    my ( $error_reason, $parser_text ) = @_;
+    my ( $error_reason, $parser_text, $hint ) = @_;
     # All command-line diagnostics go to STDERR so both the parser's own
     # message and ltl's error line appear together as one block, out of any
     # piped data stream. Layout: usage paragraph, one blank line, the error
-    # block (the raw parser line if any, then ltl's Error line), one blank
-    # line, then the help pointer.
+    # block (the raw parser line if any, then ltl's Error line, then the
+    # optional remediation hint), one blank line, then the help pointer.
+    # The hint carries its own newlines: it is pre-wrapped guidance a caller
+    # supplies when the failure has a known remedy worth spelling out.
     print STDERR "Usage: ltl [-bs <N>] [-n <N>] [-i <regex>] [-e <regex>] [-h <regex>] [-st <time>] [-et <time>]\n";
     print STDERR "           [-ov] [-or] [-ru <unit>] [-osum] [-so <field>] [-hm [metric]] [-hg [metric]] <logfile> ...\n";
     print STDERR "\n";
@@ -5254,6 +5256,7 @@ sub print_usage {
     # escape-free at line start regardless of colour settings.
     print STDERR $parser_text if defined $parser_text && $parser_text ne '';
     print STDERR bs_bold("Error: $error_reason") . "\n" if defined $error_reason;
+    print STDERR $hint if defined $hint && $hint ne '';
     print STDERR "\n";
     print STDERR "Try 'ltl --help' for more information.\n";
     return;
@@ -6638,7 +6641,7 @@ sub print_help {
     $out .= help_opt("-os,  --omit-stats",            "Deprecated: use -od, --omit-durations to skip capturing durations, or -hst, --hide-stats to hide the statistics panel");
     $out .= help_opt("-oe,  --omit-empty",            "Skip time buckets that contain zero log entries");
     $out .= help_opt("-ni,  --no-index",              "Do not read or update ltl-index.csv, the per-directory index that records each analysed file and pre-seeds later runs; the run neither benefits from nor adds to it");
-    $out .= help_opt("-r,   --recursive",             "Match each file argument's filename pattern at every depth below its directory, instead of only directly inside it. logs/access/*.log becomes every .log file anywhere under logs/access; *.log recurses from the current directory. Subdirectories are entered whatever their own names are, shallower files are read before deeper ones, and a file reachable from two arguments is read once. Directory symlinks are not followed, and directories that cannot be read are skipped and reported at the end.");
+    $out .= help_opt("-r,   --recursive",             "Match each file argument's filename pattern at every depth below its directory, instead of only directly inside it. \"logs/access/*.log\" becomes every .log file anywhere under logs/access; \"*.log\" recurses from the current directory. Put the pattern in double quotes so your shell passes it through unchanged: an unquoted pattern is expanded, or rejected, by the shell before ltl sees it, and the sweep then covers only what the shell already matched. Subdirectories are entered whatever their own names are, shallower files are read before deeper ones, and a file reachable from two arguments is read once. Directory symlinks are not followed, and directories that cannot be read are skipped and reported at the end.");
     $out .= help_opt("-or,  --omit-rate",             "Hide the error/message rate from the legend");
     $out .= help_opt("-od,  --omit-durations",        "Suppress duration extraction and related columns (significantly reduces memory and processing time on large files)");
     $out .= help_opt("-ob,  --omit-bytes",            "Suppress byte-size extraction and related columns");
@@ -10297,7 +10300,21 @@ sub adapt_to_command_line_options {
         @in_files = grep { !$seen_in_file{$_}++ } @in_files;
     }
 
-    do { print_usage( "unable to open any files" ); exit 2; } unless @in_files;
+    # A pattern the shell expanded, or refused to expand, before ltl started is
+    # the commonest reason a recursive sweep selects nothing, and once the shell
+    # has run there is no evidence left to detect it from: what arrives is a
+    # plain list of names, indistinguishable from a legitimate literal argument.
+    # The guidance therefore rides on this failure only, where the run has
+    # already stopped and it cannot mislead a successful one.
+    unless (@in_files) {
+        my $quoting_hint;
+        $quoting_hint = "Hint: with -r, put the file pattern in double quotes - ltl -r \"logs/*.log\" - so\n"
+                      . "      your shell passes it through unchanged. An unquoted pattern is expanded,\n"
+                      . "      or rejected, by the shell before ltl ever sees it.\n"
+            if $recursive_files;
+        print_usage( "unable to open any files", undef, $quoting_hint );
+        exit 2;
+    }
     # Duration keeps its bare spellings on the CLI because duration is the tool's
     # subject: every statistic in the summary table is a duration statistic unless
     # it says otherwise. A user who has learned the metric_aggregate convention from

--- a/ltl
+++ b/ltl
@@ -57,7 +57,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0-445";
+my $version_number = "0.18.0";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );

--- a/releases/v0.17.0.md
+++ b/releases/v0.17.0.md
@@ -12,7 +12,7 @@
 - New log format: Windchill Method Server and Background Method Server (including the CAD and ESI workers) log4j logs are recognised as `windchill_method_server` (#396)
 - The progress line shows how far through the current file the read is, as `Processing line N (P% complete) in file …`; input that cannot be sized shows the line count alone (#397)
 - New `-V format-registry` section reports the log formats `ltl` knows: each entry's name and group, which variants can be told apart, the order they are tried in, and how much recognition work the run prepared (#413)
-- New `-r, --recursive` option matches each file argument's filename pattern at every depth below its directory, so `-r logs/access/*.log` reads every `.log` file anywhere under `logs/access` (#420)
+- New `-r, --recursive` option matches each file argument's filename pattern at every depth below its directory, so `-r "logs/access/*.log"` reads every `.log` file anywhere under `logs/access` (#420)
 - The statistics phase's time is broken down in `-V benchmark-data`: sub-stage `TIMING` rows (`finalize/calculate_statistics/bucket_stats`, `population_walk`, `sort_selection`, `group_calc`, `threadpool_stats`, `untimed`) with matching element counts in `-V statistics-demand` and new `COUNTS` rows, so cost per element can be compared across runs and versions (#417)
 - LogTimeLine is now distributed under the Apache License 2.0 rather than the MIT licence; redistribution requires retaining the `NOTICE` file, and the licence grants no rights to the names "LogTimeLine" and `ltl` (#434)
 

--- a/tests/validate-recursive-file-selection.sh
+++ b/tests/validate-recursive-file-selection.sh
@@ -373,7 +373,7 @@ for variant in "with-r" "without-r"; do
         label       "a pattern matching nothing is a hard error ($variant)" \
         asserts     'A file pattern that selects no file leaves nothing to read, so the run stops with the same could-not-open-any-files error whether or not -r was given' \
         produced_by 'the empty-@in_files guard in adapt_to_command_line_options() in ltl, rendered via print_usage()' \
-        contract    'features/420-recursive-file-selection.md § D2 — a pattern with nothing to match against selects nothing, with or without -r'
+        contract    'features/445-unquoted-glob-consumed-by-shell-before-r.md § The failure message — a pattern matching no file stops the run with the same could-not-open-any-files error, with or without -r'
 done
 
 assert_command \

--- a/tests/validate-recursive-file-selection.sh
+++ b/tests/validate-recursive-file-selection.sh
@@ -15,6 +15,10 @@
 # so no file contributes lines and none would be distinguishable there, but
 # each still appears as a `file:` entry here.
 #
+# Two scenarios instead assert on stderr, because what they test is a
+# diagnostic and not a selection: the note naming directories the sweep could
+# not read, and the guidance a failed `-r` run gives about quoting the pattern.
+#
 # Each assertion records, per HARNESS-DESIGN.md § Self-documenting assertions:
 #   - asserts:     the file-selection invariant being tested
 #   - produced_by: where in ltl the behaviour is produced (function name)
@@ -336,6 +340,65 @@ if capture_selection "$TMP_DIR/silent.sel" $SHAPE -r "$FIXTURE_ROOT/*.888"; then
         produced_by 'read_and_process_logs() in ltl (end-of-processing note emission, guarded on @unreadable_directories)' \
         contract    'features/420-recursive-file-selection.md § D8 — unreadable directories: collect, continue, report once at the end'
 fi
+
+# --- Scenario: a -r run that selects nothing points at quoting the pattern ---
+# Invocation shape (tests/HARNESS-DESIGN.md § Invocation coherence): the
+# assertion reads a stderr diagnostic emitted while the file arguments are
+# still being expanded, before a bucket, a table or a -V section exists, so the
+# run carries no analysis options at all — the pattern is the whole input.
+current_scenario="no-match-quoting-guidance"
+echo "[$current_scenario]"
+GUIDANCE_ANCHOR='Hint: with -r, put the file pattern in double quotes'
+CONTRACT_GUIDANCE='features/445-unquoted-glob-consumed-by-shell-before-r.md § The failure message — the quoting guidance rides on the no-files failure and on no other path'
+
+for variant in "with-r" "without-r"; do
+    # The array is seeded with the two options every invocation in this harness
+    # carries: bash 3.2 expands an empty array under `set -u` as an unbound
+    # variable, which would abort the subshell before ltl ever ran.
+    nomatch_args=(--disable-progress -ni)
+    [[ "$variant" == "with-r" ]] && nomatch_args+=(-r)
+    set +e
+    ( cd "$TMP_DIR" && "$LTL" "${nomatch_args[@]}" 'no-such-*.888' ) \
+        > "$TMP_DIR/nomatch-$variant.out" 2>"$TMP_DIR/nomatch-$variant.stderr"
+    nomatch_rc=$?
+    set -e
+    # Runtime-warning cleanliness (HARNESS-DESIGN.md § Runtime-warning
+    # cleanliness). The intentional diagnostics this scenario asserts on never
+    # carry the ` at <file> line <N>` suffix, so both live on one capture.
+    if ! assert_no_runtime_warnings "$TMP_DIR/nomatch-$variant.stderr" "$current_scenario"; then
+        fail=$((fail + 1)); failures+=("$current_scenario :: perl-runtime-warnings-on-stderr")
+    fi
+    assert_command \
+        command     "[ $nomatch_rc -eq 2 ] && grep -aqF -- 'unable to open any files' '$TMP_DIR/nomatch-$variant.stderr'" \
+        label       "a pattern matching nothing is a hard error ($variant)" \
+        asserts     'A file pattern that selects no file leaves nothing to read, so the run stops with the same could-not-open-any-files error whether or not -r was given' \
+        produced_by 'the empty-@in_files guard in adapt_to_command_line_options() in ltl, rendered via print_usage()' \
+        contract    'features/420-recursive-file-selection.md § D2 — a pattern with nothing to match against selects nothing, with or without -r'
+done
+
+assert_command \
+    command     "grep -aqF -- '$GUIDANCE_ANCHOR' '$TMP_DIR/nomatch-with-r.stderr'" \
+    label       'the -r no-match failure tells the user to quote the pattern' \
+    asserts     'When -r selected nothing, the failure names the commonest cause the tool cannot detect for itself: the shell consumed the pattern before ltl started. The guidance says to enclose the pattern in double quotes, and why' \
+    produced_by 'the empty-@in_files guard in adapt_to_command_line_options() in ltl (the -r hint handed to print_usage()), rendered by print_usage()' \
+    contract    "$CONTRACT_GUIDANCE"
+
+assert_command \
+    command     "! grep -aqF -- '$GUIDANCE_ANCHOR' '$TMP_DIR/nomatch-without-r.stderr'" \
+    label       'the same failure without -r carries no quoting guidance' \
+    asserts     'The guidance is specific to -r: without it, a pattern the shell expanded selects exactly what ltl would have selected itself, so quoting is not the explanation and the advice would misdirect' \
+    produced_by 'the empty-@in_files guard in adapt_to_command_line_options() in ltl (the hint is conditional on -r)' \
+    contract    "$CONTRACT_GUIDANCE"
+
+# Reuses the stderr of the preceding scenario's successful -r sweep rather than
+# running ltl again: the assertion is that a run which selected files says
+# nothing about quoting, and that run has already happened.
+assert_command \
+    command     "[ -f '$TMP_DIR/silent.sel.stderr' ] && ! grep -aqF -- '$GUIDANCE_ANCHOR' '$TMP_DIR/silent.sel.stderr'" \
+    label       'a -r run that selected files carries no quoting guidance' \
+    asserts     'The guidance is tied to selecting nothing, never to the use of -r: a sweep that found its files says nothing about quoting, so a correct invocation is never warned about a problem it does not have' \
+    produced_by 'the empty-@in_files guard in adapt_to_command_line_options() in ltl (the hint is reached only on the failure path)' \
+    contract    "$CONTRACT_GUIDANCE"
 
 echo
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Fixes #445.

- Every documented `-r` example (`--help`, `docs/usage.md`, the shipped `releases/v0.17.0.md` note) now shows the quoted form, and the Files section of `docs/usage.md` says why: an unquoted pattern is expanded or rejected by the shell before `ltl` sees it.
- When `-r` is given and nothing matches, the "unable to open any files" failure now carries a hint to put the pattern in double quotes. A run that selected files, and a no-match failure without `-r`, are unchanged.
- `tests/validate-recursive-file-selection.sh`: new `no-match-quoting-guidance` scenario (17 → 22 assertions), each new assertion sabotage-proven.

Completion gate on `0d7fe5d`: 27/27 harnesses pass; before/after benchmark `single-day-access-log-standard` on this machine: elapsed 10.151 s → 9.861 s (−2.9 %), peak RSS unchanged. Record: `features/445-unquoted-glob-consumed-by-shell-before-r.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYhJaBPqtoqLVfKUeRsrNE