### PR TITLE
FEATURE: Move the summary section to the end of the output, after all analysis content

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,14 +149,14 @@ ltl -g 80 -iqs -is access.log
 
 ### Display & Output
 
-These options control what is shown and how. After the timeline bar graph, logtimeline prints a summary table ranking the top contributing messages — `-n` controls how many entries appear, and `-osum` suppresses it entirely. The hide options hide individual columns from the bar graph while still processing the underlying data — useful for freeing horizontal space on narrow terminals or focusing on the metrics that matter. The CSV output option (`-o`) writes the full analysis data to a file for external processing, archival, or baseline comparison. The light background mode (`-lbg`) switches color gradients for white or light terminal backgrounds. The dark background mode (`-dbg`) forces the dark gradients and overrides `-lbg` if both are passed. The pause option (`-p`) is useful when output exceeds the terminal height.
+These options control what is shown and how. After the timeline bar graph, logtimeline prints the table ranking the top contributing messages — `-n` controls how many entries appear. The run summary — category totals, line counts, timing, memory and the files that were read — comes after all the analysis content, at the end of the output, and `-osum` suppresses it. The hide options hide individual columns from the bar graph while still processing the underlying data — useful for freeing horizontal space on narrow terminals or focusing on the metrics that matter. The CSV output option (`-o`) writes the full analysis data to a file for external processing, archival, or baseline comparison. The light background mode (`-lbg`) switches color gradients for white or light terminal backgrounds. The dark background mode (`-dbg`) forces the dark gradients and overrides `-lbg` if both are passed. The pause option (`-p`) is useful when output exceeds the terminal height.
 
 | Option | Description |
 |--------|-------------|
-| `-n, --top-messages <N>` | Number of unique messages to show in the summary table (default: 10) |
+| `-n, --top-messages <N>` | Number of unique messages to show in the top-messages table (default: 10) |
 | `-o, --output-csv` | Write all extracted data to a CSV file for external analysis |
 | `-cp, --csv-precision <mode>` | Control CSV decimal precision: `default` (per-family decimals derived from `-du`), `full` (raw precise floats), or an integer N (cap all numeric columns at N decimals) |
-| `-osum, --omit-summary` | Hide the summary table printed after the bar graph |
+| `-osum, --omit-summary` | Hide the run summary printed at the end of the output |
 | `-hl, --hide-legend` | Hide the legend column (category breakdowns and rates) |
 | `-ho, --hide-occurrences` | Hide the occurrences bar graph column, freeing space for other metric columns |
 | `-hd, --hide-duration` | Hide the duration bar graph column |
@@ -171,11 +171,11 @@ These options control what is shown and how. After the timeline bar graph, logti
 | `-V, --verbose [<section>...]` | Emit diagnostic sections. Bare `-V` emits all; `-V <name>[,<name>...]` or repeated `-V` selects sections; `-V list` prints known sections. See "Verbose output (`-V`)" section below |
 
 ```bash
-# Show top 50 messages in the summary table
+# Show top 50 messages in the top-messages table
 ltl -n 50 access.log
 # Export full analysis data to CSV
 ltl -o access.log
-# Hide the summary table, show only the timeline
+# Hide the run summary, show only the analysis content
 ltl -osum access.log
 # Use color gradients suited for light terminal backgrounds
 ltl -lbg access.log

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,7 +175,7 @@ These options control what is shown and how. After the timeline bar graph, logti
 ltl -n 50 access.log
 # Export full analysis data to CSV
 ltl -o access.log
-# Hide the run summary, show only the analysis content
+# Hide the run summary at the end of the output
 ltl -osum access.log
 # Use color gradients suited for light terminal backgrounds
 ltl -lbg access.log

--- a/features/180-named-pipeline-stages.md
+++ b/features/180-named-pipeline-stages.md
@@ -50,7 +50,7 @@ The dispatcher's top-level order, per the code audit (function names are the dur
 | 7 | `calculate_heatmap_buckets()` / `calculate_histogram_buckets()` | finalize — each a #266 data-model dispatcher (raw → exact path, bin → unified finalize) |
 | 8 | `normalize_data_for_output()` | render (prep; includes layout calculation before scaling) |
 | 9 | `detect_index_drift()` + `emit_*_verbose()` family + `print_verbose_output()` | render (verbose/telemetry surface) |
-| 10 | `print_bar_graph()`, `print_histograms()`, `print_summary_table()`, `print_message_summary()`, `print_threadpool_summary()`, CSV output lifecycle | render |
+| 10 | `print_bar_graph()`, `print_histograms()`, `print_message_summary()`, `print_threadpool_summary()`, `print_summary_table()`, CSV output lifecycle | render |
 | 11 | `write_index_file()` | render (post-output; #46) |
 
 **Hard constraint:** the `measure_memory_structures()` / `memory_debug_decomposition()` instrumentation checkpoints woven between steps keep their positions — their labels are observable `-mem`/debug output.

--- a/features/180-named-pipeline-stages.md
+++ b/features/180-named-pipeline-stages.md
@@ -50,7 +50,7 @@ The dispatcher's top-level order, per the code audit (function names are the dur
 | 7 | `calculate_heatmap_buckets()` / `calculate_histogram_buckets()` | finalize — each a #266 data-model dispatcher (raw → exact path, bin → unified finalize) |
 | 8 | `normalize_data_for_output()` | render (prep; includes layout calculation before scaling) |
 | 9 | `detect_index_drift()` + `emit_*_verbose()` family + `print_verbose_output()` | render (verbose/telemetry surface) |
-| 10 | `print_bar_graph()`, `print_histograms()`, `print_message_summary()`, `print_threadpool_summary()`, `print_summary_table()`, CSV output lifecycle | render |
+| 10 | `print_bar_graph()`, `print_histograms()`, `print_run_options()`, `print_message_summary()`, `print_threadpool_summary()`, `print_summary_table()`, CSV output lifecycle | render |
 | 11 | `write_index_file()` | render (post-output; #46) |
 
 **Hard constraint:** the `measure_memory_structures()` / `memory_debug_decomposition()` instrumentation checkpoints woven between steps keep their positions — their labels are observable `-mem`/debug output.

--- a/features/457-summary-section-at-end-of-output.md
+++ b/features/457-summary-section-at-end-of-output.md
@@ -1,0 +1,121 @@
+# Issue #457 — Move the summary section to the end of the output
+
+Branch: `457-summary-section-at-end-of-output` (off `release/0.18.0`)
+
+## Requirement
+
+The summary reports on the run — the span analysed, the files read, category
+totals, timing and memory — rather than on log content. Printed between the
+timeline bar graph and the message tables it separates two bodies of analysis
+content the analyst wants to read together, and the only way to close the gap
+was to switch the summary off entirely (`-osum`).
+
+The summary is therefore printed last, after every analysis section. Placement
+only: nothing in what the summary contains, or how it is rendered, changes.
+
+## What moved
+
+`print_summary_table()` in `pipeline_render()` now runs after
+`print_message_summary()` and `print_threadpool_summary()`, immediately before
+the post-output memory measurement and `write_index_file()`.
+
+Rendered order on the terminal:
+
+| | before | after |
+|---|---|---|
+| 1 | `-V` sections (`print_verbose_output()`) | `-V` sections |
+| 2 | bar graph / heatmap | bar graph / heatmap |
+| 3 | histograms (`-hg`) | histograms (`-hg`) |
+| 4 | **run summary** | top-messages tables |
+| 5 | top-messages tables | thread-pool tables (`-tpa`/`-tpas`) |
+| 6 | thread-pool tables (`-tpa`/`-tpas`) | **run summary** |
+
+## What printed after the summary before the change
+
+Terminal output: the highlighted and overall top-messages tables
+(`print_message_summary()`), then the highlighted and overall thread-pool
+tables (`print_threadpool_summary()`, only under `-tpa`/`-tpas`), then a
+trailing newline. Non-terminal: the MESSAGES CSV header and rows, and the
+persistent index file. Nothing else.
+
+## Run-report content that is not part of the summary
+
+| Output | Stream / stage | Disposition |
+|---|---|---|
+| `-t` per-stage timing rows | rows of the summary's own table | Moved with the summary; no separate handling |
+| Echoed `environment options:` / `command-line options:` lines | stdout, emitted by `print_summary_table()` ahead of its `-osum` early return | Moved with the summary — same run-report block, and they sit directly above the table on screen. Under `-osum` they stay the only thing that stage prints, and now close the output |
+| `-r` unreadable-directory report | stderr, tail of `read_and_process_logs()` | Left where it is. It is a diagnostic about reading the input, on the other stream and in an earlier stage; moving it would relocate it across both |
+| Format-ambiguity note, numeric-filter "no metric" note, UDM zero-match notices, bin-consolidation notice | stderr, parse and finalize stages | Unchanged, for the same reason |
+
+## Decisions
+
+**D1 — the whole of `print_summary_table()` moves, including the echoed
+options lines and including under `-osum`.** The echoed options are part of the
+same run report and render as one block with the table.
+*Consequence:* with `-osum`, the echoed options now appear at the end of the
+output instead of directly below the bar graph.
+
+**D2 — the peak-memory measurement moves with the summary.** The
+`measure_memory_structures()` call that feeds `MAXIMUM MEMORY USED` sits
+immediately before the summary render, so it still accounts for every rendered
+section above it — which now includes the message and thread-pool tables.
+*Consequence:* the reported peak covers more of the run than before and can
+read marginally higher on the same input. It was already documented as
+covering "everything up to this point"; the point moved.
+
+**D3 — the regression harness's output filter is bounded, not removed.**
+`strip_nondeterministic()` in `tests/capture-regression.sh` and
+`tests/validate-regression.sh` dropped everything from the `TOP OVERALL`
+heading to end of output. With the summary now below that heading, the same
+rule would have silently dropped the summary out of the asserted surface — the
+category totals, the `HIGHLIGHTED` row, the file legend and the format legend,
+which the highlight scenarios exist to assert. The skip now ends at the
+summary's first line (the echoed options).
+*Consequence:* the asserted surface is unchanged from before this issue; the
+`TOP OVERALL` block stays excluded.
+
+**D4 — `docs/usage.md` § Display & Output no longer calls two different things
+"the summary table".** The paragraph claimed `-osum` suppressed the
+top-messages table, which it never did. The `-n` row now says "top-messages
+table" and `-osum` says "run summary", on both surfaces (`print_help()` and
+`docs/usage.md`).
+*Consequence:* one wording change to a `--help` row that this issue did not
+strictly have to touch, made so the section does not use one name for two
+tables while restating the ordering.
+
+## Surfaces changed
+
+- `ltl` — `pipeline_render()` call order and its stage comment; the `-n` and
+  `-osum` rows of `print_help()`.
+- `docs/usage.md` — § Display & Output paragraph, the `-n` and `-osum` rows,
+  and the `-osum` example comment.
+- `tests/capture-regression.sh`, `tests/validate-regression.sh` —
+  `strip_nondeterministic()` (D3); the two copies remain byte-identical.
+- `tests/reference-output/*.txt` — re-blessed, see below.
+- `features/180-named-pipeline-stages.md` — stage-10 membership row reordered
+  to match the render order.
+
+## Reference re-bless
+
+Re-blessed with the sanctioned procedure, `./tests/capture-regression.sh`; no
+golden was hand-edited. Ten of the seventy-one references changed — every
+scenario that keeps the summary (the `hl-*` highlight scenarios; the rest pass
+`-osum`). Each changed file was checked to be a pure reordering: the sorted set
+of lines is identical to the committed version, so only placement moved.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `tests/validate-regression.sh` before the re-bless | 61 passed, 10 failed — every failure a block move of the summary below the message tables, no content difference |
+| `tests/validate-regression.sh` after the re-bless | 71 passed, 0 failed, 0 skipped |
+| Sabotage proof that the summary is still asserted | One digit changed in the `LINES READ` row of a copied reference: 70 passed, 1 failed, and the failing scenario is the doctored one |
+| `tests/validate-help-content.sh` | 11 passed, 0 failed |
+| `tests/validate-duration-display.sh` | 21 passed, 0 failed |
+| `tests/validate-format-detection.sh` | 192 passed, 0 failed |
+| `tests/validate-log-level-vocabulary.sh` | 8 passed, 0 failed |
+| `tests/validate-message-control-characters.sh` | 11 passed, 0 failed |
+| CSV output (`-o`) | STATS and MESSAGES files byte-identical to the pre-change build on the same input |
+| `-V` section sequence | Identical to the pre-change build; no section is emitted by `print_summary_table()`, and the verbose surface flushes before the bar graph |
+| `-osum` | Still suppresses the table; the echoed options print at the end |
+| `-t` timing rows | Render inside the summary, at the end |

--- a/features/457-summary-section-at-end-of-output.md
+++ b/features/457-summary-section-at-end-of-output.md
@@ -159,3 +159,79 @@ else, including the echoed options line, changes position or content.
 | `-t` timing rows | Render inside the summary, at the end |
 | Anchor guard (D5) | Filter status probed through the harness's own pipeline shape: summary present → 0, summary absent → 3, `-osum` in the echoed options → 0 |
 | Echoed options position (D1) | Byte-identical to the release branch: the ten re-blessed references sort equal to their release-branch versions, and the sixty-one `-osum` references are unchanged |
+
+## Completion gate
+
+Run on `2d3d7de` (`#457: restore release version for the completion gate`), the
+commit being merged, after rebasing onto `origin/release/0.18.0` (`b94a75e`,
+the #445 quoted-`-r` release-notes commit). The rebase was clean — no
+conflicts. `$version_number` reads `0.18.0`.
+
+### Harness suite — 27 of 27 exit 0
+
+| Harness | Summary line |
+|---|---|
+| `validate-csv-output.sh` | CSV output integrity: 21 scenarios, 21 pass, 0 fail |
+| `validate-statistics.sh` | Statistics drift: 21 scenarios, 21 pass, 0 fail |
+| `validate-csv-input.sh` | CSV input robustness: 4 pass, 0 fail |
+| `validate-distribution-shape.sh` | 8 passed, 0 failed |
+| `validate-doc-examples.sh` | 46 passed, 0 failed, 9 skipped |
+| `validate-duration-display.sh` | 21 passed, 0 failed |
+| `validate-explain.sh` | 148 passed, 0 failed |
+| `validate-format-detection.sh` | 192 passed, 0 failed |
+| `validate-format-registry.sh` | 22 passed, 0 failed |
+| `validate-heatmap-palette.sh` | 85 passed, 0 failed |
+| `validate-help-content.sh` | 11 passed, 0 failed |
+| `validate-help-layout.sh` | 6 passed, 0 failed |
+| `validate-histogram-bin-counters.sh` | 84 passed, 0 failed |
+| `validate-histogram-ticks.sh` | Total: 21 \| Passed: 21 \| Failed: 0 |
+| `validate-index-read-back.sh` | 59 passed, 0 failed |
+| `validate-log-level-vocabulary.sh` | PASS: 8, FAIL: 0 |
+| `validate-message-control-characters.sh` | PASS: 11, FAIL: 0 |
+| `validate-message-grouping-notices.sh` | 4 passed, 0 failed |
+| `validate-numeric-criteria-notices.sh` | 10 passed, 0 failed |
+| `validate-profile-render.sh` | 22 passed, 0 failed |
+| `validate-profile.sh` | 50 passed, 0 failed |
+| `validate-recursive-file-selection.sh` | 22 passed, 0 failed |
+| `validate-regression.sh` | 71 passed, 0 failed, 0 skipped |
+| `validate-runtime-config.sh` | 36 passed, 0 failed |
+| `validate-statistics-demand.sh` | 75 passed, 0 failed |
+| `validate-udm-counting.sh` | 28 passed, 0 failed |
+| `validate-udm-specs.sh` | 43 passed, 0 failed |
+
+`validate-statistics.sh` tiers: zero T4 and zero T3 on every layer — the drift
+check against the committed baselines, the intra-row arithmetic invariants, and
+the NumPy/SciPy oracle. 943 T2 advisories, all on the oracle layer and all
+pre-existing (they are the tolerance band between `ltl`'s bin-model percentiles
+and the oracle's exact ones, not a difference this branch introduced). 31 oracle
+cells are registered known failures for #469 (bin-model percentile projection
+onto the shared geometry) in `tests/statistics-drift/known-failures.tsv`.
+
+`./tests/cleanup-test-artifacts.sh` run afterwards; the tree is clean.
+
+### Before/after benchmark
+
+`single-day-access-log-standard` (761,698 lines), run back-to-back on this
+machine: *before* from a worktree of `origin/release/0.18.0`, *after* from this
+branch's gated tip. No metric worse by more than 5%.
+
+| Metric | Before | After | Delta | Change |
+|---|---|---|---|---|
+| `TIMING/total` | 10 s | 10.0 s | −77 ms | −0.8% |
+| `parse/read_files` | 9.9 s | 9.8 s | −80 ms | −0.8% |
+| `finalize/calculate_statistics` | 151 ms | 155 ms | +4 ms | +2.6% |
+| `finalize/calculate_statistics/bucket_stats` | 100 ms | 104 ms | +4 ms | +4.0% |
+| `finalize/calculate_statistics/group_calc` | 46 ms | 45 ms | −1 ms | −2.2% |
+| `finalize/calculate_statistics/sort_selection` | 6 ms | 6 ms | 0 ms | 0.0% |
+| `detect/registry_build` | 9 ms | 8 ms | −1 ms | −11.1% |
+| `render/normalize_data` | 1 ms | 1 ms | 0 ms | 0.0% |
+| `MEMORY/rss_peak` | 142.1 MB | 142.3 MB | +144 KB | +0.1% |
+
+The change is a render-order change with no per-line or per-key work added, so
+the timing movements are run-to-run noise on a single pair of runs, not
+attribution. The +144 KB on peak RSS is the direction D2 predicts — the
+measurement instant now sits after the message and thread-pool tables have been
+rendered — and it is 0.1%, an order of magnitude inside the 5% threshold.
+
+Both benchmark TSVs were deleted afterwards and the base worktree removed; they
+are instruments, not deliverables.

--- a/features/457-summary-section-at-end-of-output.md
+++ b/features/457-summary-section-at-end-of-output.md
@@ -19,6 +19,12 @@ only: nothing in what the summary contains, or how it is rendered, changes.
 `print_message_summary()` and `print_threadpool_summary()`, immediately before
 the post-output memory measurement and `write_index_file()`.
 
+The echoed options lines did **not** move. They were printed by
+`print_summary_table()` ahead of its `-osum` early return; they are now
+`print_run_options()`, called from `pipeline_render()` at the position the
+summary render used to occupy — directly under the bar graph and any
+histograms — so the bytes at that point in the output are unchanged.
+
 Rendered order on the terminal:
 
 | | before | after |
@@ -26,9 +32,10 @@ Rendered order on the terminal:
 | 1 | `-V` sections (`print_verbose_output()`) | `-V` sections |
 | 2 | bar graph / heatmap | bar graph / heatmap |
 | 3 | histograms (`-hg`) | histograms (`-hg`) |
-| 4 | **run summary** | top-messages tables |
-| 5 | top-messages tables | thread-pool tables (`-tpa`/`-tpas`) |
-| 6 | thread-pool tables (`-tpa`/`-tpas`) | **run summary** |
+| 4 | echoed environment / command-line options | echoed environment / command-line options |
+| 5 | **run summary** | top-messages tables |
+| 6 | top-messages tables | thread-pool tables (`-tpa`/`-tpas`) |
+| 7 | thread-pool tables (`-tpa`/`-tpas`) | **run summary** |
 
 ## What printed after the summary before the change
 
@@ -43,25 +50,34 @@ persistent index file. Nothing else.
 | Output | Stream / stage | Disposition |
 |---|---|---|
 | `-t` per-stage timing rows | rows of the summary's own table | Moved with the summary; no separate handling |
-| Echoed `environment options:` / `command-line options:` lines | stdout, emitted by `print_summary_table()` ahead of its `-osum` early return | Moved with the summary — same run-report block, and they sit directly above the table on screen. Under `-osum` they stay the only thing that stage prints, and now close the output |
+| Echoed `environment options:` / `command-line options:` lines | stdout, their own `print_run_options()` stage | Stay directly under the bar graph, where they were (D1) |
 | `-r` unreadable-directory report | stderr, tail of `read_and_process_logs()` | Left where it is. It is a diagnostic about reading the input, on the other stream and in an earlier stage; moving it would relocate it across both |
 | Format-ambiguity note, numeric-filter "no metric" note, UDM zero-match notices, bin-consolidation notice | stderr, parse and finalize stages | Unchanged, for the same reason |
 
 ## Decisions
 
-**D1 — the whole of `print_summary_table()` moves, including the echoed
-options lines and including under `-osum`.** The echoed options are part of the
-same run report and render as one block with the table.
-*Consequence:* with `-osum`, the echoed options now appear at the end of the
-output instead of directly below the bar graph.
+**D1 — only the summary table moves; the echoed options stay directly under
+the timeline bar graph.** They are extracted into `print_run_options()` and
+called from the position the summary render used to hold, so that stretch of
+output is byte-for-byte what it was before this issue. Two reasons: the
+options belong to the view above them — `docs/purpose.md` states that each view
+can be screenshot with the command-line options displayed for reproducibility,
+which only holds while the options sit with the timeline they describe — and
+under `-osum` moving them would have ended the run on a dangling options line
+with nothing under it.
+*Consequence:* the run report is no longer one contiguous block. The options
+echo is a caption on the timeline; the summary is the closing section, and
+`-osum` suppresses that section alone.
 
 **D2 — the peak-memory measurement moves with the summary.** The
 `measure_memory_structures()` call that feeds `MAXIMUM MEMORY USED` sits
-immediately before the summary render, so it still accounts for every rendered
-section above it — which now includes the message and thread-pool tables.
+immediately before the summary render, so the measurement instant is now after
+every analysis section has been printed — the message and thread-pool tables
+included — rather than before them.
 *Consequence:* the reported peak covers more of the run than before and can
-read marginally higher on the same input. It was already documented as
-covering "everything up to this point"; the point moved.
+read marginally higher on the same input. Measured: 26.9 → 27.0 MiB on the
+434-line fixture, no change on the 5k-line access log. It was already
+documented as covering "everything up to this point"; the point moved.
 
 **D3 — the regression harness's output filter is bounded, not removed.**
 `strip_nondeterministic()` in `tests/capture-regression.sh` and
@@ -69,20 +85,26 @@ covering "everything up to this point"; the point moved.
 heading to end of output. With the summary now below that heading, the same
 rule would have silently dropped the summary out of the asserted surface — the
 category totals, the `HIGHLIGHTED` row, the file legend and the format legend,
-which the highlight scenarios exist to assert. The skip now ends at the
-summary's first line (the echoed options).
+which the highlight scenarios exist to assert. The skip ends on the summary's
+first line: the rule above the `Category` header, matched by its shape (two
+spaces of indent, box-drawing rule, right padding) rather than by a hard-coded
+width, so the wider rules inside the skipped message tables do not close it.
 *Consequence:* the asserted surface is unchanged from before this issue; the
 `TOP OVERALL` block stays excluded.
 
-**D5 — the bounded skip fails loudly when its closing anchor is absent.**
-Ending the skip on a content line makes the filter silent about a run that
-never prints one: it would drop the whole tail and hand back a smaller surface
-that still compares clean. `tests/HARNESS-DESIGN.md` § "a grep that matches
-nothing is a failure" governs exactly this, so the filter now exits 3 when it
-reaches end of input with the skip still open, and both harnesses check that
-status alongside `ltl`'s own.
+**D5 — the bounded skip fails loudly when its closing anchor is absent,
+except where no summary is printed.** Ending the skip on a content line makes
+the filter silent about a run that never prints one: it would drop the whole
+tail and hand back a smaller surface that still compares clean.
+`tests/HARNESS-DESIGN.md` § "a grep that matches nothing is a failure" governs
+exactly this, so the filter exits 3 when it reaches end of input with the skip
+still open, and both harnesses check that status alongside `ltl`'s own. A run
+passing `-osum` prints no summary, so for it the skip legitimately runs to end
+of output; the filter recognises this from the echoed options line, which
+under D1 sits above the skipped block and names the option.
 *Consequence:* a truncated surface aborts the capture or fails the scenario
-instead of quietly narrowing what is asserted.
+instead of quietly narrowing what is asserted, while the sixty-one `-osum`
+scenarios keep the pre-existing skip-to-end behaviour.
 
 **D4 — `docs/usage.md` § Display & Output no longer calls two different things
 "the summary table".** The paragraph claimed `-osum` suppressed the
@@ -95,8 +117,10 @@ tables while restating the ordering.
 
 ## Surfaces changed
 
-- `ltl` — `pipeline_render()` call order and its stage comment; the `-n` and
-  `-osum` rows of `print_help()`.
+- `ltl` — `pipeline_render()` call order and its stage comment; the echoed
+  options extracted from `print_summary_table()` into `print_run_options()`
+  and called from the summary's former position (D1); the `-n` and `-osum`
+  rows of `print_help()`.
 - `docs/usage.md` — § Display & Output paragraph, the `-n` and `-osum` rows,
   and the `-osum` example comment.
 - `tests/capture-regression.sh`, `tests/validate-regression.sh` —
@@ -111,8 +135,11 @@ tables while restating the ordering.
 Re-blessed with the sanctioned procedure, `./tests/capture-regression.sh`; no
 golden was hand-edited. Ten of the seventy-one references changed — every
 scenario that keeps the summary (the `hl-*` highlight scenarios; the rest pass
-`-osum`). Each changed file was checked to be a pure reordering: the sorted set
-of lines is identical to the committed version, so only placement moved.
+`-osum`, and their references are byte-identical to the release branch). Each
+changed file was checked against the release branch's version of the same file
+and is a pure reordering: sorted, the two are identical, so only placement
+moved — the summary block travels below the top-messages table and nothing
+else, including the echoed options line, changes position or content.
 
 ## Verification
 
@@ -128,6 +155,7 @@ of lines is identical to the committed version, so only placement moved.
 | `tests/validate-message-control-characters.sh` | 11 passed, 0 failed |
 | CSV output (`-o`) | STATS and MESSAGES files byte-identical to the pre-change build on the same input |
 | `-V` section sequence | Identical to the pre-change build; no section is emitted by `print_summary_table()`, and the verbose surface flushes before the bar graph |
-| `-osum` | Still suppresses the table; the echoed options print at the end |
+| `-osum` | Still suppresses the summary; the echoed options print under the bar graph and the output ends with the top-messages table |
 | `-t` timing rows | Render inside the summary, at the end |
-| Anchor guard (D5) | Filter status probed through the harness's own pipeline shape: summary present → 0, summary absent → 3, no `TOP OVERALL` at all → 0 |
+| Anchor guard (D5) | Filter status probed through the harness's own pipeline shape: summary present → 0, summary absent → 3, `-osum` in the echoed options → 0 |
+| Echoed options position (D1) | Byte-identical to the release branch: the ten re-blessed references sort equal to their release-branch versions, and the sixty-one `-osum` references are unchanged |

--- a/features/457-summary-section-at-end-of-output.md
+++ b/features/457-summary-section-at-end-of-output.md
@@ -74,6 +74,16 @@ summary's first line (the echoed options).
 *Consequence:* the asserted surface is unchanged from before this issue; the
 `TOP OVERALL` block stays excluded.
 
+**D5 — the bounded skip fails loudly when its closing anchor is absent.**
+Ending the skip on a content line makes the filter silent about a run that
+never prints one: it would drop the whole tail and hand back a smaller surface
+that still compares clean. `tests/HARNESS-DESIGN.md` § "a grep that matches
+nothing is a failure" governs exactly this, so the filter now exits 3 when it
+reaches end of input with the skip still open, and both harnesses check that
+status alongside `ltl`'s own.
+*Consequence:* a truncated surface aborts the capture or fails the scenario
+instead of quietly narrowing what is asserted.
+
 **D4 — `docs/usage.md` § Display & Output no longer calls two different things
 "the summary table".** The paragraph claimed `-osum` suppressed the
 top-messages table, which it never did. The `-n` row now says "top-messages
@@ -90,7 +100,8 @@ tables while restating the ordering.
 - `docs/usage.md` — § Display & Output paragraph, the `-n` and `-osum` rows,
   and the `-osum` example comment.
 - `tests/capture-regression.sh`, `tests/validate-regression.sh` —
-  `strip_nondeterministic()` (D3); the two copies remain byte-identical.
+  `strip_nondeterministic()` (D3) and the filter-status check that guards its
+  closing anchor (D5); the two copies of the filter remain byte-identical.
 - `tests/reference-output/*.txt` — re-blessed, see below.
 - `features/180-named-pipeline-stages.md` — stage-10 membership row reordered
   to match the render order.
@@ -119,3 +130,4 @@ of lines is identical to the committed version, so only placement moved.
 | `-V` section sequence | Identical to the pre-change build; no section is emitted by `print_summary_table()`, and the verbose surface flushes before the bar graph |
 | `-osum` | Still suppresses the table; the echoed options print at the end |
 | `-t` timing rows | Render inside the summary, at the end |
+| Anchor guard (D5) | Filter status probed through the harness's own pipeline shape: summary present → 0, summary absent → 3, no `TOP OVERALL` at all → 0 |

--- a/ltl
+++ b/ltl
@@ -57,7 +57,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0";
+my $version_number = "0.18.0-457";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );
@@ -6658,10 +6658,10 @@ sub print_help {
 
     # Display & Output
     $out .= help_subheading("Display & Output");
-    $out .= help_opt("-n,   --top-messages <N>",      "Number of unique messages to show in the summary table (default: 10)");
+    $out .= help_opt("-n,   --top-messages <N>",      "Number of unique messages to show in the top-messages table (default: 10)");
     $out .= help_opt("-o,   --output-csv",            "Write all extracted data to a CSV file for external analysis");
     $out .= help_opt("-cp,  --csv-precision <mode>",  "Control CSV decimal precision: 'default' (per-family decimals derived from -du), 'full' (raw precise floats), or an integer N (cap all numeric columns at N decimals)");
-    $out .= help_opt("-osum, --omit-summary",         "Hide the summary table printed after the bar graph");
+    $out .= help_opt("-osum, --omit-summary",         "Hide the run summary printed at the end of the output");
     $out .= help_opt("-hl,  --hide-legend",           "Hide the legend column (category breakdowns and rates)");
     $out .= help_opt("-ho,  --hide-occurrences",      "Hide the occurrences bar graph column, freeing space for other metric columns");
     $out .= help_opt("-hd,  --hide-duration",         "Hide the duration bar graph column");
@@ -16935,8 +16935,8 @@ sub pipeline_finalize {
 # Receives: finalized statistics and bucket structures; resolved demand.
 # Emits: normalized/scaled display data (layout before scaling), index-drift
 # detection plus the verbose/telemetry surface flush, bar graph, histograms,
-# summary tables, message/threadpool summaries, CSV output lifecycle, and the
-# persistent index file (#46).
+# message/threadpool summaries, the closing run summary, CSV output lifecycle,
+# and the persistent index file (#46).
 sub pipeline_render {
     # NORMALIZE DATA FOR CONSOLE OUTPUT #
     $start_time = [gettimeofday];
@@ -16991,16 +16991,6 @@ sub pipeline_render {
     print_histograms() if $histogram_enabled;  # Issue #25: Histograms appear after bar graph
     close $csv_fh or die "Could not close file: $!" if( $write_messages_to_csv && defined $csv_fh );	# Close the file handle
 
-    # Issue #356 (S1): capture the peak through normalize/bar-graph/CSV rendering
-    # so the displayed MAXIMUM MEMORY USED reflects everything up to this point.
-    # The output stages below can no longer move the peak materially (#362 clamped
-    # the only O(-n) allocation); their residual is covered by the post-output
-    # measurement and visible under -mem debug.
-    measure_memory_structures();
-
-    print_summary_table();
-    memory_debug_decomposition("after_summary_table");
-
     if( $write_messages_to_csv ) {                     # If write to CSV enabled, open filehandles
         $csv = Text::CSV->new({ binary => 1, eol => $/ });                                              # Create a new CSV object
         my $csv_file_name = build_csv_filename('MESSAGES');
@@ -17035,6 +17025,18 @@ sub pipeline_render {
 
     print_threadpool_summary() if $include_threadpool_summary;										    # Print threadpool summaries
     memory_debug_decomposition("after_threadpool_summary") if $include_threadpool_summary;
+
+    # Issue #356 (S1): capture the peak across every rendered analysis section so
+    # the MAXIMUM MEMORY USED the summary reports accounts for all of them. The
+    # summary render's own residual is covered by the post-output measurement
+    # below and visible under -mem debug.
+    measure_memory_structures();
+
+    # The summary reports on the run itself -- the span analysed, the files read,
+    # the totals, timing and memory -- so it closes the output, leaving the
+    # analysis sections above it contiguous on screen.
+    print_summary_table();
+    memory_debug_decomposition("after_summary_table");
 
     # Issue #356 (S1): post-output measurement keeps the recorded peak honest for
     # the full process lifetime; surfaced by the -mem debug "end" line below.

--- a/ltl
+++ b/ltl
@@ -57,7 +57,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0-457";
+my $version_number = "0.18.0";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );

--- a/ltl
+++ b/ltl
@@ -16002,24 +16002,11 @@ sub render_histogram_legend {
     return ($result, $result_hl);
 }
 
-sub print_summary_table {
-    my $category_column_width = 30;
-    my $occurrences_column_width = 10;
-    my $table_padding = 2;
-    my $padding = " " x $table_padding;
-    my $column_padding = " " x 1;
-    my $table_format = "$padding%-${category_column_width}s %${occurrences_column_width}d$padding\n";
-    my $summary_table_width = $table_padding + $category_column_width + 1 + $occurrences_column_width + $table_padding;
-    my $file_detail_width = $terminal_width - ( $summary_table_width + $table_padding * 2 );
-    my ( @summary_table, @file_details );
-    my ( @match_char ) = ( "$colors{'red'}χ", "$colors{'green'}√", "$colors{'green-HL'}√" );
-
-    ## FORMAT MIN/MAX LOG TIMESTAMPS FOR THE SUMMARY ##
-    my $min_timestamp_str = strftime($output_timestamp_format, gmtime($output_timestamp_min));
-    my $max_timestamp_str = strftime($output_timestamp_format, gmtime($output_timestamp_max));
-    $min_timestamp_str .= sprintf ".%03d", ($output_timestamp_min-int($output_timestamp_min))*1000 if $print_milliseconds;
-    $max_timestamp_str .= sprintf ".%03d", ($output_timestamp_max-int($output_timestamp_max))*1000 if $print_milliseconds;
-
+# Echo the options the run was invoked with, directly under the timeline view
+# they produced: each view is meant to be screenshot with the command that made
+# it, so the reader can reproduce it (docs/purpose.md). Printed for every run,
+# including one whose run summary is suppressed.
+sub print_run_options {
     ## PRINT COMMAND AND ARGUMENTS ##
     if ($ltl_config_raw ne '') {
         print "\n$colors{'bright-black'}environment options: $ltl_config_raw$colors{'NC'}";
@@ -16054,8 +16041,27 @@ sub print_summary_table {
         print "\n$colors{'bright-black'}command-line options: $cli_options$colors{'NC'}";
     }
     print "\n";
+}
 
+sub print_summary_table {
     return if $omit_summary;
+
+    my $category_column_width = 30;
+    my $occurrences_column_width = 10;
+    my $table_padding = 2;
+    my $padding = " " x $table_padding;
+    my $column_padding = " " x 1;
+    my $table_format = "$padding%-${category_column_width}s %${occurrences_column_width}d$padding\n";
+    my $summary_table_width = $table_padding + $category_column_width + 1 + $occurrences_column_width + $table_padding;
+    my $file_detail_width = $terminal_width - ( $summary_table_width + $table_padding * 2 );
+    my ( @summary_table, @file_details );
+    my ( @match_char ) = ( "$colors{'red'}χ", "$colors{'green'}√", "$colors{'green-HL'}√" );
+
+    ## FORMAT MIN/MAX LOG TIMESTAMPS FOR THE SUMMARY ##
+    my $min_timestamp_str = strftime($output_timestamp_format, gmtime($output_timestamp_min));
+    my $max_timestamp_str = strftime($output_timestamp_format, gmtime($output_timestamp_max));
+    $min_timestamp_str .= sprintf ".%03d", ($output_timestamp_min-int($output_timestamp_min))*1000 if $print_milliseconds;
+    $max_timestamp_str .= sprintf ".%03d", ($output_timestamp_max-int($output_timestamp_max))*1000 if $print_milliseconds;
 
     ## START SUMMARY STATISTIC TABLE ##
     push @summary_table, sprintf( "\n  " . "─" x ( $category_column_width + $occurrences_column_width + 1 ) . "$padding\n" );
@@ -16935,8 +16941,8 @@ sub pipeline_finalize {
 # Receives: finalized statistics and bucket structures; resolved demand.
 # Emits: normalized/scaled display data (layout before scaling), index-drift
 # detection plus the verbose/telemetry surface flush, bar graph, histograms,
-# message/threadpool summaries, the closing run summary, CSV output lifecycle,
-# and the persistent index file (#46).
+# echoed options, message/threadpool summaries, the closing run summary, CSV
+# output lifecycle, and the persistent index file (#46).
 sub pipeline_render {
     # NORMALIZE DATA FOR CONSOLE OUTPUT #
     $start_time = [gettimeofday];
@@ -16990,6 +16996,8 @@ sub pipeline_render {
     memory_debug_decomposition("after_bar_graph");
     print_histograms() if $histogram_enabled;  # Issue #25: Histograms appear after bar graph
     close $csv_fh or die "Could not close file: $!" if( $write_messages_to_csv && defined $csv_fh );	# Close the file handle
+
+    print_run_options();
 
     if( $write_messages_to_csv ) {                     # If write to CSV enabled, open filehandles
         $csv = Text::CSV->new({ binary => 1, eol => $/ });                                              # Create a new CSV object

--- a/tests/capture-regression.sh
+++ b/tests/capture-regression.sh
@@ -87,10 +87,12 @@ done
 # references freeze, so it is dropped. The drop is bounded: the run summary
 # closes the output, and its first line (the echoed options) ends the skip so
 # the category totals, the HIGHLIGHTED row and the file/format legend stay
-# inside the captured surface.
+# inside the captured surface. Per tests/HARNESS-DESIGN.md, an anchor that
+# matches nothing is a failure: if the skip is still open at end of input the
+# filter exits 3, so a truncated surface aborts instead of being captured.
 strip_nondeterministic() {
     perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g; s/log timeline \[[^\]]+\]/log timeline [VERSION]/' \
-    | perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
+    | perl -ne 'BEGIN{$skip=0} END{ $? = 3 if $skip } $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
 }
 
 # Create output directory
@@ -120,6 +122,16 @@ run_test() {
 
     if [[ "${pipe_status[0]}" -ne 0 ]]; then
         echo "  FAIL  $name :: ltl exited ${pipe_status[0]}; stderr:" >&2
+        sed 's/^/        /' "$stderrfile" >&2
+        rm -f "$outfile"
+        exit 1
+    fi
+    # strip_nondeterministic exits 3 when it reached end of input still skipping,
+    # i.e. the run summary that ends the TOP OVERALL skip never appeared. Per
+    # tests/HARNESS-DESIGN.md an anchor that matches nothing is a failure —
+    # blessing a truncated reference would weaken every later run silently.
+    if [[ "${pipe_status[1]}" -ne 0 ]]; then
+        echo "  FAIL  $name :: output filter found no run summary to end the TOP OVERALL skip; the reference would be truncated" >&2
         sed 's/^/        /' "$stderrfile" >&2
         rm -f "$outfile"
         exit 1

--- a/tests/capture-regression.sh
+++ b/tests/capture-regression.sh
@@ -81,10 +81,16 @@ for f in "$ACCESS_LOG" "$SCRIPT_LOG" "$APACHE_LOG" "$PLOT_LOG" "$DPM5K_LOG"; do
     fi
 done
 
-# Strip ANSI escape codes and non-deterministic lines (timing, memory) from stdin
+# Strip ANSI escape codes and non-deterministic lines (timing, memory) from stdin.
+#
+# The TOP OVERALL MESSAGES block is not part of the layout surface these
+# references freeze, so it is dropped. The drop is bounded: the run summary
+# closes the output, and its first line (the echoed options) ends the skip so
+# the category totals, the HIGHLIGHTED row and the file/format legend stay
+# inside the captured surface.
 strip_nondeterministic() {
     perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g; s/log timeline \[[^\]]+\]/log timeline [VERSION]/' \
-    | perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
+    | perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
 }
 
 # Create output directory

--- a/tests/capture-regression.sh
+++ b/tests/capture-regression.sh
@@ -84,15 +84,20 @@ done
 # Strip ANSI escape codes and non-deterministic lines (timing, memory) from stdin.
 #
 # The TOP OVERALL MESSAGES block is not part of the layout surface these
-# references freeze, so it is dropped. The drop is bounded: the run summary
-# closes the output, and its first line (the echoed options) ends the skip so
-# the category totals, the HIGHLIGHTED row and the file/format legend stay
-# inside the captured surface. Per tests/HARNESS-DESIGN.md, an anchor that
-# matches nothing is a failure: if the skip is still open at end of input the
-# filter exits 3, so a truncated surface aborts instead of being captured.
+# references freeze, so it is dropped. The drop is bounded by the run summary
+# that closes the output: the skip ends on the summary's first line -- the rule
+# above the Category header, two spaces in and padded on the right -- so the
+# category totals, the HIGHLIGHTED row and the file/format legend stay inside
+# the captured surface. Per tests/HARNESS-DESIGN.md an anchor that matches
+# nothing is a failure: reaching end of input with the skip still open exits 3,
+# so a truncated surface aborts instead of being captured. A run invoked with
+# -osum prints no summary, and the echoed options line -- which sits under the
+# bar graph, ahead of the skipped block -- says so, so such a run has nothing
+# to close the skip and is exempt.
+# Must match validate-regression.sh exactly.
 strip_nondeterministic() {
     perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g; s/log timeline \[[^\]]+\]/log timeline [VERSION]/' \
-    | perl -ne 'BEGIN{$skip=0} END{ $? = 3 if $skip } $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
+    | perl -ne 'BEGIN{$skip=0; $want_summary=1} END{ $? = 3 if $skip && $want_summary } $want_summary=0 if /^(?:environment|command-line) options: / && /(?:^|\s)(?:-osum|--omit-summary)(?=\s|$)/; $skip=1 if /TOP OVERALL/; $skip=0 if /^ {2}(?:─)+ +$/; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
 }
 
 # Create output directory

--- a/tests/reference-output/hl-filelegend-two-files-w160.txt
+++ b/tests/reference-output/hl-filelegend-two-files-w160.txt
@@ -3007,11 +3007,11 @@
  2025-12-15 22:00 WARN: 48                              0:0.4/m │                                                                                               
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+command-line options: --disable-progress -ni -n 1 --terminal-width 160 -hdmin 100000 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [INFO] [https-openssl-nio-44] [S.c.t.d.e.DSLScript] SUCCEEDED - Rolex.Gre.Manager_TG GetComplexPlotB        2   2.1m   2.3m   2.3m   0.04       4.4 min 
-
-command-line options: --disable-progress -ni -n 1 --terminal-width 160 -hdmin 100000 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-04-10 06:00 and 2025-12-15 23:57

--- a/tests/reference-output/hl-filelegend-two-files-w160.txt
+++ b/tests/reference-output/hl-filelegend-two-files-w160.txt
@@ -3007,6 +3007,10 @@
  2025-12-15 22:00 WARN: 48                              0:0.4/m │                                                                                               
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [INFO] [https-openssl-nio-44] [S.c.t.d.e.DSLScript] SUCCEEDED - Rolex.Gre.Manager_TG GetComplexPlotB        2   2.1m   2.3m   2.3m   0.04       4.4 min 
+
 command-line options: --disable-progress -ni -n 1 --terminal-width 160 -hdmin 100000 
 
   ─────────────────────────────────────────   
@@ -3022,8 +3026,4 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -hdmin 10
   LINES INCLUDED                       7992   
   LINES READ                           7992   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [INFO] [https-openssl-nio-44] [S.c.t.d.e.DSLScript] SUCCEEDED - Rolex.Gre.Manager_TG GetComplexPlotB        2   2.1m   2.3m   2.3m   0.04       4.4 min 
 

--- a/tests/reference-output/hl-hbmin-w160.txt
+++ b/tests/reference-output/hl-hbmin-w160.txt
@@ -46,6 +46,10 @@
  2026-01-25 06:00 4xx: 2 3xx: 7 113 2xx: 545  0:5.6/m │ █████████████████████████    3m         2.5 MiB  │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [200] GET /Windchill/sslClientAuth/servlet/odata/v7/ProdMgmt/$metadata                                     37   35ms   72ms   5.3s   3.27       9.8 sec 
+
 command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -hbmin 5000 
 
   ─────────────────────────────────────────   
@@ -60,8 +64,4 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   LINES INCLUDED                        677   
   LINES READ                            677   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [200] GET /Windchill/sslClientAuth/servlet/odata/v7/ProdMgmt/$metadata                                     37   35ms   72ms   5.3s   3.27       9.8 sec 
 

--- a/tests/reference-output/hl-hbmin-w160.txt
+++ b/tests/reference-output/hl-hbmin-w160.txt
@@ -46,11 +46,11 @@
  2026-01-25 06:00 4xx: 2 3xx: 7 113 2xx: 545  0:5.6/m │ █████████████████████████    3m         2.5 MiB  │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -hbmin 5000 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [200] GET /Windchill/sslClientAuth/servlet/odata/v7/ProdMgmt/$metadata                                     37   35ms   72ms   5.3s   3.27       9.8 sec 
-
-command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -hbmin 5000 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41

--- a/tests/reference-output/hl-hcmin-plotlog-w160.txt
+++ b/tests/reference-output/hl-hcmin-plotlog-w160.txt
@@ -22,11 +22,11 @@
  2025-12-15 22:00 WARN: 48                             0:0.4/m │ ██                                                                                             
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+command-line options: --disable-progress -ni -n 1 --terminal-width 160 -ic -hcmin 45000 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [INFO] [https-openssl-nio-44] [S.c.t.d.e.DSLScript] SUCCEEDED - Rolex.Gre.Manager_TG GetComplexPlotB       20    18s    27s  55.2s   0.38       9.6 min 
-
-command-line options: --disable-progress -ni -n 1 --terminal-width 160 -ic -hcmin 45000 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-12-15 00:00 and 2025-12-15 23:57

--- a/tests/reference-output/hl-hcmin-plotlog-w160.txt
+++ b/tests/reference-output/hl-hcmin-plotlog-w160.txt
@@ -22,6 +22,10 @@
  2025-12-15 22:00 WARN: 48                             0:0.4/m │ ██                                                                                             
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [INFO] [https-openssl-nio-44] [S.c.t.d.e.DSLScript] SUCCEEDED - Rolex.Gre.Manager_TG GetComplexPlotB       20    18s    27s  55.2s   0.38       9.6 min 
+
 command-line options: --disable-progress -ni -n 1 --terminal-width 160 -ic -hcmin 45000 
 
   ─────────────────────────────────────────   
@@ -36,8 +40,4 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -ic -hcmi
   LINES INCLUDED                       2992   
   LINES READ                           2992   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [INFO] [https-openssl-nio-44] [S.c.t.d.e.DSLScript] SUCCEEDED - Rolex.Gre.Manager_TG GetComplexPlotB       20    18s    27s  55.2s   0.38       9.6 min 
 

--- a/tests/reference-output/hl-hdmin-w160.txt
+++ b/tests/reference-output/hl-hdmin-w160.txt
@@ -46,6 +46,10 @@
  2026-01-25 06:00 4xx: 2 1 3xx: 6 148 2xx: 510  0:5.6/m │ █████████████████████████   3m         2.5 MiB │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
+
 command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -hdmin 100 
 
   ─────────────────────────────────────────   
@@ -61,8 +65,4 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   LINES INCLUDED                        677   
   LINES READ                            677   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
 

--- a/tests/reference-output/hl-hdmin-w160.txt
+++ b/tests/reference-output/hl-hdmin-w160.txt
@@ -46,11 +46,11 @@
  2026-01-25 06:00 4xx: 2 1 3xx: 6 148 2xx: 510  0:5.6/m │ █████████████████████████   3m         2.5 MiB │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -hdmin 100 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
-
-command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -hdmin 100 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41

--- a/tests/reference-output/hl-heatmap-hdmin-w160-bin.txt
+++ b/tests/reference-output/hl-heatmap-hdmin-w160-bin.txt
@@ -11,11 +11,11 @@
  2025-04-10 06:00 ERROR: 23 498 WARN: 4474 4 INFO: 1  0.2:41.7/m │ ████████████████████   31.5m    16.4 K │ █  ██ █|████  ████████████████████|████|██| ██    ██
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1ms───────14ms─────────244ms────────4.3s────────1.5m
 
+command-line options: --disable-progress -ni -n 1 -hmdm bin --terminal-width 160 -hm duration -hdmin 963 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [WARN] [WC_0K010012_ProcessP] [S.c.t.d.e.DSLScript] SUCCEEDED - Brembo.UTM.ShiftInstances_TG SaveShi        4   1.5s   3.6s   4.4s   0.41      12.1 sec 
-
-command-line options: --disable-progress -ni -n 1 -hmdm bin --terminal-width 160 -hm duration -hdmin 963 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-04-10 06:00 and 2025-04-10 06:07

--- a/tests/reference-output/hl-heatmap-hdmin-w160-bin.txt
+++ b/tests/reference-output/hl-heatmap-hdmin-w160-bin.txt
@@ -11,6 +11,10 @@
  2025-04-10 06:00 ERROR: 23 498 WARN: 4474 4 INFO: 1  0.2:41.7/m │ ████████████████████   31.5m    16.4 K │ █  ██ █|████  ████████████████████|████|██| ██    ██
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1ms───────14ms─────────244ms────────4.3s────────1.5m
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [WARN] [WC_0K010012_ProcessP] [S.c.t.d.e.DSLScript] SUCCEEDED - Brembo.UTM.ShiftInstances_TG SaveShi        4   1.5s   3.6s   4.4s   0.41      12.1 sec 
+
 command-line options: --disable-progress -ni -n 1 -hmdm bin --terminal-width 160 -hm duration -hdmin 963 
 
   ─────────────────────────────────────────   
@@ -26,8 +30,4 @@ command-line options: --disable-progress -ni -n 1 -hmdm bin --terminal-width 160
   LINES INCLUDED                       5000   
   LINES READ                           5000   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [WARN] [WC_0K010012_ProcessP] [S.c.t.d.e.DSLScript] SUCCEEDED - Brembo.UTM.ShiftInstances_TG SaveShi        4   1.5s   3.6s   4.4s   0.41      12.1 sec 
 

--- a/tests/reference-output/hl-heatmap-hdmin-w160.txt
+++ b/tests/reference-output/hl-heatmap-hdmin-w160.txt
@@ -11,11 +11,11 @@
  2025-04-10 06:00 ERROR: 23 498 WARN: 4474 4 INFO: 1  0.2:41.7/m │ ████████████████████   31.5m    16.4 K │ █  ██ █|█████ ████████████████████|████|██| ██    ██
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1ms───────14ms─────────244ms────────4.3s────────1.5m
 
+command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -hm duration -hdmin 963 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [WARN] [WC_0K010012_ProcessP] [S.c.t.d.e.DSLScript] SUCCEEDED - Brembo.UTM.ShiftInstances_TG SaveShi        4   1.5s   3.6s   4.4s   0.41      12.1 sec 
-
-command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -hm duration -hdmin 963 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2025-04-10 06:00 and 2025-04-10 06:07

--- a/tests/reference-output/hl-heatmap-hdmin-w160.txt
+++ b/tests/reference-output/hl-heatmap-hdmin-w160.txt
@@ -11,6 +11,10 @@
  2025-04-10 06:00 ERROR: 23 498 WARN: 4474 4 INFO: 1  0.2:41.7/m │ ████████████████████   31.5m    16.4 K │ █  ██ █|█████ ████████████████████|████|██| ██    ██
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─1ms───────14ms─────────244ms────────4.3s────────1.5m
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [WARN] [WC_0K010012_ProcessP] [S.c.t.d.e.DSLScript] SUCCEEDED - Brembo.UTM.ShiftInstances_TG SaveShi        4   1.5s   3.6s   4.4s   0.41      12.1 sec 
+
 command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -hm duration -hdmin 963 
 
   ─────────────────────────────────────────   
@@ -26,8 +30,4 @@ command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -
   LINES INCLUDED                       5000   
   LINES READ                           5000   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [WARN] [WC_0K010012_ProcessP] [S.c.t.d.e.DSLScript] SUCCEEDED - Brembo.UTM.ShiftInstances_TG SaveShi        4   1.5s   3.6s   4.4s   0.41      12.1 sec 
 

--- a/tests/reference-output/hl-histogram-hdmin-w160-bin.txt
+++ b/tests/reference-output/hl-histogram-hdmin-w160-bin.txt
@@ -62,6 +62,10 @@
                            P25: 35.6ms   P50: 47.1ms   P75: 89.6ms   P90: 542.7ms   P95: 1.3s   P99: 5.3s   P99.9: 7.4s   P99.99: 7.4s          
                               P25: 147.8ms   P50: 353.1ms   P75: 1s   P90: 3.2s   P95: 5.3s   P99: 6.9s   P99.9: 7.4s   P99.99: 7.4s            
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
+
 command-line options: --disable-progress -ni -n 1 -hgdm bin --terminal-width 160 -du us -hg duration -hdmin 100 
 
   ─────────────────────────────────────────   
@@ -77,8 +81,4 @@ command-line options: --disable-progress -ni -n 1 -hgdm bin --terminal-width 160
   LINES INCLUDED                        677   
   LINES READ                            677   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
 

--- a/tests/reference-output/hl-histogram-hdmin-w160-bin.txt
+++ b/tests/reference-output/hl-histogram-hdmin-w160-bin.txt
@@ -62,11 +62,11 @@
                            P25: 35.6ms   P50: 47.1ms   P75: 89.6ms   P90: 542.7ms   P95: 1.3s   P99: 5.3s   P99.9: 7.4s   P99.99: 7.4s          
                               P25: 147.8ms   P50: 353.1ms   P75: 1s   P90: 3.2s   P95: 5.3s   P99: 6.9s   P99.9: 7.4s   P99.99: 7.4s            
 
+command-line options: --disable-progress -ni -n 1 -hgdm bin --terminal-width 160 -du us -hg duration -hdmin 100 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
-
-command-line options: --disable-progress -ni -n 1 -hgdm bin --terminal-width 160 -du us -hg duration -hdmin 100 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41

--- a/tests/reference-output/hl-histogram-hdmin-w160.txt
+++ b/tests/reference-output/hl-histogram-hdmin-w160.txt
@@ -62,11 +62,11 @@
                            P25: 35.5ms   P50: 47.1ms   P75: 89.3ms   P90: 541.2ms   P95: 1.3s   P99: 5.3s   P99.9: 7.4s   P99.99: 7.4s          
                               P25: 147.4ms   P50: 357.8ms   P75: 1s   P90: 3.2s   P95: 5.3s   P99: 6.9s   P99.9: 7.4s   P99.99: 7.4s            
 
+command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -du us -hg duration -hdmin 100 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
-
-command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -du us -hg duration -hdmin 100 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41

--- a/tests/reference-output/hl-histogram-hdmin-w160.txt
+++ b/tests/reference-output/hl-histogram-hdmin-w160.txt
@@ -62,6 +62,10 @@
                            P25: 35.5ms   P50: 47.1ms   P75: 89.3ms   P90: 541.2ms   P95: 1.3s   P99: 5.3s   P99.9: 7.4s   P99.99: 7.4s          
                               P25: 147.4ms   P50: 357.8ms   P75: 1s   P90: 3.2s   P95: 5.3s   P99: 6.9s   P99.9: 7.4s   P99.99: 7.4s            
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
+
 command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -du us -hg duration -hdmin 100 
 
   ─────────────────────────────────────────   
@@ -77,8 +81,4 @@ command-line options: --disable-progress -ni -n 1 -dm raw --terminal-width 160 -
   LINES INCLUDED                        677   
   LINES READ                            677   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [200] GET /Windchill/sslClientAuth/servlet/odata/v6/ProdMgmt/$metadata                                     12  106ms  167ms   5.4s   2.18       8.4 sec 
 

--- a/tests/reference-output/hl-regex-hdmin-w160.txt
+++ b/tests/reference-output/hl-regex-hdmin-w160.txt
@@ -46,11 +46,11 @@
  2026-01-25 06:00 4xx: 2 3xx: 7 19 2xx: 639  0:5.6/m │ ███████████████████████████   3m         2.5 MiB  │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h BomTransformation -hdmin 100 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [200] GET /Windchill/sslClientAuth/servlet/odata/v2/BomTransformation/$metadata                            10  133ms  184ms  903ms   0.94       2.5 sec 
-
-command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h BomTransformation -hdmin 100 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41

--- a/tests/reference-output/hl-regex-hdmin-w160.txt
+++ b/tests/reference-output/hl-regex-hdmin-w160.txt
@@ -46,6 +46,10 @@
  2026-01-25 06:00 4xx: 2 3xx: 7 19 2xx: 639  0:5.6/m │ ███████████████████████████   3m         2.5 MiB  │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [200] GET /Windchill/sslClientAuth/servlet/odata/v2/BomTransformation/$metadata                            10  133ms  184ms  903ms   0.94       2.5 sec 
+
 command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h BomTransformation -hdmin 100 
 
   ─────────────────────────────────────────   
@@ -60,8 +64,4 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   LINES INCLUDED                        677   
   LINES READ                            677   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [200] GET /Windchill/sslClientAuth/servlet/odata/v2/BomTransformation/$metadata                            10  133ms  184ms  903ms   0.94       2.5 sec 
 

--- a/tests/reference-output/hl-regex-only-w160.txt
+++ b/tests/reference-output/hl-regex-only-w160.txt
@@ -46,6 +46,10 @@
  2026-01-25 06:00 4xx: 2 3xx: 7 34 2xx: 624  0:5.6/m │ ██████████████████████████    3m         2.5 MiB  │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  [200] GET /Windchill/sslClientAuth/servlet/odata/v3/BomTransformation/$metadata                            18   59ms  108ms   1.6s   1.76       3.6 sec 
+
 command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h BomTransformation 
 
   ─────────────────────────────────────────   
@@ -60,8 +64,4 @@ command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h
   LINES INCLUDED                        677   
   LINES READ                            677   
   ─────────────────────────────────────────   
-
-  TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  [200] GET /Windchill/sslClientAuth/servlet/odata/v3/BomTransformation/$metadata                            18   59ms  108ms   1.6s   1.76       3.6 sec 
 

--- a/tests/reference-output/hl-regex-only-w160.txt
+++ b/tests/reference-output/hl-regex-only-w160.txt
@@ -46,11 +46,11 @@
  2026-01-25 06:00 4xx: 2 3xx: 7 34 2xx: 624  0:5.6/m │ ██████████████████████████    3m         2.5 MiB  │  P50:47.1ms P95:1.3s   P99:5.3s   P999:7.4s   CV:3.13
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
+command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h BomTransformation 
+
   TOP HIGHLIGHTED MESSAGES (lines matching the highlight criteria)                                       Occur.    Min    P50   P99.   CV .      Duration 
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   [200] GET /Windchill/sslClientAuth/servlet/odata/v3/BomTransformation/$metadata                            18   59ms  108ms   1.6s   1.76       3.6 sec 
-
-command-line options: --disable-progress -ni -n 1 --terminal-width 160 -du us -h BomTransformation 
 
   ─────────────────────────────────────────   
   Category                            Total      These file(s) were processed with analysis including results between 2026-01-22 08:49 and 2026-01-25 07:41

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -95,10 +95,13 @@ DPM5K_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k
 # references freeze, so it is dropped. The drop is bounded: the run summary
 # closes the output, and its first line (the echoed options) ends the skip so
 # the category totals, the HIGHLIGHTED row and the file/format legend stay
-# inside the asserted surface. Must match capture-regression.sh exactly.
+# inside the asserted surface. Per tests/HARNESS-DESIGN.md, an anchor that
+# matches nothing is a failure: if the skip is still open at end of input the
+# filter exits 3, so a truncated surface aborts instead of being asserted.
+# Must match capture-regression.sh exactly.
 strip_nondeterministic() {
     perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g; s/log timeline \[[^\]]+\]/log timeline [VERSION]/' \
-    | perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
+    | perl -ne 'BEGIN{$skip=0} END{ $? = 3 if $skip } $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
 }
 
 # Verify reference directory exists
@@ -169,6 +172,14 @@ run_test() {
 
     if [[ "${pipe_status[0]}" -ne 0 ]]; then
         emit_regression_fail "$name" "ltl exited ${pipe_status[0]} (stderr below)" "$stderrfile"
+        return
+    fi
+    # strip_nondeterministic exits 3 when it reached end of input still skipping,
+    # i.e. the run summary that ends the TOP OVERALL skip never appeared. Per
+    # tests/HARNESS-DESIGN.md an anchor that matches nothing is a failure, not a
+    # smaller surface that quietly passes.
+    if [[ "${pipe_status[1]}" -ne 0 ]]; then
+        emit_regression_fail "$name" "output filter found no run summary to end the TOP OVERALL skip; the asserted surface would be truncated (stderr below)" "$stderrfile"
         return
     fi
     # Runtime-warning cleanliness (HARNESS-DESIGN.md section Runtime-warning

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -90,9 +90,15 @@ DPM5K_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k
 # the life of the branch, per CLAUDE.md § Version Stamping, so every development
 # build carries a suffix. Matching only [0-9.]+ made every scenario fail on any
 # branch, for the one reason the goldens are explicitly meant to ignore.
+#
+# The TOP OVERALL MESSAGES block is not part of the layout surface these
+# references freeze, so it is dropped. The drop is bounded: the run summary
+# closes the output, and its first line (the echoed options) ends the skip so
+# the category totals, the HIGHLIGHTED row and the file/format legend stay
+# inside the asserted surface. Must match capture-regression.sh exactly.
 strip_nondeterministic() {
     perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g; s/log timeline \[[^\]]+\]/log timeline [VERSION]/' \
-    | perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
+    | perl -ne 'BEGIN{$skip=0} $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
 }
 
 # Verify reference directory exists

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -92,16 +92,20 @@ DPM5K_LOG="logs/ThingworxLogs/CustomThingworxLogs/ScriptLog-DPMExtended-clean-5k
 # branch, for the one reason the goldens are explicitly meant to ignore.
 #
 # The TOP OVERALL MESSAGES block is not part of the layout surface these
-# references freeze, so it is dropped. The drop is bounded: the run summary
-# closes the output, and its first line (the echoed options) ends the skip so
-# the category totals, the HIGHLIGHTED row and the file/format legend stay
-# inside the asserted surface. Per tests/HARNESS-DESIGN.md, an anchor that
-# matches nothing is a failure: if the skip is still open at end of input the
-# filter exits 3, so a truncated surface aborts instead of being asserted.
+# references freeze, so it is dropped. The drop is bounded by the run summary
+# that closes the output: the skip ends on the summary's first line -- the rule
+# above the Category header, two spaces in and padded on the right -- so the
+# category totals, the HIGHLIGHTED row and the file/format legend stay inside
+# the asserted surface. Per tests/HARNESS-DESIGN.md an anchor that matches
+# nothing is a failure: reaching end of input with the skip still open exits 3,
+# so a truncated surface aborts instead of being asserted. A run invoked with
+# -osum prints no summary, and the echoed options line -- which sits under the
+# bar graph, ahead of the skipped block -- says so, so such a run has nothing
+# to close the skip and is exempt.
 # Must match capture-regression.sh exactly.
 strip_nondeterministic() {
     perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g; s/\e\[\d*m//g; s/log timeline \[[^\]]+\]/log timeline [VERSION]/' \
-    | perl -ne 'BEGIN{$skip=0} END{ $? = 3 if $skip } $skip=1 if /TOP OVERALL/; $skip=0 if /^(?:environment|command-line) options: /; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
+    | perl -ne 'BEGIN{$skip=0; $want_summary=1} END{ $? = 3 if $skip && $want_summary } $want_summary=0 if /^(?:environment|command-line) options: / && /(?:^|\s)(?:-osum|--omit-summary)(?=\s|$)/; $skip=1 if /TOP OVERALL/; $skip=0 if /^ {2}(?:─)+ +$/; print unless $skip || /PROCESSING TIME|TOTAL TIME|MAXIMUM MEMORY|INITIALIZE EMPTY|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS|GROUP SIMILAR MESSAGES|SCALE DATA|DETECT: FORMAT REGISTRY BUILD|PARSE: FILE PROCESSING|ACCUMULATE: EMPTY BUCKETS|FINALIZE: (?:GROUP SIMILAR|CALCULATE STATISTICS|HEATMAP STATISTICS|HISTOGRAM STATISTICS)|RENDER: SCALE DATA/i'
 }
 
 # Verify reference directory exists


### PR DESCRIPTION
Closes #457.

- The run summary (time range, files read, memory, timing) is now the last section printed, after the messages table, thread-pool table, heatmap and histograms. Content and rendering are unchanged — the goldens re-blessed for this are verified pure reorderings.
- The echoed `command-line options:` line stays directly under the timeline bar graph (docs/purpose.md: each view can be screenshot with its options shown), split into `print_run_options()`.
- `docs/usage.md` ordering statements and the `-osum` example updated.
- `tests/validate-regression.sh` / `tests/capture-regression.sh`: the bounded TOP OVERALL skip is re-anchored on the summary's opening rule and fails hard (exit 3) if the anchor never arrives, except under `-osum`.

Completion gate on `2d3d7de`: 27/27 harnesses pass; before/after benchmark `single-day-access-log-standard` on this machine: elapsed −0.8 %, peak RSS +0.1 % (the peak is now measured after all tables have rendered). Record: `features/457-summary-section-at-end-of-output.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYhJaBPqtoqLVfKUeRsrNE