### PR TITLE
A soft-wrap failure names the surface and sub that produced each line

### DIFF
--- a/tests/HARNESS-DESIGN.md
+++ b/tests/HARNESS-DESIGN.md
@@ -42,6 +42,16 @@ XFAIL with its issue number. A registered scenario that *stops* overflowing is
 reported as XPASS, so a fix cannot land silently and leave a stale entry.
 Adding an entry requires a filed issue.
 
+**A failure names its own focus area.** `assert_no_soft_wrap` classifies each
+offending line by the surface it belongs to and the sub that renders it — *"line
+19 is 154 columns (over by 54) in the timeline [print_bar_graph() in ltl]"* — and
+surfaces the capture path and the width it rendered at alongside the three
+mandatory fields. A soft-wrap failure spans surfaces with different producers, so
+a single `produced_by` naming one sub would be wrong for most of the lines
+reported; the per-line attribution is what lets the reader act without opening
+the capture or re-running anything. This is the § *Self-documenting assertions*
+rule applied to a check whose failures are not confined to one renderer.
+
 **Three traps, each of which produced a wrong answer while this was built:**
 decode UTF-8 before measuring (the box-drawing rules are multi-byte, and
 counting bytes reports a 160-column rule as 480); `38;5;0` is a black

--- a/tests/lib/rendered-output.sh
+++ b/tests/lib/rendered-output.sh
@@ -65,15 +65,32 @@ assert_no_soft_wrap() {
         binmode(STDOUT, ":encoding(UTF-8)");
         my ($lib, $file, $width) = @ARGV;
         open my $fh, "<:encoding(UTF-8)", $file or die "cannot open $file: $!\n";
+
+        # Name the surface an offending line belongs to, and the sub that
+        # renders it, so the reader is not left counting lines into a capture
+        # to find out what overflowed. The reader must be able to act on the
+        # failure without opening the capture at all
+        # (HARNESS-DESIGN.md section Self-documenting assertions).
+        my $surface = "unclassified";
+        my $producer = "the layout engine in ltl";
         my ($n, @bad);
         while (my $line = <$fh>) {
             $n++;
-            my $w = display_width($line);
-            next if $w <= $width;
             (my $plain = $line) =~ s/\e\[[0-9;]*m//g;
             chomp $plain;
-            push @bad, sprintf("line %d is %d columns (over by %d): %s",
-                               $n, $w, $w - $width, substr($plain, 0, 60));
+
+            if    ($plain =~ /,:: ltl ::. log timeline/)  { $surface = "run banner";        $producer = "the banner block in ltl (fixed width, does not read --terminal-width)" }
+            elsif ($plain =~ /^\s*timestamp\s+legend/)    { $surface = "timeline";          $producer = "print_bar_graph() in ltl" }
+            elsif ($plain =~ /^command-line options:/)    { $surface = "run options echo";  $producer = "print_run_options() in ltl" }
+            elsif ($plain =~ /TOP (OVERALL|HIGHLIGHTED) MESSAGES/) { $surface = "messages table"; $producer = "print_message_summary() in ltl" }
+            elsif ($plain =~ /^\s*Category\s+Total/)      { $surface = "run summary";       $producer = "print_summary_table() in ltl" }
+            elsif ($plain =~ /^\s*THREADPOOLS/)           { $surface = "threadpool table";  $producer = "print_summary_table() in ltl" }
+
+            my $w = display_width($line);
+            next if $w <= $width;
+            push @bad, sprintf("line %d is %d columns (over by %d) in the %s [%s]: %s",
+                               $n, $w, $w - $width, $surface, $producer,
+                               substr($plain, 0, 52));
         }
         close $fh;
         print "$_\n" for @bad;
@@ -86,10 +103,13 @@ assert_no_soft_wrap() {
         echo "        asserts:     no line the tool prints exceeds the terminal width, so the"
         echo "                     reader can rely on character placement — a line that wraps"
         echo "                     displaces every line below it and every column with them"
-        echo "        produced_by: the layout engine in ltl (@column_layout width allocation),"
-        echo "                     and any renderer that emits a line of its own"
+        echo "        produced_by: the surface and its rendering sub are named per offending"
+        echo "                     line below; width is allocated by the layout engine in ltl"
+        echo "                     (@column_layout)"
         echo "        contract:    features/column-layout-refactor.md section Minimum supported"
         echo "                     terminal width (100 columns)"
+        echo "        capture:     $capture"
+        echo "        rendered at: --terminal-width $width"
         while IFS= read -r _line; do printf '        %s\n' "$_line"; done <<< "$report"
     } >&2
     return 1


### PR DESCRIPTION
Answers the question "does the failure report exactly what failed, without re-running or investigating?" — asked of the framework merged in #499. It partly did; this closes the gaps.

**What was already right:** the three mandatory fields (`asserts` / `produced_by` / `contract`) were surfaced, along with each offending line, its width and its overage.

**Three gaps against `HARNESS-DESIGN.md` § *Self-documenting assertions*:**

1. `produced_by` named a category — *"the layout engine in ltl, and any renderer that emits a line of its own"* — where the rule requires a function name. A soft-wrap failure spans surfaces with different producers, so a single `produced_by` is wrong for most of the lines it reports.
2. The reader could not tell which surface an offending line belonged to without counting into the capture.
3. The capture path was not surfaced, though the rule requires it.

**Now:** each offending line names its own surface and rendering sub, and the block carries the capture path and the width it rendered at.

```
XFAIL heatmap-duration-w100 :: output does not fit 100 columns
      asserts:     no line the tool prints exceeds the terminal width, so the
                   reader can rely on character placement — a line that wraps
                   displaces every line below it and every column with them
      produced_by: the surface and its rendering sub are named per offending
                   line below; width is allocated by the layout engine in ltl
      contract:    features/column-layout-refactor.md section Minimum supported
                   terminal width (100 columns)
      capture:     /tmp/.../heatmap-duration-w100.txt
      rendered at: --terminal-width 100
      line 19 is 154 columns (over by 54) in the timeline [print_bar_graph() in ltl]: ────
      line 21 is 104 columns (over by 4) in the run options echo [print_run_options() in ltl]: command-line options: ...
```

**It corrected an attribution of mine immediately.** I had reported the width-100 overflow as the heatmap. It is the **timeline's closing rule**, drawn at heatmap width while the header and data rows above it fit at exactly 100 — and the **echoed run options** are a fourth overflowing surface I had not identified. Both recorded on #497, which now lists four surfaces with their rendering subs rather than the two I had.

Gate: all 30 harnesses exit 0, regression 74/74. No `ltl` change, so no benchmark.

Co-Authored-By: Claude <noreply@anthropic.com>