### PR TITLE
FEATURE: -n 0 outputs no specific messages, and retains and computes nothing per message

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,7 +155,7 @@ Alongside the messages ranking, logtimeline prints a **Category** table totallin
 
 | Option | Description |
 |--------|-------------|
-| `-n, --top-messages <N>` | Number of unique messages to show in the top-messages table (default: 10) |
+| `-n, --top-messages <N>` | Number of unique messages to show in the top-messages table (default: 10). `0` keeps no individual message at all: no message table, no message CSV and no per-message statistics, so a log with many distinct messages costs far less memory. The timeline and the statistics over the whole population are unchanged, and inclusion/exclusion filtering still applies. Message grouping (`-g`), the message statistics data model (`-mdm`) and the message ranking (`-so`) then have nothing to act on and are ignored, with a note saying so |
 | `-o, --output-csv` | Write all extracted data to a CSV file for external analysis |
 | `-cp, --csv-precision <mode>` | Control CSV decimal precision: `default` (per-family decimals derived from `-du`), `full` (raw precise floats), or an integer N (cap all numeric columns at N decimals) |
 | `-osum, --omit-summary` | Hide the run summary printed at the end of the output |

--- a/features/458-top-messages-zero-no-per-message-retention.md
+++ b/features/458-top-messages-zero-no-per-message-retention.md
@@ -241,3 +241,80 @@ failed with their `asserts`/`produced_by`/`contract` triple surfaced. The 4 that
 still passed are the ones asserting behaviour `-n 0` does *not* change (the bucket
 store stays demanded, the timeline and its percentiles are still rendered, and the
 CSV/extended/shape groups are undemanded on any terminal-only run).
+
+## Completion gate
+
+Run on `5928714` (`#458: restore release version for the completion gate`), the
+commit being merged — the branch rebased onto `release/0.18.0` at `3129fea`
+(release notes for #463, the descriptive category names) with `$version_number`
+restored to `0.18.0`.
+
+**No benchmark was run.** The architect has ruled that performance benchmarks are
+not part of feature work; `tests/baseline/run-benchmark.sh` was not invoked and no
+`458-*.tsv` result was produced. The dev-scale before/after under § Measurement
+above measures what the option does, not what the change did to the tool, and
+stands on its own.
+
+### Rebase
+
+Two conflicts, both the same one-line edit on two surfaces: the `-n` option
+description in `print_help()` and its row in `docs/usage.md`. #457 (the run summary
+printed at the end of the output) renamed the table the option controls from "the
+summary table" to "the top-messages table" on both surfaces; this branch had
+extended the same sentence to document `0`. Resolved by keeping the release
+branch's name for the table and this branch's documentation of `0` after it, so
+the merged row reads "Number of unique messages to show in the top-messages table
+(default: 10). 0 keeps no individual message at all: …". Both surfaces carry the
+same merge, so the `--help`/`docs/usage.md` parity `validate-help-content.sh`
+enforces is preserved. `perl -c ltl` clean; no regression golden conflicted.
+
+### Harness suite — 28 of 28 pass
+
+Every harness exited 0 and its summary line reports checks actually run — 1 175
+passing, 0 failing, across the whole suite.
+
+| Harness | Summary |
+|---|---|
+| `validate-csv-output` | 21 scenarios, 21 pass, 0 fail |
+| `validate-statistics` | 21 scenarios, 21 pass, 0 fail |
+| `validate-category-names` | PASS 26, FAIL 0 |
+| `validate-csv-input` | 4 pass, 0 fail |
+| `validate-distribution-shape` | 8 passed, 0 failed |
+| `validate-doc-examples` | 46 passed, 0 failed, 9 skipped |
+| `validate-duration-display` | 21 passed, 0 failed |
+| `validate-explain` | 148 passed, 0 failed |
+| `validate-format-detection` | 192 passed, 0 failed |
+| `validate-format-registry` | 22 passed, 0 failed |
+| `validate-heatmap-palette` | 85 passed, 0 failed |
+| `validate-help-content` | 11 passed, 0 failed |
+| `validate-help-layout` | 6 passed, 0 failed |
+| `validate-histogram-bin-counters` | 84 passed, 0 failed |
+| `validate-histogram-ticks` | 21 passed, 0 failed |
+| `validate-index-read-back` | 59 passed, 0 failed |
+| `validate-log-level-vocabulary` | PASS 8, FAIL 0 |
+| `validate-message-control-characters` | PASS 11, FAIL 0 |
+| `validate-message-grouping-notices` | 4 passed, 0 failed |
+| `validate-numeric-criteria-notices` | 10 passed, 0 failed |
+| `validate-profile-render` | 22 passed, 0 failed |
+| `validate-profile` | 50 passed, 0 failed |
+| `validate-recursive-file-selection` | 22 passed, 0 failed |
+| `validate-regression` | 71 passed, 0 failed, 0 skipped |
+| `validate-runtime-config` | 36 passed, 0 failed |
+| `validate-statistics-demand` | 95 passed, 0 failed |
+| `validate-udm-counting` | 28 passed, 0 failed |
+| `validate-udm-specs` | 43 passed, 0 failed |
+
+`validate-csv-output.sh` ran before `validate-statistics.sh` for the shared `CI=1`
+cache. `./tests/cleanup-test-artifacts.sh` was run afterwards.
+
+### Statistics-drift advisories
+
+No T3 or T4 failure on any of the three layers, so nothing blocks. The advisory
+counts are 943 T2 cells, all on the algorithm-aware oracle layer, and 28 registered
+known failures — every one of them the single projection onto the shared bin
+geometry already tracked as #469 (bin-model percentile projection error), listed in
+`tests/statistics-drift/known-failures.tsv`. Both counts are identical to the run
+recorded for #463 (descriptive category names) on the same release branch, which is
+what a change that retains fewer messages but alters no statistic should produce:
+every drift scenario runs with a positive `-n`, so none of them takes the `-n 0`
+path at all.

--- a/features/458-top-messages-zero-no-per-message-retention.md
+++ b/features/458-top-messages-zero-no-per-message-retention.md
@@ -1,0 +1,210 @@
+# `-n 0`: no specific messages, nothing retained or computed per message (#458)
+
+## Overview
+
+`-n, --top-messages` accepts `0`, meaning the run keeps no individual log message at
+all. This is not a display setting: the per-message store is never populated, so
+nothing downstream of it exists — no per-message statistics, no messages table, no
+MESSAGES CSV. The timeline and the statistics over the whole population are produced
+exactly as before, and inclusion/exclusion filtering is unaffected because it decides
+whether a line is considered at all, ahead of this decision.
+
+The motivation is cost. Retaining a copy of every unique message is what makes the
+tool expensive on large volumes: high cardinality drives memory, and every later pass
+over that population pays for it. When the question is about the timeline and the
+population as a whole, `-n 0` removes that cost by construction.
+
+## GitHub Issue
+
+https://github.com/gregeva/logtimeline/issues/458
+
+Related: #2 (memory ceiling and automatic detection — `-n 0` is the user-declared way
+to reach a minimal footprint), #426 (the per-message statistics store, whose traversal
+cost this avoids), #354 (`-mdm bin` message-stats memory on high-cardinality logs),
+#44 (source-file heuristics for automatic optimisation), #97 (hierarchical roll-up,
+which also changes what the `-n` operand means).
+
+## Locked decisions
+
+### D1 — The decision is taken per line, at the population site
+
+`read_and_process_logs()` guards the whole message-capture branch:
+
+```perl
+if( $capture_messages && defined( $message ) ) {
+```
+
+`$capture_messages` is a single file-scoped scalar resolved once, in
+`adapt_to_command_line_options()`, from the top-message count. Leading the test with
+it means a run that retains nothing skips key construction, grouping and per-key
+accumulation entirely, and a retaining run pays one boolean per line and nothing
+else. Nothing is populated and then cleared: the store is never written.
+
+**Consequence.** No other site needs an emptiness guard. Every consumer of the store
+iterates it (`foreach my $category (sort keys %log_messages)`), so an empty store is
+zero iterations rather than a special case — this is the "gate on observation counts"
+rule satisfied structurally.
+
+### D2 — A count of zero or less retains nothing
+
+`$capture_messages = ( $top_n_messages > 0 ) ? 1 : 0;`. A negative operand was
+previously accepted and produced an empty table over a fully populated store; it now
+takes the same path as `0`. No new error path was added for negative values.
+
+### D3 — Options that only configure the per-message store are ignored, not rejected
+
+Message grouping (`-g`), the message statistics data model (`-mdm`) and the message
+ranking (`-so`) configure something that will never exist. They are not an error —
+the retention setting wins — but the user is told, once, naming only the options they
+actually passed:
+
+```
+Note: -n/--top-messages 0 retains no message, so -g/--group-similar,
+-mdm/--message-stats-data-model, -so/--sort-on have no effect
+```
+
+The notice is a behavioural notice, not progress output, so it is not gated behind
+`--disable-progress`. Grouping is switched off at this point
+(`$group_similar_sensitivity = "none"`) rather than left to find an empty store, so
+its final pass, its `-V message-grouping` section and its own notices never run.
+
+`-so` is included even though the issue names only `-g` and `-mdm`: it is in the same
+class — it orders the messages table and nothing else.
+
+**Consequence.** The three unsatisfiable-sort notices (#418) are suppressed under
+`-n 0`: `apply_parse_time_sort_gate()`, `apply_pre_walk_sort_gate()` and
+`apply_post_walk_sort_gate()` all return early. With no message retained there is
+nothing to rank, so there is no fallback to report. `-V statistics-demand` still
+records the operand and its family truthfully (`fallback=none`).
+
+### D4 — No MESSAGES CSV file is created
+
+`-o` continues to write the STATS CSV (per time bucket). The MESSAGES CSV is the
+per-message store written out; with no rows there is no file. A header-only CSV would
+read as a run that found nothing rather than one that was asked to keep nothing.
+
+### D5 — The thread-pool summary follows the same top-N operand
+
+`print_threadpool_summary()` ranks by the same `-n` operand as the messages table, so
+a top-N of zero leaves it no rows. It is skipped rather than printed empty.
+
+**Consequence.** `-tpas` with `-n 0` produces no thread-pool table. This is the one
+decision here that touches a surface the issue does not mention; it follows from the
+operand being shared, not from message retention. *Open for the architect: if the
+thread-pool summary should keep its own row count independent of `-n`, that is a
+separate operand and a separate change.*
+
+## What changed, by surface
+
+| surface | change |
+|---|---|
+| `ltl` — hot path | `read_and_process_logs()`: message-capture branch gated on `$capture_messages` |
+| `ltl` — option resolution | `adapt_to_command_line_options()`: `$capture_messages` resolved before the sort resolution; inert-option notice and grouping fold before the statistics-demand resolution |
+| `ltl` — demand registry | `@STAT_CONSUMERS`: all three message-store consumers (`messages-table`, `messages-csv`, `sort-on`) read `$capture_messages`. `$message_duration_stats_demand` reduces to `!$omit_durations && $capture_messages`: both of its surfaces exist only for retained messages, so retention is the single condition |
+| `ltl` — sort gates | `apply_parse_time_sort_gate()`, `apply_pre_walk_sort_gate()`, `apply_post_walk_sort_gate()` return early |
+| `ltl` — render | `pipeline_render()`: MESSAGES CSV open, `print_message_summary()`, `print_threadpool_summary()` and the MESSAGES file-handle close all gated |
+| `ltl` — help | `print_help()` `-n` row documents `0` |
+| `docs/usage.md` | `-n` row documents `0` (parity with `--help`) |
+| `tests/validate-statistics-demand.sh` | scenarios 9 and 10 |
+| `tests/baseline/run-benchmark.sh` | `no-messages\|-n 0` scenario |
+| `tests/baseline/compare-results.sh` | `no-messages` in the table-view scenario list |
+
+## Downstream audit
+
+Every consumer of the per-message store was checked against an empty store. None
+needed a guard, and none produces a warning, a division by zero or an empty header:
+
+| consumer | behaviour with an empty store |
+|---|---|
+| `group_similar_messages()` and its `-V message-grouping` section | never reached — grouping is off (D3) |
+| `bin_consolidation_notice()` | returns immediately (grouping is off) |
+| `calculate_all_statistics()` message walk, sort selection, group calc | zero iterations over `keys %log_messages` |
+| `finalize_message_stats_unified()` | returns on an empty counter store |
+| `print_message_summary()` | not called (D4/D5 render gating) |
+| MESSAGES CSV | not opened (D4) |
+| `-V statistics-demand` | `store: message` reports `store_demand: 0`, `population: 0`, every group `demanded=0`, `stats_calls: 0` |
+| `-V benchmark-data` | `COUNTS log_messages_entries 0`, `COUNTS log_messages_population 0` |
+| `measure_memory_structures()` / `-mem` | sizes an empty hash |
+| index file write side (#46) | does not read the message store |
+
+Combinations exercised end to end on the 5,000-line Tomcat access slice and a
+ThingWorx ScriptLog, all exit 0 with no Perl runtime warning on stderr: `-n 0` alone,
+`-hm duration -hg duration`, `-V` (all sections), `-o`, `-tpas`, `--profile day`,
+`-osum`, `-so impact`, `-od`, `-hst`.
+
+## Measurement
+
+Dev-scale before/after of the option itself — the same build, the same file, `-n 25`
+against `-n 0`. Not a release benchmark: it measures what the option does, not what
+the change did to the tool.
+
+- Input: `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt`
+  (148 MB, 761,698 lines, 3,184 distinct message keys at `-n 25`)
+- Invocation: `./ltl --disable-progress -ni --terminal-width 200 -bs 60 -n <N> -V benchmark-data`
+- 3 runs each, medians below; values read from the `benchmark-data` section
+
+| metric | `-n 25` | `-n 0` | change |
+|---|---|---|---|
+| peak RSS | 141.0 MiB | 86.1 MiB | **-38.9%** |
+| total runtime | 9.900 s | 7.493 s | **-24.3%** |
+| `parse/read_files` | 9.718 s | 7.382 s | **-24.0%** |
+| message-store entries | 3,184 | 0 | — |
+
+Ranges across the three runs: `-n 25` total 9.775–9.938 s, RSS 147.77–147.90 MB;
+`-n 0` total 7.350–7.994 s, RSS 90.11–90.28 MB. The two distributions do not overlap
+on either metric.
+
+The saving lands in the read pass, which is where the issue's benchmark comment
+predicted it would have to come from: the per-message accumulation is per line, so
+removing it removes per-line work, not a finalize pass.
+
+**Attribution of the memory saving** — a separate `-mem` run on the same file (the
+structure walk raises peak RSS slightly, so it is not merged with the table above):
+
+| structure | high-water at `-n 25` |
+|---|---|
+| `log_messages` | 58,804,089 B (56.1 MiB) |
+| peak RSS | 148,488,192 B |
+
+The 57.6 MB the `-n 0` run does not allocate is the message store itself. The store
+is not dominated by key count: 3,184 keys hold 761,698 retained duration values
+between them under the raw message-statistics data model, about 18.5 KB per key.
+
+## Benchmark-suite coverage
+
+A `no-messages` scenario (`-n 0`) was added to `run-benchmark.sh`, immediately after
+`standard`, so every file selection measures it at every scale and the release
+comparison picks it up automatically. `compare-results.sh` was extended with the same
+scenario in its table view and verified against a synthetic before/after pair (both
+`summary` and `table` modes render the new scenario and its deltas).
+
+**The XL tier was not run.** The bundled XL selections are release-gate instruments,
+not development tools; the pairing the issue's benchmark comment asks to be read —
+`month-many-servers-access-logs-standard` against its `no-messages` counterpart —
+belongs to the release-cut benchmark run (release steps 13–14), not to this branch.
+
+## Test coverage
+
+`tests/validate-statistics-demand.sh`:
+
+- **scenario-9-no-message-retention** (`-n 0`): message store reports
+  `store_demand: 0`, `population: 0`, every group `demanded=0`, `stats_calls: 0`;
+  the bucket store is untouched (`store_demand: 1`); `benchmark-data` reports both
+  message-store counts as 0; neither messages-table header is rendered; the timeline
+  header row and the latency percentiles are present. Stderr is checked for Perl
+  runtime warnings by the shared capture check.
+- **scenario-10-no-message-retention-inert-options** (`-n 0 -g 85 -mdm bin -so p50`):
+  the inert-option notice names all three options; `sort_gate` records the operand
+  with `fallback=none`.
+
+The render assertions read the displayed surface because "the messages table is
+absent" and "the timeline is present" are properties of that surface with no
+internal-state equivalent (`tests/HARNESS-DESIGN.md` § Render-invariant harnesses);
+the layout is pinned at `--terminal-width 200` and ANSI is stripped before matching.
+
+**Failure proof** (`tests/HARNESS-DESIGN.md` § Proving a new assertion can fail): both
+scenarios were re-run with `-n 10` substituted for `-n 0`. 9 of the 13 new assertions
+failed with their `asserts`/`produced_by`/`contract` triple surfaced. The 4 that
+still passed are the ones asserting behaviour `-n 0` does *not* change (the bucket
+store stays demanded, the timeline and its percentiles are still rendered, and the
+CSV/extended/shape groups are undemanded on any terminal-only run).

--- a/features/458-top-messages-zero-no-per-message-retention.md
+++ b/features/458-top-messages-zero-no-per-message-retention.md
@@ -69,19 +69,37 @@ The notice is a behavioural notice, not progress output, so it is not gated behi
 its final pass, its `-V message-grouping` section and its own notices never run.
 
 `-so` is included even though the issue names only `-g` and `-mdm`: it is in the same
-class — it orders the messages table and nothing else.
+class — it orders the messages table and nothing else. Ranking a set of rows that will
+never exist is not a partial capability, so `-so` is reported inert exactly as `-g`
+and `-mdm` are.
 
 **Consequence.** The three unsatisfiable-sort notices (#418) are suppressed under
 `-n 0`: `apply_parse_time_sort_gate()`, `apply_pre_walk_sort_gate()` and
-`apply_post_walk_sort_gate()` all return early. With no message retained there is
-nothing to rank, so there is no fallback to report. `-V statistics-demand` still
-records the operand and its family truthfully (`fallback=none`).
+`apply_post_walk_sort_gate()` all return early. Those notices exist to tell the user
+that a requested ranking could not be satisfied and what it fell back to; with no
+message retained there is nothing ranked at all, so a fallback notice would report a
+substitution that never happened — the inert-option notice above is the accurate
+statement, and it is the only one printed. `-V statistics-demand` still records the
+operand and its family truthfully (`sort_gate: operand=<key> family=<family>
+observed=n/a fallback=none`), so the diagnostic surface still shows what the user
+asked for.
 
-### D4 — No MESSAGES CSV file is created
+### D4 — No MESSAGES CSV file is created, and the user is told
 
 `-o` continues to write the STATS CSV (per time bucket). The MESSAGES CSV is the
 per-message store written out; with no rows there is no file. A header-only CSV would
 read as a run that found nothing rather than one that was asked to keep nothing.
+
+A CSV request is therefore half-served, and a user who scripts around the file names
+must learn that at run time rather than by finding one file where they expected two.
+`-o` is not listed among the inert options — its per-time-bucket half still runs — so
+it is reported on its own line of the same notice, emitted whenever a CSV was
+requested under `-n 0` (a behavioural notice, so never gated behind
+`--disable-progress`). Exact text, on stderr:
+
+```
+Note: -n/--top-messages 0 retains no message, so -o/--output-csv writes the STATS CSV only: no MESSAGES CSV is written
+```
 
 ### D5 — The thread-pool summary follows the same top-N operand
 
@@ -90,22 +108,24 @@ a top-N of zero leaves it no rows. It is skipped rather than printed empty.
 
 **Consequence.** `-tpas` with `-n 0` produces no thread-pool table. This is the one
 decision here that touches a surface the issue does not mention; it follows from the
-operand being shared, not from message retention. *Open for the architect: if the
-thread-pool summary should keep its own row count independent of `-n`, that is a
-separate operand and a separate change.*
+operand being shared, not from message retention. Giving the thread-pool summary a
+row count of its own, independent of `-n`, would be a new operand with its own name,
+help row and documentation — a separate requirement and a separate issue, not part of
+this one. Until such an operand exists, `-n` governs both tables and `-n 0` empties
+both.
 
 ## What changed, by surface
 
 | surface | change |
 |---|---|
 | `ltl` — hot path | `read_and_process_logs()`: message-capture branch gated on `$capture_messages` |
-| `ltl` — option resolution | `adapt_to_command_line_options()`: `$capture_messages` resolved before the sort resolution; inert-option notice and grouping fold before the statistics-demand resolution |
+| `ltl` — option resolution | `adapt_to_command_line_options()`: `$capture_messages` resolved before the sort resolution; inert-option notice, half-served-CSV notice and grouping fold before the statistics-demand resolution |
 | `ltl` — demand registry | `@STAT_CONSUMERS`: all three message-store consumers (`messages-table`, `messages-csv`, `sort-on`) read `$capture_messages`. `$message_duration_stats_demand` reduces to `!$omit_durations && $capture_messages`: both of its surfaces exist only for retained messages, so retention is the single condition |
 | `ltl` — sort gates | `apply_parse_time_sort_gate()`, `apply_pre_walk_sort_gate()`, `apply_post_walk_sort_gate()` return early |
 | `ltl` — render | `pipeline_render()`: MESSAGES CSV open, `print_message_summary()`, `print_threadpool_summary()` and the MESSAGES file-handle close all gated |
 | `ltl` — help | `print_help()` `-n` row documents `0` |
 | `docs/usage.md` | `-n` row documents `0` (parity with `--help`) |
-| `tests/validate-statistics-demand.sh` | scenarios 9 and 10 |
+| `tests/validate-statistics-demand.sh` | scenarios 9 to 12 |
 | `tests/baseline/run-benchmark.sh` | `no-messages\|-n 0` scenario |
 | `tests/baseline/compare-results.sh` | `no-messages` in the table-view scenario list |
 
@@ -200,6 +220,15 @@ belongs to the release-cut benchmark run (release steps 13–14), not to this br
   takes the same path as zero (D2) — the message store reports `store_demand: 0` and
   `population: 0`. Proved to fail with `-n 5` substituted: both assertions failed with
   their `asserts`/`produced_by`/`contract` triple surfaced.
+- **scenario-12-no-message-retention-csv-request** (`-bs 1440 -oe -n 0 -o`): the
+  half-served-CSV notice is printed verbatim on stderr; the STATS CSV file exists and
+  no MESSAGES CSV file does. The run gets its own scratch directory so the two file
+  assertions see only its own artifacts, and it is shaped to what it reads — a stderr
+  notice and a directory listing, never a bucket row. All three assertions were proved
+  to fail: the notice pattern finds no match in the stderr of the same run with `-n 5`
+  substituted, the STATS-CSV check fails against an empty directory, and the
+  MESSAGES-CSV absence check fails against the `-n 5` run's output directory, which
+  contains both files.
 
 The render assertions read the displayed surface because "the messages table is
 absent" and "the timeline is present" are properties of that surface with no

--- a/features/458-top-messages-zero-no-per-message-retention.md
+++ b/features/458-top-messages-zero-no-per-message-retention.md
@@ -196,6 +196,10 @@ belongs to the release-cut benchmark run (release steps 13–14), not to this br
 - **scenario-10-no-message-retention-inert-options** (`-n 0 -g 85 -mdm bin -so p50`):
   the inert-option notice names all three options; `sort_gate` records the operand
   with `fallback=none`.
+- **scenario-11-negative-top-messages-retains-nothing** (`-n -5`): a negative count
+  takes the same path as zero (D2) — the message store reports `store_demand: 0` and
+  `population: 0`. Proved to fail with `-n 5` substituted: both assertions failed with
+  their `asserts`/`produced_by`/`contract` triple surfaced.
 
 The render assertions read the displayed surface because "the messages table is
 absent" and "the timeline is present" are properties of that surface with no

--- a/ltl
+++ b/ltl
@@ -10505,6 +10505,12 @@ sub adapt_to_command_line_options {
         print STDERR "Note: -n/--top-messages 0 retains no message, so "
             . join(', ', @inert) . (@inert == 1 ? " has" : " have") . " no effect\n"
             if @inert;
+        # -o is not inert: its per-time-bucket half still runs. Only the
+        # per-message CSV disappears with the store it writes out, so it is
+        # reported on its own line rather than joined into the list above.
+        print STDERR "Note: -n/--top-messages 0 retains no message, so "
+            . "-o/--output-csv writes the STATS CSV only: no MESSAGES CSV is written\n"
+            if $write_messages_to_csv;
     }
 
     # Duration-statistics demand resolution: each statistics store is captured

--- a/ltl
+++ b/ltl
@@ -57,7 +57,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0";
+my $version_number = "0.18.0-458";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );
@@ -243,6 +243,12 @@ my ( $highlight_count_min, $highlight_count_max );
 my $numeric_highlight_active = 0;   # any numeric highlight bound given
 my $highlight_active = 0;           # regex/file highlight OR numeric highlight given; gates all highlight rendering
 my $top_n_messages = 10;
+# Per-message retention gate. A top-message count of 0 means the per-message
+# store is never populated, so nothing downstream of it exists: no per-key
+# statistics, no messages table, no MESSAGES CSV. Resolved once in
+# adapt_to_command_line_options() and read as a single scalar by the per-line
+# capture branch in read_and_process_logs().
+my $capture_messages = 1;
 my ( $write_messages_to_csv, $csv, $csv_fh, $csv_file_args ) = ( 0, undef, undef, "" );
 my $total_lines_read = 0;
 my $total_lines_included = 0;
@@ -784,13 +790,13 @@ my @STAT_CONSUMERS = (
       active => sub { $write_messages_to_csv },
       groups => [qw(terminal_core csv_body extended_percentiles shape_moments)] },
     { name => 'messages-table', store => 'message',
-      active => sub { $top_n_messages > 0 },
+      active => sub { $capture_messages },
       groups => ['terminal_core'] },
     { name => 'messages-csv', store => 'message',
-      active => sub { $write_messages_to_csv },
+      active => sub { $capture_messages && $write_messages_to_csv },
       groups => [qw(terminal_core csv_body extended_percentiles shape_moments)] },
     { name => 'sort-on', store => 'message',
-      active => sub { defined $sort_key && exists $STAT_FIELD_GROUP{$sort_key} },
+      active => sub { $capture_messages && defined $sort_key && exists $STAT_FIELD_GROUP{$sort_key} },
       groups => sub { [ $STAT_FIELD_GROUP{$sort_key} ] } },
 );
 
@@ -6687,7 +6693,7 @@ sub print_help {
 
     # Display & Output
     $out .= help_subheading("Display & Output");
-    $out .= help_opt("-n,   --top-messages <N>",      "Number of unique messages to show in the top-messages table (default: 10)");
+    $out .= help_opt("-n,   --top-messages <N>",      "Number of unique messages to show in the top-messages table (default: 10). 0 keeps no individual message at all: no message table, no message CSV and no per-message statistics, so a log with many distinct messages costs far less memory. The timeline and the statistics over the whole population are unchanged, and inclusion/exclusion filtering still applies. Message grouping (-g), the message statistics data model (-mdm) and the message ranking (-so) then have nothing to act on and are ignored, with a note saying so.");
     $out .= help_opt("-o,   --output-csv",            "Write all extracted data to a CSV file for external analysis");
     $out .= help_opt("-cp,  --csv-precision <mode>",  "Control CSV decimal precision: 'default' (per-family decimals derived from -du), 'full' (raw precise floats), or an integer N (cap all numeric columns at N decimals)");
     $out .= help_opt("-osum, --omit-summary",         "Hide the run summary printed at the end of the output");
@@ -9581,6 +9587,7 @@ sub apply_parse_time_sort_gate {
     my ($operand) = @_;
     $sort_gate{operand} = $operand;
     $sort_gate{family}  = sort_key_metric_family($sort_key);
+    return unless $capture_messages;    # no message is retained, so none is ranked
     my %killer = (
         duration => [ $omit_durations, '-od/--omit-durations' ],
         bytes    => [ $omit_bytes,     '-ob/--omit-bytes'     ],
@@ -9613,6 +9620,7 @@ sub sort_fallback_to_occurrences {
 # added per line. When it was not, no key can rank, so the walk and the re-sort are
 # skipped outright rather than run to an empty defined block.
 sub apply_pre_walk_sort_gate {
+    return unless $capture_messages;    # no message is retained, so none is ranked
     return if $sort_key eq 'occurrences';
     my $family = $sort_gate{family};
     my $observed = $family eq 'duration' ? $durations_observed
@@ -9630,6 +9638,7 @@ sub apply_pre_walk_sort_gate {
 # an available-value sort key whose family was observed always ranks something.
 sub apply_post_walk_sort_gate {
     my ($defined_keys) = @_;
+    return unless $capture_messages;    # no message is retained, so none is ranked
     return if !exists $STAT_FIELD_GROUP{$sort_key} || $defined_keys;
     sort_fallback_to_occurrences('post-walk');
 }
@@ -10082,6 +10091,12 @@ sub adapt_to_command_line_options {
     # key string per absorbed key and nothing else reads it.
     $consolidation_membership_wanted = section_requested('message-grouping') ? 1 : 0;
 
+    # Per-message retention: asking for no message rows means no message is ever
+    # retained. Resolved here, ahead of every option block that consults it (the
+    # sort resolution, the consolidation fold, the statistics-demand resolution),
+    # so those blocks see one settled answer.
+    $capture_messages = ( $top_n_messages > 0 ) ? 1 : 0;
+
     $filter_range{'start'} = $filter_range_start if defined( $filter_range_start );
     $filter_range{'end'} = $filter_range_end if defined(  $filter_range_end );
 
@@ -10476,6 +10491,22 @@ sub adapt_to_command_line_options {
         $hide_stats = 1;
     }
 
+    # With no message retained, the options that only configure the per-message
+    # store have nothing left to configure. They are not an error - the retention
+    # setting simply wins - but the user is told, because the tool is discarding
+    # something they asked for. Message grouping is switched off here rather than
+    # left to find an empty store, so its final pass and its notices never run.
+    unless ($capture_messages) {
+        my @inert;
+        push @inert, '-g/--group-similar'              if $group_similar_sensitivity ne "none";
+        push @inert, '-mdm/--message-stats-data-model' if defined $data_model_message;
+        push @inert, '-so/--sort-on'                   if $sort_key ne 'occurrences';
+        $group_similar_sensitivity = "none";
+        print STDERR "Note: -n/--top-messages 0 retains no message, so "
+            . join(', ', @inert) . (@inert == 1 ? " has" : " have") . " no effect\n"
+            if @inert;
+    }
+
     # Duration-statistics demand resolution: each statistics store is captured
     # and computed only when at least one of its output surfaces is active.
     # Duration-based sort keys (-so min/mean/p50/...) order the messages table
@@ -10487,10 +10518,10 @@ sub adapt_to_command_line_options {
            (!$hide_stats && !$heatmap_enabled)   # timeline latency-statistics column (heatmap replaces it)
         || $write_messages_to_csv                # STATS CSV statistics columns
     ) ) ? 1 : 0;
-    $message_duration_stats_demand = ( !$omit_durations && (
-           $top_n_messages > 0                   # messages-table statistics variant
-        || $write_messages_to_csv                # MESSAGES CSV statistics columns
-    ) ) ? 1 : 0;
+    # Both message-store surfaces - the messages-table statistics variant and the
+    # MESSAGES CSV statistics columns - exist only for retained messages, so
+    # retention is the single condition on this store's demand.
+    $message_duration_stats_demand = ( !$omit_durations && $capture_messages ) ? 1 : 0;
 
     # Statistics-group demand (#305): layer per-group demand on top of the
     # store-level booleans above, from the consumer declarations in
@@ -11322,7 +11353,11 @@ sub read_and_process_logs {
                 $total_lines_included++;
                 $profile_included_samples++ if $profile_mode;
 
-                if( defined( $message ) ) {
+                # $capture_messages leads the test so that a run retaining no
+                # message pays a single scalar read per line and skips key
+                # construction, grouping and per-key accumulation entirely; a
+                # retaining run pays that one boolean and nothing else.
+                if( $capture_messages && defined( $message ) ) {
                     my $log_key = "";
                     my $max_object_length = 25;
                     my $log_level = $status_code > 0 ? $status_code : $category_bucket;			# If we received an actual HTTP status code, use that for the message statistic data model
@@ -17043,7 +17078,10 @@ sub pipeline_render {
 
     print_run_options();
 
-    if( $write_messages_to_csv ) {                     # If write to CSV enabled, open filehandles
+    # The MESSAGES CSV is the per-message store written out. With no message
+    # retained there are no rows and no file: a header-only CSV would look like
+    # a run that found nothing rather than one that was asked to keep nothing.
+    if( $write_messages_to_csv && $capture_messages ) {                     # If write to CSV enabled, open filehandles
         $csv = Text::CSV->new({ binary => 1, eol => $/ });                                              # Create a new CSV object
         my $csv_file_name = build_csv_filename('MESSAGES');
         open $csv_fh, '>', $csv_file_name or die "Could not open file '$csv_file_name': $!";            # Open a file for writing, then print the header/column names
@@ -17071,11 +17109,13 @@ sub pipeline_render {
         $csv->print($csv_fh, [qw(category message occurrences bytes_occurrences bytes_min bytes_mean bytes_max bytes bytes_nice count_occurrences count_min count_mean count_max count_sum duration_min duration_mean duration_max duration_std_dev duration_p1 duration_p5 duration_p10 duration_p25 duration_p50 duration_p75 duration_iqr duration_p90 duration_p95 duration_p99 duration_p999 duration_p9999 duration_p99999 duration_cv duration_skewness duration_kurtosis duration_bimodality_coef duration duration_nice impact), @udm_csv_headers]);
     }
 
-    print_message_summary();														                    # Print and write message summaries
+    print_message_summary() if $capture_messages;									                    # Print and write message summaries
     memory_debug_decomposition("after_message_summary");
-    close $csv_fh or die "Could not close file: $!" if( $write_messages_to_csv && defined $csv_fh );	# Close the file handle
+    close $csv_fh or die "Could not close file: $!" if( $write_messages_to_csv && $capture_messages && defined $csv_fh );	# Close the file handle
 
-    print_threadpool_summary() if $include_threadpool_summary;										    # Print threadpool summaries
+    # The thread-pool summary is ranked by the same top-N operand as the
+    # messages table, so a top-N of zero leaves it no rows to show.
+    print_threadpool_summary() if $include_threadpool_summary && $capture_messages;					    # Print threadpool summaries
     memory_debug_decomposition("after_threadpool_summary") if $include_threadpool_summary;
 
     # Issue #356 (S1): capture the peak across every rendered analysis section so

--- a/ltl
+++ b/ltl
@@ -57,7 +57,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0-458";
+my $version_number = "0.18.0";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );

--- a/tests/baseline/compare-results.sh
+++ b/tests/baseline/compare-results.sh
@@ -762,6 +762,7 @@ TABLE_AWK_COMMON='
 
         ns = 0
         scenarios[++ns] = "standard"
+        scenarios[++ns] = "no-messages"
         scenarios[++ns] = "top25"
         scenarios[++ns] = "top25-consolidate"
         scenarios[++ns] = "heatmap"
@@ -772,14 +773,15 @@ TABLE_AWK_COMMON='
         scenarios[++ns] = "sort-skewness"
 
         slabel[1] = "standard"
-        slabel[2] = "top25"
-        slabel[3] = "top25-cons"
-        slabel[4] = "heatmap"
-        slabel[5] = "histogram"
-        slabel[6] = "hm+hg"
-        slabel[7] = "hm+hg+cons"
-        slabel[8] = "sort-p99"
-        slabel[9] = "sort-skew"
+        slabel[2] = "no-msgs"
+        slabel[3] = "top25"
+        slabel[4] = "top25-cons"
+        slabel[5] = "heatmap"
+        slabel[6] = "histogram"
+        slabel[7] = "hm+hg"
+        slabel[8] = "hm+hg+cons"
+        slabel[9] = "sort-p99"
+        slabel[10] = "sort-skew"
     }
 
     NR == FNR && FNR == 1 { next }

--- a/tests/baseline/run-benchmark.sh
+++ b/tests/baseline/run-benchmark.sh
@@ -88,6 +88,10 @@ FILE_SELECTIONS+=("month-many-servers-access-logs|xl|7.6 GB, 140 files|AccessLog
 declare -a SCENARIOS=()
 
 SCENARIOS+=("standard|")
+# The counterpart of every retaining scenario: no message is kept, so the peak
+# and the parse-stage cost read without the per-message store. Compared against
+# `standard` on the same file selection.
+SCENARIOS+=("no-messages|-n 0")
 SCENARIOS+=("top25|-n 25")
 SCENARIOS+=("top25-consolidate|-n 25 -g")
 SCENARIOS+=("heatmap|-hm")

--- a/tests/baseline/run-benchmark.sh
+++ b/tests/baseline/run-benchmark.sh
@@ -10,7 +10,7 @@
 #   all   — all file selections x all scenarios
 #   <name> — run a single named test case (e.g. "twx-unique-errors-standard")
 #
-# Test cases are the cross-product of 7 file selections x 7 option scenarios = 49 total.
+# Test cases are the cross-product of 7 file selections x 10 option scenarios = 70 total.
 #
 # Issue #56: Memory Baseline Profiling
 

--- a/tests/validate-statistics-demand.sh
+++ b/tests/validate-statistics-demand.sh
@@ -4,7 +4,7 @@
 # per-store moment source, and the per-store statistics-calculation counters
 # (stats_calls invocations plus per-group computed/skipped_demand/ineligible)
 # (Issues #305, #303), and the resolution when the run retains no message at
-# all (-n 0, Issue #458).
+# all (-n 0, or any non-positive count, Issue #458).
 # Usage: ./tests/validate-statistics-demand.sh
 #
 # Follows the self-documenting assertion design from tests/HARNESS-DESIGN.md
@@ -687,6 +687,29 @@ if body=$(extract_section "$out"); then
         pattern     '^sort_gate: operand=p50 family=duration observed=n/a fallback=none$' \
         asserts     'A ranking request is recorded as given but never falls back, because with no message retained there is nothing to rank and no fallback to report' \
         produced_by 'apply_parse_time_sort_gate() / apply_pre_walk_sort_gate() / apply_post_walk_sort_gate() in ltl' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+# A negative top-message count takes the same path as zero: it cannot rank a
+# row either, so nothing is retained. Read from the demand section alone —
+# nothing here depends on the render or on the bucket axis.
+current_scenario="scenario-11-negative-top-messages-retains-nothing"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand -n -5)
+check_capture_warnings "$out"
+if body=$(extract_section "$out"); then
+    sm=$(extract_store "$body" message)
+    assert_line "$sm" \
+        pattern     '^  store_demand: 0$' \
+        asserts     'A negative top-message count retains nothing, exactly as zero does: the message store has no active consumer' \
+        produced_by 'adapt_to_command_line_options() in ltl (retention resolved from the top-message count being greater than zero)' \
+        contract    "$CONTRACT"
+    assert_line "$sm" \
+        pattern     '^  population: 0$' \
+        asserts     'No message key is walked under a negative top-message count, because none was ever stored' \
+        produced_by 'calculate_all_statistics() in ltl ($stats_population_messages, per-category population accumulation)' \
         contract    "$CONTRACT"
 fi
 echo

--- a/tests/validate-statistics-demand.sh
+++ b/tests/validate-statistics-demand.sh
@@ -715,6 +715,39 @@ fi
 echo
 
 ############################################################
+# A CSV request under -n 0 is half-served: the STATS CSV is written, the
+# MESSAGES CSV is not, and the user is told so at run time. The run gets its
+# own scratch directory so the two file assertions see only its own artifacts
+# (scenario 2 also writes CSVs into the shared workdir). `-bs 1440 -oe`: this
+# scenario reads a stderr notice and which files exist, never a bucket row.
+current_scenario="scenario-12-no-message-retention-csv-request"
+echo "--- $current_scenario ---"
+CSV_ONLY_DIR="$WORKDIR/csv-no-message-retention"
+mkdir -p "$CSV_ONLY_DIR"
+cd "$CSV_ONLY_DIR"
+out=$(run_section statistics-demand -bs 1440 -oe -n 0 -o)
+cd "$WORKDIR"
+check_capture_warnings "$out"
+assert_line "$out.stderr" \
+    pattern     'Note: -n/--top-messages 0 retains no message, so -o/--output-csv writes the STATS CSV only: no MESSAGES CSV is written' \
+    asserts     'A CSV request is reported as half-served when no message is retained: the user is told at run time which of the two files is not written and why' \
+    produced_by 'adapt_to_command_line_options() in ltl (per-message retention fold, before the statistics-demand resolution)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+assert_command \
+    command     "ls '$CSV_ONLY_DIR'/*-LTL-STATS-*.csv" \
+    label       'the STATS CSV is still written' \
+    asserts     'Retaining no message does not affect the per-time-bucket CSV: -o still writes it' \
+    produced_by 'pipeline_render() in ltl (STATS CSV open, gated only on the CSV request)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+assert_command \
+    command     "! ls '$CSV_ONLY_DIR'/*-LTL-MESSAGES-*.csv" \
+    label       'no MESSAGES CSV file is created' \
+    asserts     'The MESSAGES CSV is the per-message store written out: with nothing retained no file is created, not even a header-only one' \
+    produced_by 'pipeline_render() in ltl (MESSAGES CSV open gated on message retention)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+echo
+
+############################################################
 echo "=== validate-statistics-demand: $pass passed, $fail failed ==="
 if [[ $fail -gt 0 ]]; then
     echo "Failures:"

--- a/tests/validate-statistics-demand.sh
+++ b/tests/validate-statistics-demand.sh
@@ -3,7 +3,8 @@
 # per-store statistics-group demand resolution with raising consumers, the
 # per-store moment source, and the per-store statistics-calculation counters
 # (stats_calls invocations plus per-group computed/skipped_demand/ineligible)
-# (Issues #305, #303).
+# (Issues #305, #303), and the resolution when the run retains no message at
+# all (-n 0, Issue #458).
 # Usage: ./tests/validate-statistics-demand.sh
 #
 # Follows the self-documenting assertion design from tests/HARNESS-DESIGN.md
@@ -590,6 +591,102 @@ if body=$(extract_section "$out"); then
         label       'message store_demand agrees with runtime-config message-duration-stats-demand' \
         asserts     'The statistics-demand store_demand line and the runtime-config message-duration-stats-demand boolean report the same resolved value (single resolution surface)' \
         produced_by 'emit_statistics_demand_verbose() and emit_runtime_config_verbose() in ltl, both reading $message_duration_stats_demand' \
+        contract    "$CONTRACT"
+fi
+echo
+
+############################################################
+# -n 0 retains no message at all, so the message store has no consumer, no
+# population and no rendered table — while the bucket store and the timeline
+# are untouched. The demand side is read from the statistics-demand section
+# and the store size from benchmark-data's COUNTS rows; the two render
+# assertions read the displayed surface itself, because "the messages table is
+# absent" and "the timeline is present" are properties of that surface with no
+# internal-state equivalent (tests/HARNESS-DESIGN.md section Render-invariant
+# harnesses). The layout is pinned by run_section's --terminal-width 200 and
+# ANSI is stripped before matching.
+current_scenario="scenario-9-no-message-retention"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand,benchmark-data -n 0)
+check_capture_warnings "$out"
+sed -E 's/\x1b\[[0-9;]*m//g' "$out" > "$out.plain"
+if body=$(extract_section "$out"); then
+    sm=$(extract_store "$body" message)
+    assert_line "$sm" \
+        pattern     '^  store_demand: 0$' \
+        asserts     'With no message retained the message store has no active consumer, so its store demand is 0' \
+        produced_by 'adapt_to_command_line_options() in ltl (store-level demand resolution gated on $capture_messages)' \
+        contract    "$CONTRACT"
+    assert_line "$sm" \
+        pattern     '^  population: 0$' \
+        asserts     'No message key is walked because none was ever stored: the message store block-boundary population is 0' \
+        produced_by 'calculate_all_statistics() in ltl ($stats_population_messages, per-category population accumulation)' \
+        contract    "$CONTRACT"
+    for group in terminal_core csv_body extended_percentiles shape_moments; do
+        assert_line "$sm" \
+            pattern     "^  group $group: demanded=0 consumers=-\$" \
+            asserts     "With the message store undemanded no group can be demanded on it ($group)" \
+            produced_by 'resolve_statistics_group_demand() in ltl (store-level demand is a precondition for every consumer)' \
+            contract    "$CONTRACT"
+    done
+    assert_line "$sm" \
+        pattern     '^  stats_calls: 0$' \
+        asserts     'The per-message statistics primitive is never invoked when no message is retained' \
+        produced_by 'calculate_statistics() / calculate_statistics_bin() in ltl (stats_calls in %stats_demand_telemetry)' \
+        contract    "$CONTRACT"
+    sb=$(extract_store "$body" bucket)
+    assert_line "$sb" \
+        pattern     '^  store_demand: 1$' \
+        asserts     'Retaining no message leaves the per-time-bucket store untouched: the timeline latency column still consumes it' \
+        produced_by 'adapt_to_command_line_options() in ltl (store-level demand resolution)' \
+        contract    "$CONTRACT"
+fi
+assert_line "$out" \
+    pattern     '^COUNTS[[:space:]]+log_messages_entries[[:space:]]+0$' \
+    asserts     'No log message is added to the per-message store, so it holds zero entries at the end of the run' \
+    produced_by 'emit_benchmark_data_verbose() in ltl (COUNTS rows over %log_messages)' \
+    contract    'tests/HARNESS-DESIGN.md section Reserved section names — benchmark-data COUNTS rows are stability-contracted; renames are breaking'
+assert_line "$out" \
+    pattern     '^COUNTS[[:space:]]+log_messages_population[[:space:]]+0$' \
+    asserts     'The walk-time message population re-emitted into benchmark-data agrees with the statistics-demand population line (one source, two surfaces)' \
+    produced_by 'emit_benchmark_data_verbose() in ltl (re-emitted $stats_population_messages)' \
+    contract    'tests/HARNESS-DESIGN.md section Counters serving benchmark attribution — one source, two surfaces'
+assert_command \
+    command     "! grep -qE 'TOP (OVERALL|HIGHLIGHTED) MESSAGES' '$out.plain'" \
+    label       'neither messages-table header is rendered' \
+    asserts     'The message summary table is skipped entirely - not printed empty, and not printed with a header only' \
+    produced_by 'pipeline_render() in ltl (print_message_summary is not called when no message is retained)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+assert_line "$out.plain" \
+    pattern     '^[[:space:]]+timestamp[[:space:]]+legend[[:space:]]+occurrences[[:space:]]' \
+    asserts     'The timeline bar graph is still produced when no message is retained' \
+    produced_by 'print_bar_graph() in ltl (column header row)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+assert_line "$out.plain" \
+    pattern     'P50:[0-9]+' \
+    asserts     'Statistics over the whole population are still computed and displayed: the timeline latency column carries its percentiles' \
+    produced_by 'print_bar_graph() in ltl (latency statistics column, fed by the per-time-bucket store)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+echo
+
+############################################################
+# The options that configure only the per-message store are ignored rather than
+# rejected, and the tool says so on stderr. The notice is a behavioural notice,
+# not progress output, so it is emitted whatever --disable-progress is set to.
+current_scenario="scenario-10-no-message-retention-inert-options"
+echo "--- $current_scenario ---"
+out=$(run_section statistics-demand -n 0 -g 85 -mdm bin -so p50)
+check_capture_warnings "$out"
+assert_line "$out.stderr" \
+    pattern     'Note: -n/--top-messages 0 retains no message, so .*-g/--group-similar.*-mdm/--message-stats-data-model.*-so/--sort-on have no effect' \
+    asserts     'Message grouping, the message statistics data model and the message ranking are reported inert (not rejected) when no message is retained, naming each option the user passed' \
+    produced_by 'adapt_to_command_line_options() in ltl (per-message retention fold, before the statistics-demand resolution)' \
+    contract    'features/458-top-messages-zero-no-per-message-retention.md section Decisions'
+if body=$(extract_section "$out"); then
+    assert_line "$body" \
+        pattern     '^sort_gate: operand=p50 family=duration observed=n/a fallback=none$' \
+        asserts     'A ranking request is recorded as given but never falls back, because with no message retained there is nothing to rank and no fallback to report' \
+        produced_by 'apply_parse_time_sort_gate() / apply_pre_walk_sort_gate() / apply_post_walk_sort_gate() in ltl' \
         contract    "$CONTRACT"
 fi
 echo


### PR DESCRIPTION
Closes #458.

- `-n 0` is accepted: no log message is added to the per-message store, no per-message statistics are computed, and the top-messages table is skipped; the timeline and population-level statistics are still produced. Include/exclude filtering still applies.
- `-g`, `-mdm` and `-so` are reported inert under `-n 0` in a run-time notice; with `-o`, the notice also says the MESSAGES CSV is not written (the STATS CSV still is). The thread-pool summary (`-tpas`) ranks by the same `-n` operand and is likewise skipped.
- `no-messages|-n 0` scenario added to `tests/baseline/run-benchmark.sh` for the release-stage suite. `--help` and `docs/usage.md` document 0. Owning harness `tests/validate-statistics-demand.sh` gains the `-n 0` scenario (95 assertions).

Completion gate on `5928714`: 28/28 harnesses pass (1,175 checks). No benchmark (architect ruling). Dev-scale `-n 25` vs `-n 0` memory/runtime measurement recorded in `features/458-top-messages-zero-no-per-message-retention.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYhJaBPqtoqLVfKUeRsrNE