### PR TITLE
#516 Bytes aggregate family captured only on demand

### DIFF
--- a/features/516-bytes-aggregate-demand-gate.md
+++ b/features/516-bytes-aggregate-demand-gate.md
@@ -1,0 +1,60 @@
+# #516 — Bytes aggregate family captured only on demand
+
+Issue #516 (bytes aggregate family is captured per line with no consumer on a
+default run). Fixes part of the v0.18.0-first parse/read_files regression
+attributed in `tests/profile/results/0180-parse-regression/analysis.md`
+(~0.30 s of ~0.9 s on single-day-access-log-standard).
+
+## Requirement
+
+The per-line capture of the bytes aggregate family — `bytes_occurrences`,
+`bytes_min`, `bytes_max`, at the per-message and per-bucket scopes — runs only
+when a surface that reads it is active. The consumers are fixed by
+`features/432-metric-aggregate-naming-parity.md` § D8: the two CSV surfaces
+(both produced under `-o`) and the bytes-family sort operands
+(`-so bytes_occurrences|bytes_min|bytes_mean|bytes_max`). `total_bytes` (the
+rendered bytes column at both scopes, and the bare `-so bytes` operand) is not
+part of the family and stays captured unconditionally.
+
+## Decisions
+
+### D1 — Store-level demand flag, resolved with the duration-statistics demand
+
+One run-start boolean, `$bytes_aggregate_demand`, computed in the existing
+demand-resolution block of `adapt_to_command_line_options()` (beside
+`$bucket_duration_stats_demand`), true when `-o` is active or the resolved
+`$sort_key` is one of the four family operands, and never true under `-ob`.
+Both capture sites test the flag inside their existing bytes guard, so the
+total-bytes accumulation and `$bytes_observed` behave exactly as today.
+
+### D2 — Downstream reads are already absence-tolerant, so nothing else moves
+
+`log_stats` projection guards `bytes_mean` on `bytes_occurrences`; the
+consolidation merge copies family fields only when defined; the CSV writers run
+only under `-o`, where the flag is true. No consumer changes.
+
+## Acceptance criteria
+
+1. **Default run skips the capture** (assertable): on a bytes-carrying input
+   with no `-o` and no bytes-family sort, the per-message and per-bucket
+   entries carry no `bytes_occurrences`/`bytes_min`/`bytes_max`. Asserted by
+   the before/after benchmark on `single-day-access-log-standard`
+   (`parse/read_files` recovers on the order of the isolation measurement) —
+   and by criterion 2's surfaces being the only place the family appears.
+2. **CSV surfaces unchanged** (assertable): with `-o`, the STATS CSV and
+   MESSAGES CSV are byte-identical before/after the change on the same input
+   (existing mechanism: `stats_csv_bytes_columns_active()` columns and the
+   MESSAGES CSV family columns). Asserted by direct diff of the four CSVs and
+   by `tests/validate-csv-output.sh`.
+3. **Bytes-family sort unchanged** (assertable): `-so bytes_min` (and mean/max/
+   occurrences) orders the messages table identically before/after on the same
+   input. Asserted by direct diff of the rendered table.
+4. **No runtime warnings** (assertable): stderr carries no ` at ltl line N`
+   lines on the criterion 1–3 runs (HARNESS-DESIGN.md discriminator).
+5. **Full suite green** (assertable): every `tests/validate-*.sh` passes on the
+   finished commit (completion gate).
+
+## Merge gate
+
+Per-feature workflow step 1: full harness suite + before/after benchmark
+(516-before captured on the base commit).

--- a/ltl
+++ b/ltl
@@ -801,6 +801,7 @@ my $bucket_stats_capture_mode      = undef;   # 'raw' or 'bin' (set before parsi
 # the consumer half of that conjunction. One boolean per statistics store.
 my $bucket_duration_stats_demand   = 0;       # per-time-bucket statistics (%log_analysis): timeline latency column, STATS CSV
 my $message_duration_stats_demand  = 0;       # per-message-key statistics (%log_messages): messages-table statistics variant, MESSAGES CSV
+my $bytes_aggregate_demand         = 0;       # bytes_occurrences/bytes_min/bytes_max at both scopes: CSV surfaces and bytes-family sorts (#516)
 
 # Statistics-group demand registry (#305): extends the store-level demand
 # above to statistic-group granularity. The 22-statistic duration ladder is
@@ -11723,6 +11724,15 @@ sub adapt_to_command_line_options {
     # MESSAGES CSV statistics columns - exist only for retained messages, so
     # retention is the single condition on this store's demand.
     $message_duration_stats_demand = ( !$omit_durations && $capture_messages ) ? 1 : 0;
+    # Bytes aggregate-family demand (#516): bytes_occurrences/bytes_min/bytes_max
+    # (and the bytes_mean derived from them) reach the user only through the two
+    # CSV surfaces and the bytes-family sort operands — nothing is rendered from
+    # them (the rendered bytes columns read total_bytes, which stays ungated).
+    # A run with no such consumer skips the per-line capture at both scopes.
+    $bytes_aggregate_demand = ( !$omit_bytes && (
+           $write_messages_to_csv
+        || $sort_key =~ /^bytes_(?:occurrences|min|mean|max)$/
+    ) ) ? 1 : 0;
 
     # Statistics-group demand (#305): layer per-group demand on top of the
     # store-level booleans above, from the consumer declarations in
@@ -12783,11 +12793,13 @@ sub read_and_process_logs {
                         if( defined $bytes && !$omit_bytes ) {
                             my $e = $log_messages{$category}{$log_key};
                             $e->{total_bytes} += $bytes;
-                            if( $e->{bytes_occurrences}++ ) {
-                                $e->{bytes_min} = $bytes if $bytes < $e->{bytes_min};
-                                $e->{bytes_max} = $bytes if $bytes > $e->{bytes_max};
-                            } else {
-                                $e->{bytes_min} = $e->{bytes_max} = $bytes;
+                            if( $bytes_aggregate_demand ) {
+                                if( $e->{bytes_occurrences}++ ) {
+                                    $e->{bytes_min} = $bytes if $bytes < $e->{bytes_min};
+                                    $e->{bytes_max} = $bytes if $bytes > $e->{bytes_max};
+                                } else {
+                                    $e->{bytes_min} = $e->{bytes_max} = $bytes;
+                                }
                             }
                         }
 
@@ -13060,11 +13072,13 @@ sub read_and_process_logs {
                             $e->{total_bytes} += $bytes;
                             $e->{'total_bytes-HL'} += $bytes if $category_bucket =~ /-HL$/;
                         }
-                        if( $e->{bytes_occurrences}++ ) {
-                            $e->{bytes_min} = $bytes if $bytes < $e->{bytes_min};
-                            $e->{bytes_max} = $bytes if $bytes > $e->{bytes_max};
-                        } else {
-                            $e->{bytes_min} = $e->{bytes_max} = $bytes;
+                        if( $bytes_aggregate_demand ) {
+                            if( $e->{bytes_occurrences}++ ) {
+                                $e->{bytes_min} = $bytes if $bytes < $e->{bytes_min};
+                                $e->{bytes_max} = $bytes if $bytes > $e->{bytes_max};
+                            } else {
+                                $e->{bytes_min} = $e->{bytes_max} = $bytes;
+                            }
                         }
                     }
 

--- a/tests/profile/results/0180-parse-regression/100k/summary.txt
+++ b/tests/profile/results/0180-parse-regression/100k/summary.txt
@@ -1,0 +1,49 @@
+====================================================================================================
+Profile:  /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/results/0180-parse-regression/100k/nytprof.out
+Script:   /Users/gregeva/Documents/GitHub/logtimeline/ltl
+Perl:     5.42.2
+CPU time: 2.7633 s (sum of exclusive times)
+Subs:     25 shown of 452 matching (from 1158 total)
+Sort:     incl time | Filter: Perl subs only
+ltl -V:   lines_read=100000  total=4.528s  rss=51 MB
+====================================================================================================
+
+Rank  Subroutine                                               Calls   Incl(s)   Excl(s)   ms/call   %Tot
+----------------------------------------------------------------------------------------------------
+   1  pipeline_parse                                               1    2.6629  0.000038  2662.909   96.4
+   2  read_and_process_logs                                        1    2.6577    1.7587  2657.684   96.2
+   3  __ANON__[(eval 45)[/Users/gregeva/Documents/GitHu...    100045    0.7526    0.5374     0.008   27.2
+   4  get_memory_usage                                             7    0.0267    0.0002     3.815    1.0
+   5  pipeline_finalize                                            1    0.0239  0.000048    23.915    0.9
+   6  measure_memory_structures                                    5    0.0202  0.000062     4.045    0.7
+   7  calculate_all_statistics                                     1    0.0195    0.0064    19.475    0.7
+   8  pipeline_detect                                              1    0.0130  0.000009    12.968    0.5
+   9  build_format_registry                                        1    0.0130    0.0023    12.954    0.5
+  10  calculate_statistics                                        13    0.0127    0.0042     0.975    0.5
+  11  Term::ReadKey::GetTerminalSize                               1    0.0125    0.0001    12.545    0.5
+  12  format_scan_sub_resolve                                      1    0.0114  0.000013    11.354    0.4
+  13  compile_format_scan_sub                                      1    0.0113    0.0037    11.341    0.4
+  14  pipeline_render                                              1    0.0113  0.000087    11.261    0.4
+  15  BEGIN@50                                                     1    0.0069    0.0003     6.942    0.3
+  16  Text::CSV::_load                                             2    0.0066  0.000038     3.296    0.2
+  17  Text::CSV::_load_pp                                          1    0.0065         -     6.549    0.2
+  18  Text::CSV::BEGIN@1.1                                         1    0.0065    0.0062     6.525    0.2
+  19  BEGIN@38                                                     1    0.0060    0.0016     6.017    0.2
+  20  BEGIN@37                                                     1    0.0058    0.0015     5.817    0.2
+  21  compile_format_extractor                                    34    0.0057    0.0051     0.168    0.2
+  22  BEGIN@41                                                     1    0.0044    0.0031     4.429    0.2
+  23  pipeline_accumulate                                          1    0.0038  0.000051     3.778    0.1
+  24  XSLoader::load                                               8    0.0036    0.0036     0.444    0.1
+  25  BEGIN@49                                                     1    0.0023    0.0007     2.299    0.1
+
+Note: %Tot = incl_time / 2.7633 s (total Perl CPU time)
+      Use --all to include XSubs [xs] and opcodes [op]
+      Use --sort excl to rank by exclusive time
+
+====================================================================================================
+Cross-Validation: NYTProf call counts vs ltl -V output
+----------------------------------------------------------------------------------------------------
+  read_and_process_logs                     NYTProf calls=1  ltl-V lines_read=100000
+    (called once; loops internally over lines)
+
+  [OK] All cross-validation checks within tolerance.

--- a/tests/profile/results/0180-parse-regression/100k/verbose.txt
+++ b/tests/profile/results/0180-parse-regression/100k/verbose.txt
@@ -1,0 +1,331 @@
+[0;37m [90m[109m
+──────────────────────────────────────────────────────────────────────────────────────────────
+   ,:: ltl ::' log timeline [0.18.0] --  by Greg Eva // geva@ptc.com // gregeva@gmail.com
+──────────────────────────────────────────────────────────────────────────────────────────────
+[0m
+Note: the detected log format (tomcat_access_with_duration) is written by more than one producer and the duration unit differs between them (assumed ms); nothing in the file names or content decided which - use -du <unit> or -lf httpd_access_with_duration if the files come from the other producer
+
+=== runtime-config ===
+include (merged): (not set)
+exclude (merged): (not set)
+highlight (merged): (not set)
+threadpool-activity (merged): (not set)
+bucket-duration-stats-demand: 1
+message-duration-stats-demand: 1
+=== runtime-config / command-line ===
+bucket-size: 60
+no-index: 1
+=== END runtime-config / command-line ===
+=== runtime-config / environment-variable ===
+=== END runtime-config / environment-variable ===
+=== END runtime-config ===
+
+=== index-read-back ===
+index_used: no
+index_filter_signature: -
+file: /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/localhost_access_log-twx01-twx-thingworx-0.2025-05-07-100000.txt
+  lookup: none
+  matched_entry_date: -
+  freshness: no_entry
+  preseed_duration_min: -
+  preseed_duration_max: -
+  preseed_file_bytes_min: -
+  preseed_file_bytes_max: -
+  preseed_count_min: -
+  preseed_count_max: -
+  preseed_first_timestamp: -
+  preseed_last_timestamp: -
+=== END index-read-back ===
+=== histogram-bin-counters ===
+data_model_precision: 5 (default)
+
+consumer: summary_table
+  path: user_opt_out
+
+consumer: csv_output
+  path: feature_not_active
+
+consumer: time_bucket_stats
+  path: user_opt_out
+
+consumer: heatmap_markers
+  path: feature_not_active
+
+consumer: heatmap_cells
+  path: feature_not_active
+
+consumer: histogram_view
+  path: feature_not_active
+
+consumer: histogram_bins
+  path: feature_not_active
+=== END histogram-bin-counters ===
+=== format-detection ===
+duration_unit_override: -
+format_pin: -
+legend: 1=tomcat_access_with_duration
+files: 1
+file: /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/localhost_access_log-twx01-twx-thingworx-0.2025-05-07-100000.txt
+  format: tomcat_access_with_duration
+  match_type: 3
+  metrics_observed: yes
+  event_ledger: yes
+  matched_lines: 100000
+  unmatched_lines: 0
+  first_match_line: 1
+  scan_attempts: 100000
+  scan_failed_attempts: 0
+  window: 0
+  sample: yes
+  sample_file_bytes: 20285412
+  sample_whole_file: no
+  sample_lines: 123
+  sample_matched_lines: 123
+  sample_formats: mt3=123
+  sample_part: 1 offset=0 bytes=8192 lines=42 avg_line=195 matched=42 first_ts="07/May/2025:00:00:00 +0000" last_ts="07/May/2025:00:00:03 +0000"
+  sample_part: 2 offset=10138610 bytes=8192 lines=41 avg_line=193 matched=41 first_ts="07/May/2025:01:22:59 +0000" last_ts="07/May/2025:01:23:03 +0000"
+  sample_part: 3 offset=20277220 bytes=8192 lines=40 avg_line=204 matched=40 first_ts="07/May/2025:02:46:11 +0000" last_ts="07/May/2025:02:46:15 +0000"
+  sample_us: 2430.0
+  formats: tomcat_access_with_duration
+  filename_evidence: stem=- ext=- date=- index=-
+  variant_group: access_with_duration
+  candidates: mt3=3.00,mt3us=1.00
+  selected: mt3
+  selection_basis: default
+  confidence: 0.75
+  flips: 0
+  probes: sample_out_of_range=0 sample_monotonic_violations=0 out_of_range=0 monotonic_violations=0 filename_date=-
+=== format-detection / scan ===
+entries: 15
+guarded: mt12,mt4,mt9
+window_size: 0
+window_fallback: 1000
+sample_parts: 3
+sample_bytes_per_part: 8192
+final_order: mt12,mt4,mt9,mt3,mt1std,mt10,mt16,mt1gen,mt2,mt5,mt6,mt7,mt8,mt17,mt11
+promotions: 0
+match_counts: mt1std=0,mt10=0,mt10ir=0,mt16=0,mt1gen=0,mt2=0,mt12=0,mt4=0,mt9=0,mt3=100000,mt3us=0,mt5=0,mt6=0,mt7=0,mt8=0,mt17=0,mt11=0
+variant_groups: connection_server=mt10,access_with_duration=mt3
+nomatch_scan_samples: 0
+nomatch_scan_avg_us: -
+=== END format-detection / scan ===
+=== format-detection / classification ===
+lines_included: 100000
+successes: 99900
+failures: 100
+classified: 100000
+unclassified: 0
+unclassified_pct: 0.0
+success_pct: 99.900
+failure_pct: 0.100
+pct_eligible: 1
+non_qualifying_lines: 0
+unmatched_lines: 0
+event_ledger_files: 1/1
+rule_changes: 0
+default_failure: category_bucket=^(?:ERROR|FATAL|CRITICAL)$
+=== END format-detection / classification ===
+=== END format-detection ===
+=== format-registry ===
+entries: 18
+scanned_entries: 17
+scan_slots: 15
+  entry: mt1std slug=thingworx_standard group=mt1std default=yes role=scanned
+  entry: mt10 slug=connection_server_standard group=connection_server default=yes role=scanned
+  entry: mt10ir slug=integration_runtime_standard group=connection_server default=no role=scanned
+  entry: mt16 slug=windchill_workgroup_manager group=mt16 default=yes role=scanned
+  entry: mt1gen slug=thingworx_standard group=mt1gen default=yes role=scanned
+  entry: mt2 slug=thingworx_rac_client group=mt2 default=yes role=scanned
+  entry: mt12 slug=tomcat_codebeamer group=mt12 default=yes role=scanned
+  entry: mt4 slug=tomcat_access_common group=mt4 default=yes role=scanned
+  entry: mt9 slug=jboss_access group=mt9 default=yes role=scanned
+  entry: mt3 slug=tomcat_access_with_duration group=access_with_duration default=yes role=scanned
+  entry: mt3us slug=httpd_access_with_duration group=access_with_duration default=no role=scanned
+  entry: mt5 slug=connection_server_json group=mt5 default=yes role=scanned
+  entry: mt6 slug=java_gc_g1 group=mt6 default=yes role=scanned
+  entry: mt7 slug=tw_analytics_v2 group=mt7 default=yes role=scanned
+  entry: mt8 slug=tw_analytics_worker group=mt8 default=yes role=scanned
+  entry: mt17 slug=windchill_method_server group=mt17 default=yes role=scanned
+  entry: mt11 slug=tw_edge_c_sdk group=mt11 default=yes role=scanned
+  entry: csv slug=csv group=csv default=yes role=stateful
+variant_groups: connection_server=mt10,access_with_duration=mt3
+  group: connection_server slot=1 default=mt10 members=mt10,mt10ir
+  group: access_with_duration slot=8 default=mt3 members=mt3,mt3us
+static_order: mt1std,mt10,mt16,mt1gen,mt2,mt12,mt4,mt9,mt3,mt5,mt6,mt7,mt8,mt17,mt11
+  ancestors: mt1std <- -
+  ancestors: connection_server <- -
+  ancestors: mt16 <- -
+  ancestors: mt1gen <- mt1std
+  ancestors: mt2 <- mt1std,connection_server,mt16,mt1gen
+  ancestors: mt12 <- -
+  ancestors: mt4 <- -
+  ancestors: mt9 <- -
+  ancestors: access_with_duration <- mt12,mt4,mt9
+  ancestors: mt5 <- -
+  ancestors: mt6 <- -
+  ancestors: mt7 <- -
+  ancestors: mt8 <- mt1std,connection_server,mt1gen
+  ancestors: mt17 <- -
+  ancestors: mt11 <- -
+scan_subs_compiled: 1
+scan_sub_cache_hits: 0
+scan_subs_rss_bytes: 999424
+scan_sub_rss_measured: yes
+compiled_orders: mt12,mt4,mt9,mt3,mt1std,mt10,mt16,mt1gen,mt2,mt5,mt6,mt7,mt8,mt17,mt11
+=== END format-registry ===
+=== heatmap-palette ===
+heatmap_active: no
+metric: n/a
+light_bg: 0
+light_bg_source: default
+color_name: n/a
+gradient_dark: n/a
+gradient_light: n/a
+gradient_active: n/a
+=== END heatmap-palette ===
+=== csv-output ===
+csv_active: no
+=== END csv-output ===
+=== percentile-algorithm ===
+=== percentile-algorithm / histogram ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / histogram ===
+=== percentile-algorithm / heatmap ===
+data_model: bin
+effective_algorithm: exponential_interpolation_within_bucket
+effective_bpd: 616
+formula: rank_in_bin = ceil(q * total_N) - cum_before_bin; fraction = rank_in_bin / bin_count; value = lower * (upper/lower)^fraction
+algorithm_source: features/187-histogram-bin-counter-percentiles.md § Decision 1 (Prometheus histogram_quantile native-exponential rule)
+=== END percentile-algorithm / heatmap ===
+=== percentile-algorithm / message-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / message-stats ===
+=== percentile-algorithm / bucket-stats ===
+data_model: raw
+effective_algorithm: nearest_rank
+formula: value = sorted[int(n * q)]; q in [0,1]; n = sample count
+algorithm_source: features/272-percentile-algorithm-industry-grounding.md § Nearest-rank
+=== END percentile-algorithm / bucket-stats ===
+=== END percentile-algorithm ===
+=== statistics-demand ===
+store: bucket
+  store_demand: 1
+  population: 3
+  group terminal_core: demanded=1 consumers=timeline-latency-column
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 3
+  group_calc terminal_core: computed=3 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=3 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=3 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=3 ineligible=0
+store: message
+  store_demand: 1
+  population: 108
+  group terminal_core: demanded=1 consumers=messages-table
+  group csv_body: demanded=0 consumers=-
+  group extended_percentiles: demanded=0 consumers=-
+  group shape_moments: demanded=0 consumers=-
+  moment_source: none
+  stats_calls: 10
+  group_calc terminal_core: computed=10 skipped_demand=0 ineligible=0
+  group_calc csv_body: computed=0 skipped_demand=10 ineligible=0
+  group_calc extended_percentiles: computed=0 skipped_demand=10 ineligible=0
+  group_calc shape_moments: computed=0 skipped_demand=10 ineligible=0
+threadpool_population: 0
+sort_gate: operand=occurrences family=occurrences observed=n/a fallback=none
+=== END statistics-demand ===
+=== profile ===
+profile_active: no
+=== END profile ===
+=== udm-counting ===
+counting_udms: none
+=== END udm-counting ===
+=== udm-specs ===
+=== END udm-specs ===
+=== benchmark-data ===
+version	0.18.0
+FILES	/Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/localhost_access_log-twx01-twx-thingworx-0.2025-05-07-100000.txt	20285412
+lines_read	100000
+lines_included	100000
+TIMING	detect/registry_build	0.015
+TIMING	detect/scan_sub_compile	0.005
+TIMING	parse/read_files	4.492
+TIMING	accumulate/initialize_buckets	0.000
+TIMING	finalize/group_similar	0.000
+TIMING	finalize/calculate_statistics	0.020
+TIMING	finalize/calculate_statistics/bucket_stats	0.013
+TIMING	finalize/calculate_statistics/population_walk	0.000
+TIMING	finalize/calculate_statistics/sort_selection	0.000
+TIMING	finalize/calculate_statistics/group_calc	0.006
+TIMING	finalize/calculate_statistics/threadpool_stats	0.000
+TIMING	finalize/calculate_statistics/untimed	0.000
+TIMING	finalize/heatmap_statistics	0.000
+TIMING	finalize/histogram_statistics	0.000
+TIMING	render/normalize_data	0.001
+TIMING	total	4.528
+MEMORY	rss_peak	53641216
+MEMORY	format_scan_subs	999424
+COUNTS	log_messages_entries	108
+COUNTS	log_occurrences_entries	3
+COUNTS	log_stats_entries	3
+COUNTS	log_analysis_entries	3
+COUNTS	log_messages_population	108
+COUNTS	threadpool_entries	0
+COUNTS	format_scan_subs_compiled	1
+COUNTS	format_scan_sub_cache_hits	0
+CONFIG	terminal_width	200
+CONFIG	terminal_height	24
+CONFIG	max_log_message_length	200
+CONFIG	time_bucket_size	60
+CONFIG	bucket_size_seconds	3600.00
+=== END benchmark-data ===
+
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[90m[109m     timestamp                    legend                 success failure                 occurrences                   duration        bytes                         latency statistics                 
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+ 2025-05-07 00:00 [0;33m4xx: 36[0m [0;35m3xx: 16[0m [0;32m2xx: 35.9k[0m  [91m[109m0.6[0m[90m[109m:[0m[0m600[0m[90m[109m/m[0m   [38;5;34m99.9%[0m    [38;5;160m0.1%[0m  [90m[109m│[0m [0;33m[0m[0;35m[0m[0;32m███████████████████████████████████████[0m  [48;5;226m[38;5;0m[48;5;184m[38;5;0m 44.9 min   [0m[93m [0m[0m  [48;5;46m[38;5;0m[48;5;34m[38;5;0m 12.3 MiB    [0m[0m [90m[109m│[0m  [36m[49mP50:1ms   [0m [0;33mP95:1s    [0m [93mP99:1s    [0m [0;31mP999:1s    [0m [4;37mCV:2.98[0m
+ 2025-05-07 01:00 [0;33m4xx: 36[0m [0;35m3xx: 13[0m [0;32m2xx: 35.9k[0m  [91m[109m0.6[0m[90m[109m:[0m[0m600[0m[90m[109m/m[0m   [38;5;34m99.9%[0m    [38;5;160m0.1%[0m  [90m[109m│[0m [0;33m[0m[0;35m[0m[0;32m███████████████████████████████████████[0m  [48;5;226m[38;5;0m[48;5;184m[38;5;0m 44.9 min    [0m[0m  [48;5;46m[38;5;0m[48;5;34m[38;5;0m 12.3 MiB   [0m[32m [0m[0m [90m[109m│[0m  [36m[49mP50:1ms   [0m [0;33mP95:1s    [0m [93mP99:1s    [0m [0;31mP999:1s    [0m [4;37mCV:2.97[0m
+ 2025-05-07 02:00 [0;33m4xx: 28[0m [0;35m3xx: 9[0m [0;32m2xx: 28k[0m   [91m[109m0.5[0m[90m[109m:[0m[0m466.7[0m[90m[109m/m[0m   [38;5;34m99.9%[0m    [38;5;160m0.1%[0m  [90m[109m│[0m [0;33m[0m[0;35m[0m[0;32m██████████████████████████████[0m           [48;5;226m[38;5;0m[48;5;184m[38;5;0m 35.1 min [0m[93m   [0m[0m  [48;5;46m[38;5;0m[48;5;34m[38;5;0m 9.7 MiB  [0m[32m   [0m[0m [90m[109m│[0m  [36m[49mP50:1ms   [0m [0;33mP95:1s    [0m [93mP99:1s    [0m [0;31mP999:1s    [0m [4;37mCV:2.95[0m
+[90m[109m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+
+[90m[109mcommand-line options: -V all --disable-progress -ni --terminal-width 200 -bs 60 [0m
+
+ [96m[49m TOP OVERALL MESSAGES (retained for after inclusion, exclusion, time range, and duration filters)                                 Occurre.      Min      P50    P99.9     CV %         Duration [0m[96m
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+  [200] POST /Thingworx/Things/Brembo.ProductionDashboard.Manager/Services/GetDateAndTime                                             31919     51ms     58ms    166ms     0.12         31.3 min 
+  [200] POST /Thingworx/Things/Brembo.ProductionDashboard.Manager/Services/UpdateHeartbeat                                             5315       1s       1s       1s     0.00           1.5 hr 
+  [200] POST /Thingworx/Things/SAMCL002/Services/GetNamedProperties                                                                    2661      0ms      1ms      2ms     0.59            2 sec 
+  [200] POST /Thingworx/Things/SAESA024/Services/GetNamedProperties                                                                    1331      0ms      1ms      1ms     0.69         900 msec 
+  [200] POST /Thingworx/Things/GFPCH011/Services/GetNamedProperties                                                                    1330      0ms      1ms      1ms     0.67         924 msec 
+  [200] POST /Thingworx/Things/GMPOB012/Services/GetNamedProperties                                                                    1330      0ms      1ms      2ms     0.69            1 sec 
+  [200] POST /Thingworx/Things/GQXRY011/Services/GetNamedProperties                                                                    1330      0ms      1ms      1ms     0.70         891 msec 
+  [200] POST /Thingworx/Things/GQXRY018/Services/GetNamedProperties                                                                    1330      0ms      1ms      1ms     0.62         959 msec 
+  [200] POST /Thingworx/Things/GUGCL024/Services/GetNamedProperties                                                                    1330      0ms      1ms      1ms     0.63         953 msec 
+  [200] POST /Thingworx/Things/GUGCL031/Services/GetNamedProperties                                                                    1330      0ms      1ms      2ms     0.58         997 msec 
+
+
+  ─────────────────────────────────────────   
+  Category                            Total      [4;37mThese file(s) were processed with analysis including results between 2025-05-07 00:00 and 2025-05-07 02:46[0m
+  ─────────────────────────────────────────   
+  [0m[93m4xx Client error               100 (0.1%)[0m      [36m[37m[[0;32m√[0m[36m[37m] /Users/gregeva/Documents/GitHub/logtimeline/tests/profile/samples/localhost_access_log-twx01-twx-thingworx-0.2025-05-07-100000.txt           [[38;5;111m1[36m[37m][0m
+  [0m[35m3xx Redirection               38 (0.038%)[0m   
+  [48;5;34m[38;5;0m2xx Success                 99862 (99.9%)[0m      [4;37mLog Formats[0m
+  ─────────────────────────────────────────   
+  LINES READ                         100000      [38;5;111m1[36m[37m tomcat_access_with_duration[0m
+  LINES INCLUDED                     100000   
+  [38;5;34mSUCCESS CLASSIFIED          99900 (99.9%)[0m   
+  [38;5;160mFAILURE CLASSIFIED             100 (0.1%)[0m   
+  TOTAL TIME                        4.5 sec   
+  MAXIMUM MEMORY USED              51.2 MiB   
+  ─────────────────────────────────────────   
+

--- a/tests/profile/results/0180-parse-regression/analysis.md
+++ b/tests/profile/results/0180-parse-regression/analysis.md
@@ -1,0 +1,109 @@
+# Profiling Analysis: 0180-parse-regression
+
+Investigation of the v0.18.0-first vs v0.17.0-release benchmark regression:
+parse/read_files +15.9% suite-wide (+17.5 min), rss_peak +21.6%, %log_messages
++28.2%. Reference case: single-day-access-log-standard (148 MB, 0.76M lines),
+invocation `--disable-progress -ni -V benchmark-data -mem --terminal-width 200
+-bs 60` (the benchmark shape plus `-ni` for hermetic A/B).
+
+## Hypothesis
+
+See hypothesis.md: expected the delta concentrated in the classification/outcome
+work (#453/#452/#455). That expectation was WRONG in proportion — those explain
+under a third.
+
+## Method
+
+1. Per-case TSV comparison normalised to seconds per million lines: access-log
+   cases +1.1–1.7 s/Mline, application logs +0.3–0.5, custom logs ~0,
+   consolidate-heavy cases ~flat (added cost diluted by grouping).
+2. Same-machine interleaved A/B (3x each): HEAD read_files 9.62 s vs v0.17.0
+   8.67 s — +0.95 s reproduced, ranges tight (±0.02).
+3. NYTProf 100k-line profiles of BOTH versions (v0.17.0 via a scratch worktree),
+   line-time aggregation keyed by source text to survive line-number drift.
+   read_and_process_logs exclusive: 1.759 vs 1.569 s; the generated scan sub's
+   exclusive time is EQUAL (0.537 vs 0.542) — extraction codegen is not the cost.
+4. Isolation variants (patched copies, real un-profiled runs, interleaved):
+
+| Variant (what was disabled) | read_files | recovered |
+|---|---|---|
+| HEAD (round 1 / round 2)                                   | 9.62 / 9.49 | — |
+| V1: per-message `outcomes[]++` writes                      | 9.51 | ~0.11 s |
+| V2: V1 + per-bucket outcome accounting (`%bucket_outcomes`, totals, pct-qualifying, cls-sig compare) | 9.46 | ~0.05 s |
+| V3: V2 + classifier statement nulled (scan-block regexes)  | 9.36 | ~0.10 s |
+| G1: #447 control-char `tr///` scan                         | 9.41 | ~0.08 s |
+| G2: #432 bytes min/max/occurrences family (both scopes) reverted to pre-#432 shape | 9.20 | ~0.30 s |
+| ALL (V3+G1+G2 union)                                       | 8.69 / 8.68 | ~0.85 s |
+| v0.17.0 (same rounds)                                      | 8.63 / 8.58 | — |
+
+The union lands within ~0.07 s (<1%) of v0.17.0: **these groups are the whole
+regression**. Residual is spread micro-additions (per-line
+`$fdd->{metrics_observed}` write, `$capture_messages` conditional, `sel_*`
+occurrence counters).
+
+## Memory attribution
+
+humungous-log-uniqueness (286K unique message keys), MEMORY/log_messages:
+
+| Build | log_messages | rss_peak |
+|---|---|---|
+| HEAD          | 181.3 MB | 268 MB |
+| V1 (no per-message outcomes) | 133.2 MB | 218 MB |
+| v0.17.0       | 133.2 MB | 217 MB |
+
+**100% of the %log_messages growth is the per-message `outcomes` array refs**
+(~168 bytes/key for a 3-slot array). The suite-wide +21.8 GB in log_messages and
+most of the +24.9 GB rss_peak follow.
+
+## Diagnosis
+
+The regression is four deliberate per-line features, two of which are captured
+without a demand gate although their only consumers are optional surfaces:
+
+1. **#432 bytes aggregate family (~0.30 s, 33%)** — per-message AND per-bucket
+   `bytes_occurrences`/`bytes_min`/`bytes_max`. Feature doc D8 records the only
+   consumers: `-so bytes_*` sorts and the two CSV files; nothing is rendered.
+   The capture runs unconditionally — a default terminal run pays it for
+   surfaces it will never produce. (#432's own analysis measured the +4.0% and
+   it was accepted; the demand question was not raised there.)
+2. **#453/#452 classification + outcome accounting (~0.26 s, 29%)** — of which:
+   - per-message `outcomes[]++` (~0.11 s + ALL the log_messages memory): its
+     only consumers are the MESSAGES CSV successes/failures columns and the
+     consolidation merge — CSV-gated surfaces, capture is not.
+   - the compiled classifier statement (~0.10 s): two anchored alternation
+     regexes per line (`^(?:4xx|5xx)$` then `^(?:1xx|2xx|3xx)$`) on a 3-char
+     value; codegen could emit eq-chains for all-literal alternations.
+   - per-bucket `%bucket_outcomes` + run totals (~0.05 s): feeds the DEFAULT
+     surfaces (summary classified rows, timeline % columns, errRate) —
+     legitimately ungated.
+3. **#447 control-char normalisation (~0.08 s, 9%)** — the `tr///` count IS the
+   documented gate (D1–D5, measured at introduction). Deliberate.
+4. **Residual micro-spread (~0.1 s)** — accepted small costs.
+
+## Cross-Validation
+
+read_and_process_logs called once, scan sub 100,045 calls vs lines_read=100000
+(45 = registry sample validation), both versions. No [WARN]s.
+
+## Surprises
+
+- The scan sub (extraction + inlined classification) contributes nothing
+  measurable to the version delta at sub level; the classifier's cost shows up
+  only in the V3 isolation (~0.10 s/0.76M).
+- The largest single contributor (#432 bytes family) was the one with the most
+  careful measurement record — measured for cost, not for demand.
+
+## Action
+
+None yet — findings first. Candidate fixes proposed to the architect:
+demand-gate the #432 bytes family and the #453 per-message outcomes on their
+actual consumers (the existing stats-demand flag pattern), optional eq-chain
+classifier codegen.
+
+## Learnings
+
+- A hot-path capture needs BOTH measurements: what it costs, and who consumes
+  it. #432's analysis proved the cost acceptable without asking whether a
+  default run has any consumer for the captured family.
+- Line-time aggregation keyed by normalised source text is an effective way to
+  diff NYTProf profiles across versions with heavy line drift.

--- a/tests/profile/results/0180-parse-regression/hypothesis.md
+++ b/tests/profile/results/0180-parse-regression/hypothesis.md
@@ -1,0 +1,24 @@
+# Hypothesis: v0.18.0-first parse/read_files regression vs v0.17.0
+
+Benchmark comparison (v0.17.0-release vs v0.18.0-first, all tier) shows
+parse/read_files +15.9% suite-wide; per-line normalization puts access-log
+cases at +1.1-1.7 s/Mline, application logs +0.3-0.5, custom logs ~0.
+
+A/B on single-day-access-log-standard (148 MB, 0.76M lines, same machine,
+interleaved 3x): HEAD 9.62s vs v0.17.0 8.67s read_files -> +0.95s reproducible.
+
+Isolation variants (classification/outcome work #453/#452/#455):
+- V1 (per-message outcomes writes removed):        9.51s  (-0.11)
+- V2 (V1 + per-bucket outcome accounting removed): 9.46s  (-0.05)
+- V3 (V2 + classifier statement nulled):           9.36s  (-0.10)
+
+So classification + outcome accounting ~= 0.26s of the 0.95s. Hypothesis for
+the remaining ~0.7s: an additional per-line cost in the include path or the
+generated scan block that is NOT part of classification — candidate suspects:
+bucket_epoch indirection (#451 profile modes), highlight/filter gate
+restructuring (#455), or scan-block changes. Expect read_and_process_logs
+line-level profile to show the delta concentrated on specific new lines in
+the include loop.
+
+Expected call counts: read_and_process_logs called once; scan sub once per
+line (100k sample); classification inline (no sub calls).


### PR DESCRIPTION
Fixes #516 (bytes aggregate family captured per line with no consumer on a default run).

The per-message and per-bucket capture of bytes_occurrences/bytes_min/bytes_max now runs only when a consumer is active: `-o` (STATS + MESSAGES CSV) or a bytes-family sort operand (`-so bytes_occurrences|bytes_min|bytes_mean|bytes_max`). `total_bytes` (rendered columns, bare `-so bytes`) and `$bytes_observed` are unchanged.

Gate evidence (per-feature completion gate):
- Full harness suite: 32/32 exit 0 with assertions confirmed run.
- Before/after benchmark, single-day-access-log-standard, same machine: parse/read_files 9.9 s → 9.3 s (−5.5%), rss flat.
- CSV surfaces (STATS + MESSAGES) and bytes-family sort output byte-identical before/after on a bytes-carrying fixture; stderr clean of runtime warnings.

Record: features/516-bytes-aggregate-demand-gate.md; regression attribution: tests/profile/results/0180-parse-regression/analysis.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpHPe9Hw5rJc1LswLZkd4M