### PR TITLE
Assert what the tool renders, not which escapes it emitted

### DIFF
--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -6,6 +6,50 @@ If you are adding a new harness, modifying an existing one, or changing any `-V`
 
 This document covers **how a harness is built**, once you know what it must assert. What it must assert comes from the feature's acceptance criteria, which are derived from its requirements and agreed *before* implementation — see [`docs/test-driven-development.md`](../docs/test-driven-development.md). Where a criterion's verification method is not yet known, determining it is prototyping scope, not something to settle while writing the harness: [`prototype/README.md`](../prototype/README.md).
 
+## Asserting rendered output
+
+Two libraries assert what the tool **renders**, rather than which escape
+sequence it emitted: `tests/lib/rendered-output.sh` (harness-facing) and
+`tests/lib/rendered-output.pl` (the decoder it drives).
+
+**Why raw-escape assertions are not enough.** A `grep -q 'ESC\[48;5;196m'`
+confirms only that some code was emitted somewhere on the line. It cannot say
+which cell carries an attribute, what the combination of foreground and
+background on one cell is, how two rows compare, or that an attribute is absent.
+And it is written *from the implementation*: under #448 a bar built from the
+wrong colour vocabulary was asserted with the codes that vocabulary emits, and
+23 assertions passed against five simultaneous defects.
+
+**The unit is a cell.** `decode_line()` returns one record per displayed
+character carrying its resolved foreground and background, so a predicate can
+state the requirement: `bar_inverts()` (inside the fill the colour is the
+background and the text is black; outside it the colour is the foreground and
+there is no background), `fill_extent()`, `fill_colour()`, `text_colour()`.
+
+**No line may exceed the terminal width.** The output model rests on known
+character placement, so a line that soft-wraps displaces every line below it and
+every column with them — a rendering failure whatever the content says.
+`assert_no_soft_wrap` checks the whole capture, because a wrap anywhere in a run
+displaces the surface a harness is asserting. It applies from the minimum
+supported width upward (`MIN_SUPPORTED_WIDTH`, one value in the library;
+`features/column-layout-refactor.md` § *Minimum supported terminal width*).
+
+**Known failures are registered, never tolerated.**
+`tests/rendered-output/soft-wrap-known-failures.tsv` suppresses the block for a
+scenario whose overflow is a filed, open defect. The check still runs, the
+overflow is still measured, and the offending lines are still printed — as
+XFAIL with its issue number. A registered scenario that *stops* overflowing is
+reported as XPASS, so a fix cannot land silently and leave a stale entry.
+Adding an entry requires a filed issue.
+
+**Three traps, each of which produced a wrong answer while this was built:**
+decode UTF-8 before measuring (the box-drawing rules are multi-byte, and
+counting bytes reports a 160-column rule as 480); `38;5;0` is a black
+foreground, not a reset, so SGR parameters are read as whole values rather than
+by a regex that matches a trailing `;0`; and a row is sliced to its own width
+before decoding, because the summary table shares its physical line with the
+file-details pane.
+
 ## Why this exists
 
 Test harnesses make assertions against application output. When the application output and the harness drift apart silently — a section gets renamed, a key gets removed, a format changes — three things happen:

--- a/tests/lib/rendered-output.pl
+++ b/tests/lib/rendered-output.pl
@@ -1,0 +1,170 @@
+#!/usr/bin/env perl
+# rendered-output.pl — decode a rendered terminal line into the cells a terminal
+# would actually display, so a harness can assert what the READER SEES rather
+# than which escape sequence was emitted
+# (tests/HARNESS-DESIGN.md § Asserting rendered output).
+#
+# Why this exists. A harness that greps the raw output for an escape sequence
+# confirms only that some code was emitted somewhere on the line. It cannot say
+# WHICH cell carries an attribute, what the COMBINATION of foreground and
+# background on one cell is, how two rows COMPARE, or that an attribute is
+# ABSENT. Worse, such a grep is written from the implementation: when a bar was
+# built from the wrong colour vocabulary under #448, assertions were written for
+# the codes that vocabulary emits and they passed — 23 of them, against five
+# simultaneous defects. Decoding to cells makes the assertion a statement of the
+# requirement instead.
+#
+# Public functions:
+#   decode_line($line)                -> arrayref of { ch, fg, bg } per cell
+#   display_width($line)              -> printable columns (escapes are 0-width)
+#   fill_extent($cells)               -> cells carrying a background
+#   fill_colour($cells)               -> the single fill colour, 'none', or MIXED:
+#   text_colour($cells)               -> colours of unfilled, non-blank cells
+#   bar_inverts($cells)               -> (violations, filled, plain)
+#   row_text($cells)                  -> the characters, escapes removed
+#   slice_row($cells, $width)         -> the first $width cells (row isolation)
+#
+# Attribute vocabulary: 'default', "ansi:<code>" (30-37/90-97 fg, 40-47/100-107
+# bg), "256:<n>" for 38;5;n / 48;5;n, and 'reverse' for SGR 7.
+#
+# TRAPS, each of which produced a wrong answer while this was written:
+#   - Decode UTF-8 BEFORE measuring. The box-drawing rules are multi-byte;
+#     counting bytes reports a 160-column rule as 480 and manufactures failures
+#     that do not exist.
+#   - 38;5;0 is a 256-colour BLACK FOREGROUND, not a reset. Reading SGR
+#     parameters with a regex that matches a trailing ";0" treats every bar
+#     fill's black text as a reset and measures a full-width bar as zero.
+#     Parameters are read as whole values, longest first.
+#   - Isolate the row before decoding. The file-details pane is printed on the
+#     same physical line as the summary table; decoding the whole line pulls its
+#     colours into the row's attribute set and reports phantom violations.
+#
+# This file is meant to be require'd by a Perl helper, not executed directly.
+
+use strict;
+use warnings;
+
+# Decode one rendered line into per-cell records. The caller must already have
+# decoded UTF-8 (open the capture with '<:encoding(UTF-8)').
+sub decode_line {
+    my ($line) = @_;
+    my @cells;
+    my ($fg, $bg) = ('default', 'default');
+
+    while ($line =~ /\G(\e\[([0-9;]*)m|\e\][^\a]*\a|\e\[[0-9;]*[A-Za-z]|.)/gs) {
+        my ($tok, $sgr) = ($1, $2);
+
+        if (defined $sgr) {
+            my @params = split /;/, $sgr, -1;
+            @params = ('0') unless grep { $_ ne '' } @params;
+            my $i = 0;
+            while ($i <= $#params) {
+                my $p = $params[$i];
+                # A 256-colour triplet carries its own digits: consume all three
+                # so its final value is never read as a standalone parameter.
+                if ( ($p eq '38' || $p eq '48') && ( $params[$i+1] // '' ) eq '5' ) {
+                    my $v = $params[$i+2] // '';
+                    $p eq '38' ? ( $fg = "256:$v" ) : ( $bg = "256:$v" );
+                    $i += 3;
+                    next;
+                }
+                if    ( $p eq '0' || $p eq '' ) { ( $fg, $bg ) = ( 'default', 'default' ) }
+                elsif ( $p eq '39' )            { $fg = 'default' }
+                elsif ( $p eq '49' )            { $bg = 'default' }
+                elsif ( $p eq '7' )             { ( $fg, $bg ) = ( 'reverse', 'reverse' ) }
+                elsif ( $p =~ /^(?:3[0-7]|9[0-7])$/ )   { $fg = "ansi:$p" }
+                elsif ( $p =~ /^(?:4[0-7]|10[0-7])$/ )  { $bg = "ansi:$p" }
+                $i++;
+            }
+            next;
+        }
+
+        next if $tok =~ /\A\e/;              # a non-SGR escape: no cell
+        next if $tok eq "\r" || $tok eq "\n";
+        next if ord($tok) < 32;              # C0 controls occupy no column
+        push @cells, { ch => $tok, fg => $fg, bg => $bg };
+    }
+    return \@cells;
+}
+
+# Printable columns the line occupies. This is what a terminal compares against
+# its width to decide whether to soft-wrap.
+sub display_width {
+    my ($line) = @_;
+    return scalar @{ decode_line($line) };
+}
+
+# The characters of a decoded row, escapes and controls already removed.
+sub row_text {
+    my ($cells) = @_;
+    return join '', map { $_->{ch} } @$cells;
+}
+
+# The first $width cells. The summary table shares its physical line with the
+# file-details pane, so a row is sliced to its own budget before it is judged.
+sub slice_row {
+    my ($cells, $width) = @_;
+    return $cells if @$cells <= $width;
+    return [ @{$cells}[ 0 .. $width - 1 ] ];
+}
+
+# How many cells the bar covers.
+sub fill_extent {
+    my ($cells) = @_;
+    return scalar grep { $_->{bg} ne 'default' } @$cells;
+}
+
+# The fill colour: one value, 'none' when nothing is filled, or 'MIXED:a,b' when
+# the fill is not uniform — which is itself a defect worth naming.
+sub fill_colour {
+    my ($cells) = @_;
+    my %seen = map { $_->{bg} => 1 } grep { $_->{bg} ne 'default' } @$cells;
+    my @k = sort keys %seen;
+    return 'none'   if @k == 0;
+    return $k[0]    if @k == 1;
+    return 'MIXED:' . join( ',', @k );
+}
+
+# The colour of the row's text where it is NOT filled. 'none' means the row is
+# rendering in the terminal's default — which for a category row is the #448
+# defect where a row with no bar lost its colour entirely.
+sub text_colour {
+    my ($cells) = @_;
+    my %seen = map { $_->{fg} => 1 }
+               grep { $_->{bg} eq 'default' && $_->{ch} ne ' ' } @$cells;
+    my @k = sort grep { $_ ne 'default' } keys %seen;
+    return @k ? join( ',', @k ) : 'none';
+}
+
+# "The bar inverts": inside the fill the colour is the BACKGROUND and the text
+# is black; outside it the colour is the FOREGROUND and there is no background.
+# Never a foreground and a background colour at once — that inversion is what
+# keeps the row legible on a dark terminal and on a light one, because the
+# terminal supplies the surrounding foreground either way.
+#
+# Returns (arrayref of violation strings, filled cells, plain cells).
+sub bar_inverts {
+    my ($cells) = @_;
+    my @violations;
+    my ( $filled, $plain ) = ( 0, 0 );
+
+    for my $i ( 0 .. $#$cells ) {
+        my $c = $cells->[$i];
+        next if $c->{ch} eq ' ' && $c->{bg} eq 'default';   # padding
+
+        if ( $c->{bg} ne 'default' ) {
+            $filled++;
+            push @violations,
+                "col $i: filled cell carries $c->{fg} text, expected black (256:0)"
+                unless $c->{fg} eq '256:0' || $c->{fg} eq 'reverse';
+        }
+        else {
+            $plain++;
+            push @violations, "col $i: unfilled cell has no colour of its own"
+                if $c->{fg} eq 'default';
+        }
+    }
+    return ( \@violations, $filled, $plain );
+}
+
+1;

--- a/tests/lib/rendered-output.sh
+++ b/tests/lib/rendered-output.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# rendered-output.sh — shared assertions over what the tool RENDERS, for test
+# harnesses (tests/HARNESS-DESIGN.md § Asserting rendered output).
+#
+# Two classes of check live here, both reading the decoded output rather than
+# the escape sequences that produced it:
+#
+#   1. Soft wrapping. The tool's output model rests on known character
+#      placement — columns line up down a table, bars are proportional across
+#      rows, the timeline aligns with its axis. A line longer than the terminal
+#      wraps onto the next row and displaces everything below it, so it is a
+#      rendering failure whatever the content says. This applies to EVERY line
+#      the tool prints, not only the surface a feature happens to touch.
+#
+#   2. Row attributes. What colour a cell carries, how far a bar extends,
+#      whether a fill inverts. Asserting these on raw escapes confirms only
+#      that some code was emitted; #448 shipped five simultaneous defects past
+#      23 such assertions.
+#
+# The minimum supported terminal width is 100 columns
+# (features/column-layout-refactor.md § Minimum supported terminal width).
+# Below it, rendering is not undertaken to be correct.
+#
+# Public functions:
+#   assert_no_soft_wrap CAPTURE WIDTH CONTEXT_LABEL
+#       Every line in CAPTURE fits WIDTH columns. Prints the self-documenting
+#       failure block and returns 1 otherwise.
+#   soft_wrap_known_failure SCENARIO
+#       Echoes the issue number for a registered known failure, else nothing.
+#   render_row_report CAPTURE LABEL ROW_WIDTH
+#       Echoes "extent=N fill=X text=Y width=W violations=..." for the row whose
+#       label matches, sliced to ROW_WIDTH. Non-zero when the row is not found.
+#
+# This file is meant to be sourced, not executed directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "rendered-output.sh is a library; source it, do not execute it" >&2
+    exit 2
+fi
+
+# The narrowest terminal the tool undertakes to render correctly. One value,
+# here, so a harness never restates it: raising or lowering the floor is a
+# single edit (features/column-layout-refactor.md section Minimum supported
+# terminal width).
+: "${MIN_SUPPORTED_WIDTH:=100}"
+
+: "${PERL:=perl}"
+_RENDERED_OUTPUT_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/rendered-output.pl"
+
+# assert_no_soft_wrap CAPTURE WIDTH CONTEXT_LABEL
+#
+# The check runs over the WHOLE capture: a harness asserting one surface still
+# fails if any other line of that run would wrap, because the wrap displaces the
+# surface being asserted.
+assert_no_soft_wrap() {
+    local capture="$1" width="$2" context="$3"
+    local report
+
+    if [[ ! -f "$capture" ]]; then
+        echo "  FAIL  $context :: soft-wrap check found no capture at $capture" >&2
+        return 1
+    fi
+
+    report=$("$PERL" -e '
+        require $ARGV[0];
+        binmode(STDOUT, ":encoding(UTF-8)");
+        my ($lib, $file, $width) = @ARGV;
+        open my $fh, "<:encoding(UTF-8)", $file or die "cannot open $file: $!\n";
+        my ($n, @bad);
+        while (my $line = <$fh>) {
+            $n++;
+            my $w = display_width($line);
+            next if $w <= $width;
+            (my $plain = $line) =~ s/\e\[[0-9;]*m//g;
+            chomp $plain;
+            push @bad, sprintf("line %d is %d columns (over by %d): %s",
+                               $n, $w, $w - $width, substr($plain, 0, 60));
+        }
+        close $fh;
+        print "$_\n" for @bad;
+    ' "$_RENDERED_OUTPUT_LIB" "$capture" "$width" 2>&1)
+
+    [[ -z "$report" ]] && return 0
+
+    {
+        echo "  FAIL  $context :: output does not fit $width columns"
+        echo "        asserts:     no line the tool prints exceeds the terminal width, so the"
+        echo "                     reader can rely on character placement — a line that wraps"
+        echo "                     displaces every line below it and every column with them"
+        echo "        produced_by: the layout engine in ltl (@column_layout width allocation),"
+        echo "                     and any renderer that emits a line of its own"
+        echo "        contract:    features/column-layout-refactor.md section Minimum supported"
+        echo "                     terminal width (100 columns)"
+        while IFS= read -r _line; do printf '        %s\n' "$_line"; done <<< "$report"
+    } >&2
+    return 1
+}
+
+# soft_wrap_known_failure SCENARIO
+#
+# Echoes the issue number when SCENARIO is a registered known soft-wrap failure,
+# and nothing otherwise. The registry suppresses the block for a filed, open
+# defect; it is not a tolerance, and the check still runs and still reports what
+# overflowed. Registry: tests/rendered-output/soft-wrap-known-failures.tsv.
+soft_wrap_known_failure() {
+    local scenario="$1"
+    local registry="${SOFT_WRAP_KNOWN_FAILURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/rendered-output/soft-wrap-known-failures.tsv}"
+    [[ -f "$registry" ]] || return 0
+    # Always exits 0: "not a known failure" is the ordinary case, and a non-zero
+    # status here aborts a harness running under `set -e`.
+    awk -F'\t' -v s="$scenario" '$1 == s { print $2; exit }' "$registry"
+    return 0
+}
+
+# render_row_report CAPTURE LABEL ROW_WIDTH
+#
+# Echoes one line of decoded facts about the row, for a caller to compare
+# against what the requirement says. Row isolation is applied before decoding:
+# the summary table shares its physical line with the file-details pane.
+#
+# The label is matched exactly — anchored on the label followed by whitespace
+# and a digit — because a prefix match reads "2xx Success (HL)" when asked for
+# "2xx Success" and reports its twin's colours.
+render_row_report() {
+    local capture="$1" label="$2" row_width="$3"
+    "$PERL" -e '
+        require $ARGV[0];
+        binmode(STDOUT, ":encoding(UTF-8)");
+        my ($lib, $file, $label, $row_width) = @ARGV;
+        open my $fh, "<:encoding(UTF-8)", $file or die "cannot open $file: $!\n";
+        my @lines = <$fh>;
+        close $fh;
+        for my $line (@lines) {
+            (my $plain = $line) =~ s/\e\[[0-9;]*m//g;
+            next unless $plain =~ /^\s*\Q$label\E\s+\d/;
+            my $cells = slice_row(decode_line($line), $row_width);
+            my ($violations, undef, undef) = bar_inverts($cells);
+            printf "extent=%d fill=%s text=%s width=%d violations=%s\n",
+                fill_extent($cells), fill_colour($cells), text_colour($cells),
+                scalar(@$cells),
+                (@$violations ? join("; ", @$violations) : "none");
+            exit 0;
+        }
+        print "ROW-NOT-FOUND\n";
+        exit 1;
+    ' "$_RENDERED_OUTPUT_LIB" "$capture" "$label" "$row_width"
+}

--- a/tests/rendered-output/soft-wrap-known-failures.tsv
+++ b/tests/rendered-output/soft-wrap-known-failures.tsv
@@ -1,0 +1,18 @@
+# Known soft-wrap failures: regression scenarios whose render exceeds the
+# terminal width because of a filed, open defect in ltl — not because the check
+# is miscalibrated.
+#
+# An entry suppresses the block for exactly one scenario and is reported as
+# XFAIL, with its issue, on every run. It is NOT a tolerance: the check still
+# runs, the overflow is still measured, and the offending lines are still
+# printed. A scenario that STOPS overflowing while listed here is reported as an
+# unexpected pass, so a fix cannot land silently and leave a stale entry behind.
+#
+# Remove an entry when its issue is fixed. Adding one requires a filed issue.
+#
+# scenario<TAB>issue<TAB>surface
+heatmap-duration-w100	497	heatmap width is a fixed default added to a terminal budget that cannot hold it
+heatmap-count-w100	497	heatmap width is a fixed default added to a terminal budget that cannot hold it
+heatmap-duration-w100-bin	497	heatmap width is a fixed default added to a terminal budget that cannot hold it
+heatmap-count-w100-bin	497	heatmap width is a fixed default added to a terminal budget that cannot hold it
+errrate-diagnostics-highlighted-failure-w160	497	timeline legend grows with a highlighted category and the row is not re-fitted

--- a/tests/validate-regression.sh
+++ b/tests/validate-regression.sh
@@ -51,6 +51,8 @@ source "$SCRIPT_DIR/lib/colour-env.sh"
 neutralize_colour_env
 # shellcheck source=lib/fixtures.sh
 source "$SCRIPT_DIR/lib/fixtures.sh"
+# shellcheck source=lib/rendered-output.sh
+source "$SCRIPT_DIR/lib/rendered-output.sh"
 TMP_DIR=$(mktemp -d)
 # Cleanup is unconditional — if the script aborts mid-run (under set -e),
 # the explicit `rm -rf` at the end never runs. Per tests/HARNESS-DESIGN.md,
@@ -155,6 +157,15 @@ run_test() {
     local name="$1"
     shift
     local reffile="$REF_DIR/$name.txt"
+    # The width this scenario renders at, read from its own command line, so the
+    # soft-wrap check below judges the render against the terminal it was told
+    # it had rather than against a constant.
+    local render_width=""
+    local _a _prev=""
+    for _a in "$@"; do
+        [[ "$_prev" == "--terminal-width" ]] && render_width="$_a"
+        _prev="$_a"
+    done
     local tmpfile="$TMP_DIR/$name.txt"
     local stderrfile="$TMP_DIR/$name.stderr"
     local difffile="$TMP_DIR/$name.diff"
@@ -193,6 +204,34 @@ run_test() {
         fail=$((fail + 1))
         failures+=("$name :: perl-runtime-warnings-on-stderr")
         return
+    fi
+    # Soft-wrap cleanliness: a render that is byte-identical to its reference
+    # still fails the reader if it is wider than the terminal, because the wrap
+    # displaces every line below it. Only scenarios at or above the supported
+    # floor are judged — narrower ones are outside the rendering contract
+    # (features/column-layout-refactor.md section Minimum supported terminal width).
+    if [[ -n "$render_width" && "$render_width" -ge $MIN_SUPPORTED_WIDTH ]]; then
+        local wrap_issue
+        wrap_issue=$(soft_wrap_known_failure "$name")
+        if assert_no_soft_wrap "$tmpfile" "$render_width" "$name" 2>/dev/null; then
+            # A scenario listed as a known failure that no longer wraps is
+            # reported, not silently accepted: the fix has landed and the entry
+            # is stale.
+            if [[ -n "$wrap_issue" ]]; then
+                echo "  XPASS $name :: no longer exceeds its terminal width — remove its entry from tests/rendered-output/soft-wrap-known-failures.tsv (#$wrap_issue)"
+            fi
+        elif [[ -n "$wrap_issue" ]]; then
+            # The check still ran and printed what overflowed; the block is
+            # suppressed because the defect is filed and open.
+            local wrap_detail
+            wrap_detail=$(assert_no_soft_wrap "$tmpfile" "$render_width" "$name" 2>&1 >/dev/null || true)
+            printf '%s\n' "${wrap_detail//  FAIL /  XFAIL}" >&2
+            echo "  XFAIL $name :: exceeds its terminal width — known, #$wrap_issue"
+        else
+            fail=$((fail + 1))
+            failures+=("$name :: output exceeds its terminal width")
+            return
+        fi
     fi
     if [[ ! -s "$tmpfile" ]]; then
         emit_regression_fail "$name" "captured output is empty (regression target produced nothing; stderr below)" "$stderrfile"


### PR DESCRIPTION
The testing framework for visual output, built from the trigger-(d) research in `prototype/448-visual-assertion/`.

**The problem.** A harness that greps raw output for an escape sequence confirms only that *some* code was emitted somewhere on the line. It cannot express which cell carries an attribute, the combination of foreground and background on one cell, a comparison between two rows, or the absence of an attribute. And it is written from the implementation: under #448 a bar built from the wrong colour vocabulary was asserted with the codes that vocabulary emits, and 23 assertions passed against five simultaneous defects.

**The framework.**

- `tests/lib/rendered-output.pl` — decodes a line into one record per displayed cell with its resolved foreground and background, so predicates state the requirement rather than the encoding: `bar_inverts()` (inside the fill the colour is the background and the text is black; outside it the colour is the foreground and there is no background), `fill_extent()`, `fill_colour()`, `text_colour()`, `display_width()`, `slice_row()`.
- `tests/lib/rendered-output.sh` — the harness-facing side: `assert_no_soft_wrap`, `render_row_report`, `soft_wrap_known_failure`, and `MIN_SUPPORTED_WIDTH` as one shared value.
- `tests/rendered-output/soft-wrap-known-failures.tsv` — the registry.

**Soft wrapping is now enforced.** No line may exceed the terminal width, from the 100-column floor upward. The check runs over the whole capture, because a wrap anywhere in a run displaces the surface a harness is asserting. Wired into `validate-regression.sh` — 74 scenarios across widths 80/100/120/160 covering the default view, heatmaps and histograms — it immediately found a **third overflowing surface** I had not: the timeline row at width 160 when a highlighted category grows the legend, which is the width almost every golden is captured at.

**Known failures are registered, never tolerated.** The five known-defective scenarios report as XFAIL against #497: the check still runs, still measures the overflow, still prints the offending lines. A registered scenario that stops overflowing reports XPASS, so a fix cannot land silently and leave a stale entry. Both directions proved by sabotage — removing an entry makes that scenario fail properly; registering a clean scenario reports XPASS.

**Three traps are documented in the library headers**, each of which produced a wrong answer while this was built: decode UTF-8 before measuring (counting bytes reports a 160-column rule as 480); `38;5;0` is a black foreground, not a reset, so SGR parameters are read as whole values; and a row is sliced to its own width before decoding, since the summary table shares its line with the file-details pane.

Gate: all 30 harnesses exit 0 with assertions confirmed running — regression 74/74 with 10 XFAIL lines visible, contribution-bar 29, progress-line 21, format-detection 243, csv-output 23/23. No `ltl` change, so no benchmark.

Contract documented in `tests/HARNESS-DESIGN.md` § *Asserting rendered output*.

Co-Authored-By: Claude <noreply@anthropic.com>