### PR TITLE
#452 colour the classified summary rows, and say why their shares are withheld

### DIFF
--- a/features/452-success-failure-percentage-columns.md
+++ b/features/452-success-failure-percentage-columns.md
@@ -8,7 +8,8 @@ UNCLASSIFIED row, notices, CSV counts, options and doc sweep in place;
 Mixed-run bucket cells await the Q15 lock (provisionally D4's letter:
 default-off on a mixed run). Tuning values in force, to be confirmed on rendered
 output: D6 budget = 7 characters; R5 hide orders success 25 / failure 65;
-D14 shades dark-green = 256-colour 34, dark-red = 256-colour 160; D7 headers
+D14 shades kelly-green = 256-colour 34, rosso-corsa = 256-colour 160,
+gold = 256-colour 178; D7 headers
 lowercase `success` / `failure` (architect's case correction, 2026-08-31).
 
 ## Scope
@@ -90,7 +91,7 @@ denominator; two columns, not one; no number is named "reliability").
   totalised counts. The included-lines figure is reported alongside, never as the
   denominator. Where classification is off and the data does not exist, no line is
   printed — the standing verbose-surface behaviour, no policy of its own.
-- **R9 — Three mutually exclusive notices**, each with its stated content:
+- **R9 — Four notices** (the first three mutually exclusive), each with its stated content:
   - *Notice 1 — partial coverage* (non-ledger format, columns explicitly enabled):
     names two blind spots in order of severity — primary, the log may not contain a
     line for every operation that executed, so operations can be missing from the
@@ -103,6 +104,19 @@ denominator; two columns, not one; no number is named "reliability").
   - *Notice 3 — no classification configured* (columns explicitly requested for a
     format declaring no criteria): the columns are not shown, and the notice explains
     why rather than leaving them silently absent.
+  - *Notice 4 — shares withheld* (added post-delivery, architect 2026-08-31): fires
+    whenever the summary's classified rows drop their shares while a contributing
+    format defines no success rule. It states that a percentage needs a population
+    where both outcomes are classified and lists those formats, so the analyst can
+    see which source to separate out rather than infer why two percentages vanished.
+    Spoken outside the columns-visible gate: the summary rows print whether or not
+    the timeline columns do. Not mutually exclusive with the first three.
+    Condition, narrowed after the first gate run caught it firing too widely: the
+    run must report successes or have a bound format that declares them, so a
+    SUCCESS row is on screen without its share. A failure-only run has no success
+    row at all — nothing was withheld — and stays silent, which is what
+    `validate-numeric-criteria-notices.sh` and the variant scenarios of
+    `validate-format-detection.sh` proved by failing on the first cut.
 - **R10 — Documentation sweep.** The consumer enumerations in `--explain
   classification`, `--help formats`, `docs/explain/classification.md` and
   `docs/usage.md` § Log formats and classification gain the new columns and overview in
@@ -319,7 +333,7 @@ acceptance criteria and written BEFORE the code (red-first). It pins:
 - **Notice text stems** (grep anchors; wording draft is Claude's, behaviour is
   R9's): notice 1 `cover only operations the log records`; notice 2
   `matched neither the success nor the failure classification`; notice 3
-  `percentage columns are not shown`.
+  `percentage columns are not shown`; notice 4 `shares are omitted`.
 - **Colour families** (exact shade is a D14 tuning item; family and
   distinctness are the contract): success fg in the green family, failure fg in
   the red family, the two distinct, `fill_extent() == 0` on both.
@@ -440,8 +454,15 @@ acceptance criteria and written BEFORE the code (red-first). It pins:
   The architect's amendment: the named lookup hash has been built selectively, so the
   dark shades may not be present as usable entries — if the existing `green`/`red`
   entries' stops do not give a true dark green / dark red, register **new named colour
-  definitions in the hash** (e.g. dark-green, dark-red) rather than repurposing or
-  mutating existing entries.
+  definitions in the hash** rather than repurposing or mutating existing entries.
+  Post-delivery amendment (architect, 2026-08-31, on testing the build): the first
+  shades read too dark, so both moved two rungs up their axis of the colour cube,
+  and the names now state the colour they are rather than its depth — `kelly-green`
+  (256-colour 34) for success, `rosso-corsa` (256-colour 160) for failure, joined by
+  `gold` (256-colour 178) for unclassified. The same three shades colour the
+  classified rows of the run summary, so one outcome reads in one colour wherever
+  the run reports it; those rows resolve through `summary_colour()`, which is what
+  makes `-sm` print the table plain.
 - ~~Q13~~ **D15 — Single-sited visibility gate (architect, 2026-08-31).** The
   default-visibility decision
   (D2 eligibility, hide options, Q3's explicit enable) is resolved in exactly one place, and the
@@ -546,6 +567,18 @@ criteria marked (Qn) cannot be finalised until that decision is locked. Triage:
   ` at … line` suffix. *Assertable* — the notice-harness pattern
   (`tests/validate-numeric-criteria-notices.sh` shape), with an exactly-one-of-N count
   assertion.
+- **AC16** (D14, post-delivery) — On a qualifying run the SUCCESS and FAILURE
+  CLASSIFIED summary rows render in the same named colour definitions the timeline's
+  percentage columns use (`kelly-green`, `rosso-corsa`), and the UNCLASSIFIED row in a
+  third (`gold`) distinct from both; under `-sm` none of the three shades appears
+  anywhere in the table. The criterion names the definitions so it cannot pass against
+  a newly invented colour vocabulary. *Assertable* — escape-sequence assertions on the
+  summary rows of the owning harness, with the rendered output confirmed by eye on a
+  real log (the escape assertion alone cannot tell a right shade from a wrong one).
+- **AC17** (R9 notice 4, post-delivery) — A run whose classified rows drop their
+  shares because a contributing format defines no success rule prints notice 4 naming
+  those formats; a run whose shares print says nothing. *Assertable* — stderr
+  assertions in the owning harness, on the mixed and the clean captures.
 - **AC12** (R10) — The consumer enumerations in `--explain classification` and
   `docs/usage.md` name the columns and the overview; all four classification surfaces
   stay in parity; no user-facing text names a number "reliability". *Assertable* —
@@ -734,3 +767,34 @@ benchmark on `single-day-access-log-standard` against a base-commit baseline cap
 before the first code change. Version restored to `0.18.0` before the gate. Acceptance
 criteria above pass; AC13's eye pass on real data is recorded in the completion
 comment.
+
+## Post-delivery pass — colour tuning and the share-omission notice (2026-08-31)
+
+Three changes after the feature merged, all from the architect testing the built
+tool on real logs.
+
+1. **Shades too dark.** `kelly-green` (256-colour 34) and `rosso-corsa` (160)
+   replace the original 22 and 88, two rungs up their axis of the colour cube;
+   the names now state the colour rather than its depth. See D14's amendment.
+2. **The classified summary rows take those colours**, plus `gold` (178) for
+   UNCLASSIFIED, resolved through `summary_colour()` so `-sm` prints the table
+   plain. AC16.
+3. **Notice 4.** Testing a mixed run surfaced the UNCLASSIFIED row carrying a
+   share while SUCCESS and FAILURE did not, with nothing on screen to say why.
+   The architect's analysis of the asymmetry is the reason the shares stay
+   withheld: a format declaring failures only can report a failure but never a
+   success, so a pooled share would measure one source's failures against
+   another's successes, and no denominator on screen makes that ratio honest.
+   The behaviour was correct; the silence was the defect. AC17.
+
+A fourth observation from the same session is NOT fixed here and needs its own
+issue if it is to be: an HTTP status outside 1xx–5xx (a 601 seen in a real
+ThingWorx access log) is dropped by the category-vocabulary gate in
+`read_and_process_logs()` before classification is reached, so the line is
+absent from LINES INCLUDED rather than surfacing as unclassified leakage.
+
+The colouring also moved a consumer: `validate-format-detection.sh`'s
+`classification-summary-rows` scenario anchors the rows' text and shape, so its
+captures now have the escapes stripped before assertion — the colour itself is
+asserted in `tests/validate-classification-percentages.sh`, which owns that
+contract.

--- a/ltl
+++ b/ltl
@@ -1137,8 +1137,13 @@ my %colors = (
     'magenta' => "\033[35m\033[49m",
     'cyan' => "\033[36m\033[49m",
     'white' => "\033[36m\033[37m",
-    'dark-green' => "\033[38;5;34m",   # success-percentage value (#452 D14: named
-    'dark-red'   => "\033[38;5;160m",  # definitions, no @column_colors index)
+    # Classification shades, shared by the timeline's success/failure
+    # percentage columns and the classified rows of the run summary, so one
+    # outcome reads in one colour wherever it appears (#452 D14: named
+    # definitions, no @column_colors index). Named for the colour they are.
+    'kelly-green' => "\033[38;5;34m",    # success
+    'rosso-corsa' => "\033[38;5;160m",   # failure
+    'gold'        => "\033[38;5;178m",   # unclassified: neither outcome
     'bright-black' => "\033[90m\033[109m",
     'bright-red' => "\033[91m\033[109m",
     'bright-green' => "\033[92m\033[109m",
@@ -5522,6 +5527,33 @@ sub emit_classification_percentage_notices {
         print STDERR "Note: the success/failure percentage columns are not shown: the matched log format(s) do not declare both a success and a failure classification, so no percentage can be computed. See --help formats for what each format classifies.\n";
         return;
     }
+    # Notice 4 — the summary's classified rows carry their shares only on a
+    # qualifying run. A format that declares no success rule can report a
+    # failure but never a success, so a combined share would measure one
+    # source's failures against another's successes: the shares are withheld
+    # and this says why, naming the formats responsible. Spoken outside the
+    # columns-visible gate above: the summary rows print whether or not the
+    # timeline columns do. The contributing formats are read from each
+    # entry's run-total match count, which a mid-file format change cannot
+    # overwrite the way the per-file flag can.
+    # Only where a share was actually withheld: the run reports successes (or a
+    # bound format declares them), so the SUCCESS row is on screen without its
+    # share. A failure-only run has no success row at all and nothing was taken
+    # away, so it stays silent.
+    my $recon = classification_reconciliation();
+    if ( ( $cls_success_declared || $recon->{successes} )
+         && !( $recon->{pct_eligible} && $recon->{successes} ) ) {
+        my %no_success_rule;
+        for my $entry (@format_registry) {
+            next unless $entry->[FR_MATCHES];
+            my $cls = $format_registry_spec{ $entry->[FR_NAME] }{_cls};
+            next if $cls && $cls->{success} && @{ $cls->{success} };
+            $no_success_rule{ $entry->[FR_SLUG] } = 1;
+        }
+        print STDERR "Note: the SUCCESS and FAILURE CLASSIFIED shares are omitted - a percentage needs a population where both outcomes are classified, and these formats define no success rule: "
+            . join( ', ', sort keys %no_success_rule ) . ".\n"
+            if %no_success_rule;
+    }
     return unless classification_columns_visible();
     # Notice 1 — shown by explicit enable while a bound format lacks the
     # event-ledger property: the figure covers only what the log records.
@@ -5534,7 +5566,7 @@ sub emit_classification_percentage_notices {
     # Notice 2 — event-ledger formats only: any non-zero shortfall of
     # successes + failures against lines included is a coverage defect in
     # the format's configured patterns, reported with its scale.
-    my $r = classification_reconciliation();
+    my $r = $recon;
     if ( !$nonledger && $r->{unclassified} > 0 ) {
         my $leak_pct = $r->{included} ? sprintf('%.1f', $r->{unclassified} / $r->{included} * 100) : '0.0';
         print STDERR "Warning: $r->{unclassified} included line(s) ($leak_pct%) matched neither the success nor the failure classification - the percentages exclude them; investigate the format's detection patterns for coverage.\n";
@@ -15084,7 +15116,7 @@ sub build_column_layout {
             visible         => $cls_visible,
             color           => undef,
             value_only      => 1,
-            value_color     => 'dark-green',
+            value_color     => 'kelly-green',
             hide_order      => 25,
         };
         push @cols, {
@@ -15098,7 +15130,7 @@ sub build_column_layout {
             visible         => $cls_visible,
             color           => undef,
             value_only      => 1,
-            value_color     => 'dark-red',
+            value_color     => 'rosso-corsa',
             hide_order      => 65,
         };
     }
@@ -17657,20 +17689,28 @@ sub print_summary_table {
         # qualifies for percentages; the zero-success suppression stands
         # (failure-only logs would always read 100%). Counts always print.
         my $share_denominator = ($recon->{pct_eligible} && $total_successes) ? $classified : undef;
+        # Each row reads in its outcome's own colour, the same shade the
+        # timeline's percentage columns use, so a success is one colour and a
+        # failure another wherever the run reports them. The colour resolves
+        # through summary_colour(), which is what makes -sm print the table
+        # plain. The padding stays outside the colour so nothing bleeds into
+        # the file-details pane printed beside the table.
         my $emit = sub {
-            my ($label, $n, $denominator) = @_;
-            push @summary_table,
-                $padding . share_row_text( $label, $n, $denominator ) . "$padding\n";
+            my ($label, $n, $denominator, $colour) = @_;
+            my $row_text = share_row_text( $label, $n, $denominator );
+            my $fg = summary_colour( $colors{$colour} );
+            $row_text = $fg . $row_text . $colors{'NC'} if length $fg;
+            push @summary_table, $padding . $row_text . "$padding\n";
         };
-        $emit->( "SUCCESS CLASSIFIED", $total_successes, $share_denominator ) if $cls_success_declared || $total_successes;
-        $emit->( "FAILURE CLASSIFIED", $total_failures, $share_denominator )  if $cls_failure_declared || $total_failures;
+        $emit->( "SUCCESS CLASSIFIED", $total_successes, $share_denominator, 'kelly-green' ) if $cls_success_declared || $total_successes;
+        $emit->( "FAILURE CLASSIFIED", $total_failures, $share_denominator, 'rosso-corsa' )  if $cls_failure_declared || $total_failures;
         # #452 R13/R14: leakage is surfaced beside the classified rows — the
         # count of matched lines that matched neither classification, with its
         # share of INCLUDED lines (a leakage figure, not a classified-denominator
         # figure). Always carries its share, eligible run or not (D10).
         # Printed only when non-zero (architect, 2026-08-31): the row exists
         # to surface leakage, and a permanent zero row is noise.
-        $emit->( "UNCLASSIFIED", $recon->{unclassified}, $total_lines_included )
+        $emit->( "UNCLASSIFIED", $recon->{unclassified}, $total_lines_included, 'gold' )
             if $recon->{unclassified} > 0 && ( $cls_success_declared || $cls_failure_declared || $classified );
     }
     if ($show_timing) {

--- a/tests/validate-classification-percentages.sh
+++ b/tests/validate-classification-percentages.sh
@@ -185,6 +185,10 @@ capture_run "$M" 160 -V format-detection "$ACCESS_FIXTURE" "$DIAG_FIXTURE"
 # Capture M2: the same mixed run explicitly enabled.
 M2="$TMP_DIR/mixed-show.out"
 capture_run "$M2" 170 --show-classification "$ACCESS_FIXTURE" "$DIAG_FIXTURE"
+# Capture SM: the diagnostics run under -sm, for the monochrome half of the
+# summary-row colour contract (the same rows as D0, with no colour to apply).
+SM="$TMP_DIR/diag-mono.out"
+capture_run "$SM" 160 -sm "$DIAG_FIXTURE"
 
 # ---------------------------------------------------------------------------
 current_scenario="column-placement"
@@ -227,7 +231,7 @@ current_scenario="value-only-rendering"
 assert_command \
     label "no bar: fill extent 0 in both cells; value text carries each column's own colour, green vs red distinct (AC3, D1, D14)" \
     command "s=\$(cell '$A' '^ 2025-05-07 00:00' success_pct) && f=\$(cell '$A' '^ 2025-05-07 00:00' failure_pct) && [[ \$s == *'extent=0'* && \$f == *'extent=0'* ]] && sfg=\$(sed -E 's/.* fg=([^ ]+).*/\\1/' <<<\"\$s\") && ffg=\$(sed -E 's/.* fg=([^ ]+).*/\\1/' <<<\"\$f\") && [[ \$sfg =~ ^(ansi:32|256:(2|22|28|34|64|70))\$ ]] && [[ \$ffg =~ ^(ansi:31|256:(1|52|88|124|160))\$ ]] && [[ \$sfg != \"\$ffg\" ]] || { echo \"success: \$s\"; echo \"failure: \$f\"; false; }" \
-    asserts "the columns are value-only (no background fill anywhere in the cell) and the values print in a dark-green / dark-red named colour definition, not via any @column_colors index" \
+    asserts "the columns are value-only (no background fill anywhere in the cell) and the values print in a kelly-green / rosso-corsa named colour definition, not via any @column_colors index" \
     produced_by "the value-only flag on the layout entry read by the render step; named colour definitions per D14" \
     contract "features/452-success-failure-percentage-columns.md AC3, D1, D14 (exact shade locked at tuning; the family and distinctness are the contract)"
 
@@ -362,16 +366,50 @@ assert_command \
     contract "features/452-success-failure-percentage-columns.md R12/D2, R9 notice 1"
 
 # ---------------------------------------------------------------------------
+current_scenario="summary-row-colour"
+
+assert_command \
+    label "the classified summary rows carry the classification shades: success kelly-green, failure rosso-corsa (D14)" \
+    command "grep -aE $'\\033\\[38;5;34m *SUCCESS CLASSIFIED' '$A' >/dev/null && grep -aE $'\\033\\[38;5;160m *FAILURE CLASSIFIED' '$A' >/dev/null" \
+    asserts "an outcome reads in one colour wherever the run reports it: the summary rows take the same named definitions as the timeline's percentage columns, not a colour of their own" \
+    produced_by "the classified-row emitter in print_summary_table() resolving through summary_colour()" \
+    contract "features/452-success-failure-percentage-columns.md D14"
+
+assert_command \
+    label "the UNCLASSIFIED summary row carries the gold shade, distinct from both outcome colours (D14)" \
+    command "grep -aE $'\\033\\[38;5;178m *UNCLASSIFIED' '$D0' >/dev/null" \
+    asserts "the row for lines that are neither a success nor a failure is told apart from both at a glance, in a third named definition" \
+    produced_by "the classified-row emitter in print_summary_table() resolving through summary_colour()" \
+    contract "features/452-success-failure-percentage-columns.md D14"
+
+assert_command \
+    label "-sm renders the same rows with no colour at all (D14, -sm contract)" \
+    command "! grep -aE $'\\033\\[38;5;(34|160|178)m' '$SM' >/dev/null && grep -aq 'UNCLASSIFIED' '$SM'" \
+    asserts "monochrome is a property of the whole summary table: the classified rows inherit the switch through summary_colour() rather than reading %colors directly, so none of the three shades survives -sm" \
+    produced_by "summary_colour() returning empty under \$summary_mono" \
+    contract "features/452-success-failure-percentage-columns.md D14; ltl summary_colour()"
+
+# ---------------------------------------------------------------------------
+current_scenario="share-omission-notice"
+
+assert_command \
+    label "a run whose shares are withheld says why, naming the formats that define no success rule (R9)" \
+    command "grep -q 'shares are omitted' '$M.stderr' && grep -q 'these formats define no success rule: windchill_method_server' '$M.stderr'" \
+    asserts "when the classified rows drop their shares because a contributing format can report failures but never successes, the run says so and names that format — the reader is not left to infer why two percentages vanished" \
+    produced_by "emit_classification_percentage_notices(), outside the columns-visible gate: the summary rows print whether or not the timeline columns do" \
+    contract "features/452-success-failure-percentage-columns.md R9 notice 4, D10"
+
+# ---------------------------------------------------------------------------
 current_scenario="clean-run-hygiene"
 
 assert_command \
     label "no qualifying notice fires on a clean, fully-classified ledger run (AC11)" \
-    command "! grep -qE 'percentage columns are not shown|matched neither the success nor the failure classification|cover only operations the log records' '$A.stderr'" \
-    asserts "the three notices are mutually exclusive by condition and silent when no condition holds" \
+    command "! grep -qE 'percentage columns are not shown|matched neither the success nor the failure classification|cover only operations the log records|shares are omitted' '$A.stderr'" \
+    asserts "the qualifying notices are mutually exclusive by condition and silent when no condition holds — including the share-omission notice, which has nothing to say on a run whose shares print" \
     produced_by "the post-read notice emission (D12)" \
     contract "features/452-success-failure-percentage-columns.md R9, AC11"
 
-for cap in "$A" "$A2" "$H" "$D0" "$D1" "$G1" "$M" "$M2"; do
+for cap in "$A" "$A2" "$H" "$D0" "$D1" "$G1" "$M" "$M2" "$SM"; do
     label_name=$(basename "$cap")
     assert_command \
         label "no runtime warnings on stderr ($label_name)" \

--- a/tests/validate-format-detection.sh
+++ b/tests/validate-format-detection.sh
@@ -1478,6 +1478,13 @@ scenario_classification_summary_rows() {
     "$LTL" --disable-progress -ni --terminal-width 120 -bs 1440 -oe -n 1 "$gc" 2> "$r_gc.stderr" > "$r_gc"
     assert_no_runtime_warnings "$r_gc.stderr" "$current_scenario gc"
 
+    # The classified rows carry their outcome's colour. This scenario asserts
+    # the rows' text and shape — the count, the share, the funnel order — so
+    # the escapes are stripped here rather than written into every anchored
+    # pattern; the colour itself is the contract of
+    # tests/validate-classification-percentages.sh.
+    perl -i -pe 's/\e\[[0-9;]*m//g' "$r_access" "$r_diag" "$r_gc"
+
     assert_line "$r_access" \
         pattern     '^  SUCCESS CLASSIFIED +6 \(60%\) *$' \
         asserts     'An access log shows the success count with its share of all classified lines (6 of 10), right-aligned to the table boundary' \


### PR DESCRIPTION
Follow-up pass on the delivered feature, all three items from the architect testing the built tool on real logs.

**Colour names and a third shade.** `kelly-green` (256-colour 34), `rosso-corsa` (160) and new `gold` (178) — the names state the colour rather than its depth, which the earlier `dark-*` keys no longer did once the shades moved up.

**The classified summary rows take those shades.** SUCCESS, FAILURE and UNCLASSIFIED read in the same colours the timeline's percentage columns use, so an outcome is one colour wherever the run reports it. They resolve through `summary_colour()`, so `-sm` renders the table plain.

**Notice 4 — say why the shares are withheld.** Testing a mixed run showed the UNCLASSIFIED row carrying a share while SUCCESS and FAILURE did not, with nothing on screen to explain it. The behaviour is right: a format declaring failures only can report a failure but never a success, so a pooled share would measure one source's failures against another's successes. The silence was the defect. The notice names the contributing formats that define no success rule, read from each entry's run-total match count so a mid-file format change cannot hide one. It is spoken outside the columns-visible gate, since the summary rows print whether or not the timeline columns do, and stays silent on a failure-only run, which has no success row to withhold anything from.

**Harnesses.** `validate-classification-percentages.sh` gains a `-sm` capture and four assertions (the two outcome shades, the gold unclassified row, no shade surviving `-sm`, notice 4 naming the format), and its clean-run silence assertion now covers notice 4 — 40 assertions. The three behavioural ones were proved red on the pre-change `ltl`. `validate-format-detection.sh`'s `classification-summary-rows` scenario asserts the rows' text and shape, so its captures strip the escapes; the colour contract lives in the classification harness.

The first cut of notice 4 fired on failure-only runs too, which the gate caught through `validate-numeric-criteria-notices.sh` and two `validate-format-detection.sh` scenarios; the condition was narrowed and both harnesses are green.

Completion gate on the merged commit: all 30 `tests/validate-*.sh` exit 0 with assertions running (validate-statistics T3 XFAILs are the registered #469 known failures); before/after benchmark of `single-day-access-log-standard` on the same machine, TIMING/total −6.0% and MEMORY/rss_peak −0.2%, no metric worse.

No user documentation surface touched — architect's call: this presents itself in the analysis, which is what the notice is for.