### PR TITLE
#446: pad every progress frame to the row width

### DIFF
--- a/features/446-overall-progress-indicator.md
+++ b/features/446-overall-progress-indicator.md
@@ -12,7 +12,9 @@ The progress line reports the file in flight — its line count and, since #397 
 ## Status
 
 Scoped 2026-08-29; decisions D1–D7 locked. Implemented 2026-08-29 on
-`446-overall-progress-indicator`, all seven decisions as written.
+`446-overall-progress-indicator`, all seven decisions as written. D8 added
+2026-08-31 on `446-overall-progress-indicator-2` for the shrinking-frame defect
+(below).
 
 ## Research
 
@@ -54,6 +56,8 @@ Reading: file percentage over overall percentage; `line` is the position in the 
 
 **D6 — Suppression is `--disable-progress` only.** The indicator is a progress surface; it rides the existing gate and gets no option of its own.
 
+**D8 — Every frame is written at the full row width.** A carriage return moves the cursor without erasing, so a frame shorter than the one already on screen leaves its predecessor's tail standing beside it — the run reports `...2025-05-07.txtxt` (defect below). Each frame is therefore padded with spaces to `terminal_width - 1`, the same width the between-file clear writes, so painting a frame covers whatever the last one left. Nothing about the previous frame is remembered, so no format transition, rounding step or skipped file can put the row and the tracker out of step; and nothing flickers, because text overwrites text in the same write and the blanks only ever cover the tail — the row is never blanked and repainted. `progress_line_text()` already fits the line inside that width, so the pad cannot go negative.
+
 **D7 — No prototype.** No new data model; the per-line cost is one modulo check, which the existing tick already pays. The gate is time-based, so the change touches the hot path: the before/after benchmark (per-feature step 1b) is mandatory and is the instrument for D4's check cadence.
 
 ## In-drop obligations
@@ -79,6 +83,18 @@ The size sweep is `size_selected_files_for_progress()`, called from the end of `
 **Why the harness did not catch the collision.** `tests/validate-progress-line.sh` runs with the progress line on — that is its subject — but every scenario pinned the format with `-lf`, which keeps the run deterministic *and* suppresses the unit-ambiguity note, the only notice this fixture can raise. It also captured stdout and stderr to separate files. Both choices are right for asserting the line's shape and wrong for asserting that nothing writes over it: the collision exists only when a mid-read notice is raised and the two streams share a row. The `notice-not-in-progress-row` scenario closes it — no `-lf`, streams interleaved — with an anchor asserting the notice is actually raised, so the scenario fails rather than passes silently if a future format change makes this fixture unambiguous. The general lesson for this surface: a scenario that pins away the conditions that make a run interesting can only assert the quiet path.
 
 **Defect found by audit (2026-08-30): an empty file collapsed the line to one percentage.** The file percentage guards its division on `$file_size > 0`, which is right, but the guard also skipped the figure entirely — and the line's assembly then fell through to the single-file shape. A zero-byte file in a multi-file run rendered `Processing 50% (file 2/3)`, where the lone figure is the *overall* percentage occupying the slot the *file* percentage holds in every other frame, with nothing to tell the reader which one it is. The counter still advanced, so the run read as though that file were half-way through itself. A file with nothing in it has been read in full the moment it is opened, so it now reports 0: `Processing 0%/50% (file 2/3)`. The single-file forms are unchanged, and a single empty file still shows `Processing 0%` with no division. Covered by the `empty-file-keeps-both-percentages` scenario, both assertions sabotage-proved.
+
+**Defect found in use (2026-08-31): a shrinking frame left its predecessor's tail on screen.** The line shrinks routinely between repaints inside one file — the rate falls from `68.9k` to `71k`, the line count from `278.5k` to `279k` — and the paint was a bare `\r` plus the text, which erases nothing. Replaying the raw stdout of a run over the 762k-line single-day access log through a terminal (carriage returns moving the cursor, writes overwriting) shows 4 of its 22 frames leaving `xt` from the filename visible past their own end. Between *files* the defect does not appear: the read loop already blanks the whole row when a file closes, which is why a long-name-then-short-name run reproduces nothing. Fixed by D8; `paint_progress_line()` is now the one place a frame reaches the terminal, and both paint sites call it.
+
+**Acceptance criteria for the fix** (assertable, `tests/validate-progress-line.sh`):
+
+| Criterion | Observable | Method |
+|---|---|---|
+| A frame never leaves part of an older frame visible | Replaying a run's raw stdout through a terminal shows each frame alone on the row | `progress-row-check.py residue` over the multi-file capture |
+| Every painted frame fills the row | Each frame is exactly `terminal_width - 1` columns, at 140 and at 60 | `progress-row-check.py width` over the multi-file and narrow captures |
+| The erase costs no flicker | No frame is preceded by a blanking of the row it is about to occupy | Property of D8: the padding is part of the frame's own write |
+
+All three were proved to fail before they were trusted to pass (HARNESS-DESIGN.md § Proving a new assertion can fail): the width check fails on the pre-fix code against the committed fixture, the residue check fails on the pre-fix capture of the real access log with the `xt` diagnostic, and both fail on a capture containing no frame. Proving them also exposed a false pass in the checker itself — Python's text mode translates a lone carriage return to a line feed, so the row appeared to start empty for every frame; it reads bytes and decodes.
 
 ### Findings
 

--- a/ltl
+++ b/ltl
@@ -10130,6 +10130,32 @@ sub progress_line_text {
     return $prefix . $shown;
 }
 
+# Paint a progress frame into the row it owns.
+#
+# The frame is rewritten in place with a carriage return, which moves the cursor
+# without erasing anything: a frame shorter than the one already on screen would
+# leave the tail of its predecessor standing beside it. The line shrinks
+# routinely — the rate falls from "148.2k" to "71k", the line count from
+# "278.5k" to "279k" — and the reader then sees fragments of an older frame
+# glued to the current one ("...2025-05-07.txtxt").
+#
+# Every frame is therefore padded with spaces out to the width the row occupies,
+# so each paint covers whatever the previous one left. Nothing has to be
+# remembered between frames, and nothing flickers: the text is overwritten by
+# text in the same write, and the blanks only ever cover the tail — the row is
+# never blanked and repainted. The pad is the same width the line clear writes,
+# and progress_line_text() already fits the line inside it, so the pad cannot
+# go negative; the guard is there because the fit and the pad must never
+# disagree silently.
+sub paint_progress_line {
+    my ($text) = @_;
+    my $pad = $terminal_width - 1 - length($text);
+    $pad = 0 if $pad < 0;
+    print "\r$text" . " " x $pad;
+    $| = 1;                                     # Flush output to stdout
+    return;
+}
+
 sub legend_category_total {
     my ($occurrences) = @_;
     return $precise_values ? $occurrences : format_number($occurrences, 'short');
@@ -11802,10 +11828,7 @@ sub read_and_process_logs {
                 file_size     => $progress_file_size,
                 file_position => 0,
             );
-            if ($line ne "") {
-                print "\r$line";
-                $| = 1;
-            }
+            paint_progress_line($line) if $line ne "";
             $progress_last_paint = Time::HiRes::time();
         }
 
@@ -11858,10 +11881,7 @@ sub read_and_process_logs {
                         file_size     => $progress_file_size,
                         file_position => $pos,
                     );
-                    if ($line ne "") {
-                        print "\r$line";
-                        $| = 1;                             # Flush output to stdout
-                    }
+                    paint_progress_line($line) if $line ne "";
                 }
             }
 

--- a/tests/validate-progress-line.sh
+++ b/tests/validate-progress-line.sh
@@ -87,6 +87,74 @@ done
 
 TMP_DIR=$(mktemp -d); trap 'rm -rf "$TMP_DIR"' EXIT
 
+# Checker for the row the progress line owns, run against a capture's RAW
+# stdout — not the whitespace-trimmed frames the other assertions read, because
+# the trailing spaces are precisely what it is about.
+#
+#   width   <raw> <terminal-width>  every painted frame occupies exactly
+#                                   terminal-width - 1 columns
+#   residue <raw>                   replaying the stream through a terminal
+#                                   (carriage returns move the cursor, writes
+#                                   overwrite) leaves nothing of any frame
+#                                   standing past the end of its successor
+#
+# The two are the mechanism and its consequence: the frame is padded to the row
+# width so that whatever the previous frame left is covered by this one. Both
+# exit non-zero when no frame is found at all — a run that painted nothing must
+# fail here rather than pass vacuously (HARNESS-DESIGN.md § Harnesses must fail
+# on missing anchors).
+ROW_CHECK="$TMP_DIR/progress-row-check.py"
+cat > "$ROW_CHECK" <<'PYEOF'
+import re, sys
+
+check, raw_path = sys.argv[1], sys.argv[2]
+# Read as bytes and decode: Python's text mode applies universal newlines,
+# which turns every carriage return into a line feed — so the row would appear
+# to start empty for each frame and the residue check could never fail.
+text = re.sub(r'\x1b\[[0-9;]*m', '', open(raw_path, 'rb').read().decode('utf-8', 'replace'))
+FRAME = re.compile(r'^Processing +[0-9]+%')
+
+# The row as the terminal holds it: '\r' returns the cursor to column 0, a
+# write overwrites what is under it, '\n' ends the row.
+row, col, frames, problems = [], 0, 0, []
+for piece in re.split(r'(\r|\n)', text):
+    if piece == '\r':
+        col = 0
+        continue
+    if piece == '\n':
+        row, col = [], 0
+        continue
+    if not piece:
+        continue
+    for ch in piece:
+        if col < len(row):
+            row[col] = ch
+        else:
+            row.append(ch)
+        col += 1
+    if not FRAME.match(piece):
+        continue
+    frames += 1
+    if check == 'width':
+        expected = int(sys.argv[3]) - 1
+        if len(piece) != expected:
+            problems.append("frame is %d columns, expected %d: %r" % (len(piece), expected, piece))
+    else:
+        leftover = ''.join(row[len(piece):])
+        if leftover.strip():
+            problems.append("frame leaves %r visible after it: %r" % (leftover, piece))
+
+if frames == 0:
+    print("no progress frame found in %s" % raw_path)
+    sys.exit(1)
+for p in problems[:5]:
+    print(p)
+if problems:
+    print("%d of %d frames failed the %s check" % (len(problems), frames, check))
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+
 pass=0
 fail=0
 failures=()
@@ -250,6 +318,25 @@ assert_command \
     produced_by 'progress_line_text() in ltl (the filename absorbs the fit; the rate is dropped before the name)' \
     contract    'features/446-overall-progress-indicator.md D5 and the in-drop obligation that the line clear covers the longest form of the line'
 
+# The other side of the same invariant: no frame may fall SHORT of the row
+# either. The line shrinks between repaints as a matter of course — the rate
+# falls from 148.2k to 71k, the line count from 278.5k to 279k — and a carriage
+# return moves the cursor without erasing, so a frame that stops early leaves
+# the tail of its predecessor standing beside it.
+assert_command \
+    command     "python3 '$ROW_CHECK' width '$MULTI.raw' $WIDTH" \
+    label       "every painted frame occupies exactly $((WIDTH - 1)) columns" \
+    asserts     'Each frame is padded out to the width of the row it owns, so painting it covers whatever the previous frame left behind — the row never has to be blanked first, and no frame can be partly a fragment of an older one' \
+    produced_by 'paint_progress_line() in ltl' \
+    contract    'features/446-overall-progress-indicator.md D8 — every frame is written at the full row width'
+
+assert_command \
+    command     "python3 '$ROW_CHECK' residue '$MULTI.raw'" \
+    label       'no frame leaves characters of itself visible after the next one is painted' \
+    asserts     'Replaying the run through a terminal — carriage returns moving the cursor, writes overwriting — leaves nothing of any frame standing past the end of the frame that replaced it: what the reader sees is always one frame, never two spliced together' \
+    produced_by 'paint_progress_line() in ltl' \
+    contract    'features/446-overall-progress-indicator.md D8 — the padding exists to make this true without tracking what the row held'
+
 # ---------------------------------------------------------------------------
 # Scenario: single file — one percentage, no counter
 # ---------------------------------------------------------------------------
@@ -333,6 +420,13 @@ assert_command \
     asserts     'The numerics are what the narrowing protects: the file and overall percentages and the counter are still present at 60 columns, because the filename gives up its characters first' \
     produced_by 'progress_line_text() in ltl' \
     contract    'features/446-overall-progress-indicator.md D5 — truncate the variable part, never the numbers'
+
+assert_command \
+    command     "python3 '$ROW_CHECK' width '$NARROW.raw' $NARROW_WIDTH" \
+    label       "every painted frame occupies exactly $((NARROW_WIDTH - 1)) columns at a 60-column width" \
+    asserts     'The row the frame fills is the terminal it is painted on: at 60 columns the padding runs to 59, so the same self-covering property holds on a narrow terminal, where the filename shortening makes the line length vary most' \
+    produced_by 'paint_progress_line() in ltl (the pad is measured from $terminal_width)' \
+    contract    'features/446-overall-progress-indicator.md D8 — the row width is the terminal width the run was given'
 
 # ---------------------------------------------------------------------------
 # Scenario: an unreadable file keeps the two-percentage shape.


### PR DESCRIPTION
Fixes a defect in the #446 progress line (overall percentage across all files), found in use before the feature has shipped in any release.

## The defect

A carriage return moves the cursor without erasing, so a frame shorter than the one already on screen left its predecessor's tail standing beside it. The line shrinks routinely between repaints inside one file — the rate falls from `68.9k` to `71k`, the line count from `278.5k` to `279k`. Replaying the raw stdout of a run over the 762k-line single-day access log through a terminal shows 4 of its 22 frames leaving `xt` from the filename visible past their own end (`...2025-05-07.txtxt`).

Between *files* the defect does not appear: the read loop already blanks the whole row when a file closes, which is why a long-name-then-short-name run reproduces nothing.

## The fix

Both paint sites go through `paint_progress_line()`, which pads the frame to `terminal_width - 1` — the same width the between-file clear writes — and emits it in a single print. Nothing about the previous frame is remembered, so no format transition, rounding step or skipped file can put the row and a tracker out of step; and nothing flickers, because text overwrites text in the same write and the blanks only ever cover the tail. `progress_line_text()` already fits the line inside that width, so the pad cannot go negative.

Recorded as **D8** in `features/446-overall-progress-indicator.md`, with the defect and its acceptance criteria.

## Tests

`tests/validate-progress-line.sh` gains a checker that replays a capture's raw stdout as a terminal would, and three assertions:

- every painted frame occupies exactly `terminal_width - 1` columns (at 140 and at 60);
- no frame leaves any of itself visible after the next one paints.

All three were proved to fail before being trusted to pass (HARNESS-DESIGN.md § Proving a new assertion can fail): the width check fails on the pre-fix code against the committed fixture, the residue check fails on the pre-fix capture with the `xt` diagnostic, and both fail on a capture containing no frame. That proof also exposed a false pass in the checker itself — Python's text mode translates a lone carriage return to a line feed, so the row appeared to start empty for every frame; it now reads bytes and decodes.

## Completion gate

| Gate | Result |
|---|---|
| Full `tests/validate-*.sh` suite | 30/30 exit 0, 1,138 assertions, 0 failures |
| Before/after benchmark, same machine, `single-day-access-log-standard` | total time −1.2%, peak RSS +0.2% |

No release-notes bullet: the defect only ever existed in the unreleased #446 work, which `v0.18.0` already describes as the feature users will first see.