### PR TITLE
#452 an ineligible window shows the counts, not a blank cell

### DIFF
--- a/features/452-success-failure-percentage-columns.md
+++ b/features/452-success-failure-percentage-columns.md
@@ -371,7 +371,8 @@ acceptance criteria and written BEFORE the code (red-first). It pins:
   command line unfitted, a third #497-class producer alongside the
   messages-table rows and the heatmap. Registered in
   `tests/rendered-output/soft-wrap-known-failures.tsv` against #497.
-- ~~Q4~~ **D11 — Blank cells for absent measurements (architect, 2026-08-31).** Blank cell for both an
+- ~~Q4~~ **D11 — Blank cells for absent measurements (architect, 2026-08-31; the
+  ineligible half superseded 2026-09-01, see D17).** Blank cell for both an
   ineligible row (D2) and an eligible bucket with no classified lines (consistent with
   how other
   columns render bucket-absent values), never `0%`; an all-success bucket renders
@@ -588,6 +589,14 @@ criteria marked (Qn) cannot be finalised until that decision is locked. Triage:
   degradation, and the geometry trade of Q6. *Unassertable as a harness in full* — the
   per-property assertions above cover the parts; the composed look is verified by eye
   on real data (repo rule for visual surfaces), cost: minutes per iteration.
+- **AC18** (D17, post-delivery) — On a mixed run with the columns enabled, a bucket
+  whose window took lines from a format that declares no success rule renders the
+  success and failure **counts**, abbreviated with the tool's number formatter at
+  medium unit length so they fit the same cell, and carrying no `%`; a bucket whose
+  contributors all declare both outcomes still renders shares; a bucket with no
+  classified line at all still renders blank. A measured zero in an ineligible window
+  renders `0`, not a blank — the two states stay distinguishable. *Assertable* —
+  rendered-output cell assertions on the mixed capture in the owning harness.
 - **AC14** (Q4) — On a fixture where one bucket carries only unclassified lines and an
   adjacent bucket only failures, the first bucket's two cells render blank and the
   second renders `0%` success / `100%` failure — and the two rows are distinguishable
@@ -767,6 +776,33 @@ benchmark on `single-day-access-log-standard` against a base-commit baseline cap
 before the first code change. Version restored to `0.18.0` before the gate. Acceptance
 criteria above pass; AC13's eye pass on real data is recorded in the completion
 comment.
+
+## D17 — Ineligible windows show counts, not blanks (architect, 2026-09-01)
+
+**Supersedes the ineligible half of D11.** A window whose contributors include a
+format that classifies failures but not successes gets the raw success and failure
+counts in its two cells, rendered through the tool's number formatter at medium
+unit length (`3`, `218.4k`, `1.4Mil`) — at most seven characters, which is the D6
+cell budget, so the layout is untouched. Blank is reserved for a window with no
+classified line at all (D11's other half).
+
+**Why the share cannot be shown, and why blank was worse.** A failure-only format
+can add to the failure counter but can never add to the success counter, so a share
+computed over a window it touched is measured against a denominator one contributor
+could only push in one direction: the window's failure share is overstated, and
+across a run where most windows carry both outcomes and one carries only failures,
+the whole picture skews toward the failure-only source. But rendering nothing said
+something false and stronger — that the window had no successes and no failures at
+all. The counts say what is actually known.
+
+**How a reader tells the two apart:** the absent `%`. A count is an absolute number;
+a share always carries its symbol. Column headers are unchanged — both columns still
+report successes and failures, in a different unit.
+
+**Not reopened:** default visibility on a mixed run stays as D4 has it (architect,
+2026-09-01). And this changes only what an already-ineligible cell renders, not which
+cells are ineligible — a window touched by a *declining* format keeps today's
+treatment.
 
 ## Post-delivery pass — colour tuning and the share-omission notice (2026-08-31)
 

--- a/ltl
+++ b/ltl
@@ -15516,14 +15516,27 @@ sub normalize_data_for_output {
 
         # #452 D1: derive the bucket's percentage pair once, from the same
         # outcome counters the error rate reads — rendering never re-derives
-        # an outcome. D2: a bucket touched by a non-qualifying source (slot 3)
-        # keeps its counts but gets no percentage; D11: a bucket with no
-        # classified line gets no value, so its cells render blank, never 0%.
+        # an outcome. D11: a bucket with no classified line gets neither a
+        # percentage nor a count, so its cells render blank, never 0%.
+        #
+        # D2, as amended (architect, 2026-09-01): a bucket touched by a source
+        # that cannot report a success (slot 3) gets the raw counts instead of
+        # a share. A share there would be read against a denominator one
+        # contributor could only add failures to, so the window's failures
+        # would be overstated and the run skewed toward the failure-only
+        # source. Blank cells were worse than either: they read as a window
+        # with no successes and no failures at all. The absent '%' is what
+        # tells the reader a cell is a count.
         if (my $bucket_outcome = $bucket_outcomes{$bucket}) {
             my $bucket_classified = ($bucket_outcome->[1] // 0) + ($bucket_outcome->[2] // 0);
-            if ($bucket_classified > 0 && !($bucket_outcome->[3] // 0)) {
-                $log_stats{$bucket}{success_pct} = ($bucket_outcome->[1] // 0) / $bucket_classified * 100;
-                $log_stats{$bucket}{failure_pct} = ($bucket_outcome->[2] // 0) / $bucket_classified * 100;
+            if ($bucket_classified > 0) {
+                if ($bucket_outcome->[3] // 0) {
+                    $log_stats{$bucket}{success_pct_count} = $bucket_outcome->[1] // 0;
+                    $log_stats{$bucket}{failure_pct_count} = $bucket_outcome->[2] // 0;
+                } else {
+                    $log_stats{$bucket}{success_pct} = ($bucket_outcome->[1] // 0) / $bucket_classified * 100;
+                    $log_stats{$bucket}{failure_pct} = ($bucket_outcome->[2] // 0) / $bucket_classified * 100;
+                }
             }
         }
 
@@ -16451,9 +16464,16 @@ sub print_bar_graph {
                     # formatted value sits centred in the cell (the header
                     # centring geometry: odd remainder pads the left), in the
                     # column's named colour (D14). No value, no ink (D11).
+                    # A window that qualifies carries a share; one that does
+                    # not carries the count the share would have been built
+                    # from, abbreviated so it fits the same cell. Which key is
+                    # set is decided once in normalize_data_for_output().
                     my $cell_value = $log_stats{$bucket}{$col_id};
-                    if (defined $cell_value && $col_w > 0) {
-                        my $cell_text = format_percentage( $cell_value, mode => 'significant', digits => 3, width => $col_w );
+                    my $cell_count = $log_stats{$bucket}{"${col_id}_count"};
+                    if ((defined $cell_value || defined $cell_count) && $col_w > 0) {
+                        my $cell_text = defined $cell_value
+                            ? format_percentage( $cell_value, mode => 'significant', digits => 3, width => $col_w )
+                            : format_number( $cell_count, 'medium' );
                         $cell_text = substr( $cell_text, 0, $col_w ) if length($cell_text) > $col_w;
                         my $cell_pad = $col_w - length($cell_text);
                         $cell_pad = 0 if $cell_pad < 0;

--- a/tests/validate-classification-percentages.sh
+++ b/tests/validate-classification-percentages.sh
@@ -359,11 +359,18 @@ assert_command \
     contract "features/452-success-failure-percentage-columns.md D4 (visibility is a render-surface question — architect correction 2026-08-31)"
 
 assert_command \
-    label "mixed run + --show-classification: columns render; diagnostics-fed buckets blank, access-only buckets print; notice 1 fires (AC15, R12, D2)" \
-    command "[[ \$(layout_field '$M2' success_pct vis) == 1 ]] && s0=\$(cell '$M2' '^ 2025-05-07 00:00' success_pct) && s3=\$(cell '$M2' '^ 2025-05-07 03:00' success_pct) && s4=\$(cell '$M2' '^ 2025-05-07 04:00' failure_pct) && [[ \$s0 == *'centred=empty'* ]] && [[ \$s3 == *\"text='\"*'100%'* ]] && [[ \$s4 == *'66.7%'* ]] && grep -q 'cover only operations the log records' '$M2.stderr' || { echo \"s0=\$s0\"; echo \"s3=\$s3\"; echo \"s4=\$s4\"; false; }" \
-    asserts "per-bucket eligibility is a data question independent of visibility: a bucket touched by the non-qualifying source prints nothing, an untouched bucket keeps its stable figure, and the partial-coverage caution names the blind spots" \
+    label "mixed run + --show-classification: columns render; ineligible buckets print counts, qualifying buckets print shares; notice 1 fires (AC15, AC18, R12, D2)" \
+    command "[[ \$(layout_field '$M2' success_pct vis) == 1 ]] && s0=\$(cell '$M2' '^ 2025-05-07 00:00' success_pct) && f0=\$(cell '$M2' '^ 2025-05-07 00:00' failure_pct) && s3=\$(cell '$M2' '^ 2025-05-07 03:00' success_pct) && s4=\$(cell '$M2' '^ 2025-05-07 04:00' failure_pct) && [[ \$s0 == *\"text='\"*'3'* && \$s0 != *'%'* ]] && [[ \$f0 == *\"text='\"*'2'* && \$f0 != *'%'* ]] && [[ \$s3 == *\"text='\"*'100%'* ]] && [[ \$s4 == *'66.7%'* ]] && grep -q 'cover only operations the log records' '$M2.stderr' || { echo \"s0=\$s0\"; echo \"f0=\$f0\"; echo \"s3=\$s3\"; echo \"s4=\$s4\"; false; }" \
+    asserts "per-bucket eligibility is a data question independent of visibility: a bucket touched by a source that cannot report a success shows the counts the share would have been built from — never a share, and never blank, which would read as a window with no successes and no failures — while an untouched bucket keeps its stable figure and the partial-coverage caution names the blind spots" \
     produced_by "normalize_data_for_output() per-bucket derivation gated on %bucket_outcomes slot 3; emit_classification_percentage_notices()" \
     contract "features/452-success-failure-percentage-columns.md R12/D2, R9 notice 1"
+
+assert_command \
+    label "an ineligible window with no successes shows the count 0, not a blank cell (AC18, D2 as amended)" \
+    command "s=\$(cell '$M2' '^ 2025-05-07 02:00' success_pct) && f=\$(cell '$M2' '^ 2025-05-07 02:00' failure_pct) && [[ \$s == *\"text='\"*'0'* && \$s != *'%'* ]] && [[ \$f == *\"text='\"*'4'* ]] || { echo \"success: \$s\"; echo \"failure: \$f\"; false; }" \
+    asserts "a measured zero in an ineligible window is reported as a zero count: the D11 blank is reserved for a window with no classified line at all, so the two remain distinguishable after the count fallback was added" \
+    produced_by "normalize_data_for_output() setting the *_count keys on a slot-3 bucket with classified lines; the value-only render branch choosing format_number over format_percentage" \
+    contract "features/452-success-failure-percentage-columns.md D2 as amended (architect, 2026-09-01), D11, AC18"
 
 # ---------------------------------------------------------------------------
 current_scenario="summary-row-colour"


### PR DESCRIPTION
**D17, superseding the ineligible half of D11.** A time window whose contributors include a format that classifies failures but not successes renders the raw success and failure counts in its two cells — `format_number($n, 'medium')`, so `3`, `218.4k`, `1.4Mil`. At most seven characters, which is the D6 cell budget, so the layout is untouched.

**Why not a share, and why not blank.** A failure-only format adds to the failure counter and can never add to the success counter, so a share computed over a window it touched is measured against a denominator one contributor could only push in one direction: that window's failure share is overstated, and across a run where most windows carry both outcomes and one carries only failures, the whole picture skews toward the failure-only source. Rendering nothing, though, said something false and stronger — that the window had no successes and no failures at all. The counts say what is known. The absent `%` is what tells a reader the cell is a count; the column headers are unchanged, since both columns still report successes and failures, in a different unit.

Blank stays reserved for a window with no classified line at all (D11's other half), so a measured zero in an ineligible window renders `0` and the two states remain distinguishable.

Rendered on the mixed fixture with the columns enabled:

```
 2025-05-07 00:00  ...   3       2      ineligible window: counts
 2025-05-07 01:00                       no classified line: blank
 2025-05-07 02:00  ...   0       4      measured zero, not blank
 2025-05-07 03:00  ...  100%     0%     qualifying window: shares
 2025-05-07 04:00  ... 33.3%   66.7%
```

Which key is set is decided once in `normalize_data_for_output()`; the value-only render branch chooses the formatter from it, so the derivation stays single-sited. **Not reopened:** default visibility on a mixed run stays as D4 has it, and this changes only what an already-ineligible cell renders, not which cells are ineligible.

Harness: the mixed-run assertion now expects counts with no `%` in the ineligible buckets, and a new assertion covers the measured zero — 41 assertions. Feature doc carries D17 and AC18.

Completion gate on the merged commit: all 30 `tests/validate-*.sh` exit 0 with assertions running (validate-statistics T3 XFAILs are the registered #469 known failures); before/after benchmark of `single-day-access-log-standard` on the same machine, TIMING/total −3.7% and MEMORY/rss_peak +0.1%, inside the threshold.