### PR TITLE
#517 Per-message outcome counters captured only on demand

### DIFF
--- a/features/517-message-outcomes-demand-gate.md
+++ b/features/517-message-outcomes-demand-gate.md
@@ -1,0 +1,64 @@
+# #517 — Per-message success/failure counts captured only on demand
+
+Issue #517 (per-message success/failure counts are captured per line although
+only the MESSAGES CSV reads them). Fixes part of the v0.18.0-first
+parse/read_files regression and all of the `%log_messages` memory growth
+attributed in `tests/profile/results/0180-parse-regression/analysis.md`
+(~0.11 s time on single-day-access-log-standard; +48.1 MB store growth on the
+286K-unique-messages selection, +21.8 GB suite-wide).
+
+## Requirement
+
+The per-message outcome counters (the `outcomes` success/failure array on each
+`%log_messages` entry, and its seed in the consolidation stats source) are
+captured only when a surface that reads them is active. Today that is only the
+MESSAGES CSV successes/failures columns (`-o`,
+`features/453-success-failure-classification-event-ledger.md`). The
+default-surface classification figures (summary SUCCESS/FAILURE CLASSIFIED
+rows, timeline percentage columns, errRate) read the run totals and
+`%bucket_outcomes` and are untouched.
+
+Open feature #456 (per-message success/failure indicator in the messages and
+summary tables) will add a rendered consumer; when it lands, its option state
+joins this gate's demand terms.
+
+## Decisions
+
+### D1 — One store-level demand flag, resolved beside the sibling gates
+
+`$message_outcomes_demand`, computed in the demand-resolution block of
+`adapt_to_command_line_options()` (beside `$bytes_aggregate_demand`, #516 D1),
+true when `-o` is active. All three write sites test it: the two per-line
+`outcomes[]++` writes (main capture path and the consolidation-absorbed else
+branch) and the per-new-key consolidation `stats_source` seed.
+
+### D2 — Downstream reads are absence-tolerant, so nothing else moves
+
+The MESSAGES CSV writer already guards (`$outcomes ? ... : 0`) and runs only
+under `-o`, where the flag is true; `merge_consolidation_stats()` copies the
+array only when the source carries it; the cluster projection copies it only
+when present.
+
+## Acceptance criteria
+
+1. **Default run skips capture and recovers the store growth** (assertable):
+   on the 286K-unique-messages benchmark selection, `MEMORY/log_messages`
+   returns to its pre-#453 level (isolation-measured 133.2 MB vs 181.3 MB) and
+   `parse/read_files` recovers on the access-log selection. Asserted by the
+   before/after benchmark on both targeted selections.
+2. **MESSAGES CSV unchanged under `-o`** (assertable): successes/failures
+   columns byte-identical before/after on a fixture carrying both outcomes
+   (existing mechanism: the `outcomes` array read by the MESSAGES CSV writer).
+   Asserted by direct diff.
+3. **Consolidated run unchanged under `-g -o`** (assertable): the consolidation
+   merge still carries outcome counts into cluster rows; MESSAGES CSV
+   byte-identical before/after. Asserted by direct diff.
+4. **No runtime warnings** (assertable): stderr carries no ` at ltl line N`
+   lines on the criterion 1–3 runs.
+5. **Full suite green** (assertable): every `tests/validate-*.sh` passes on the
+   finished commit (completion gate).
+
+## Merge gate
+
+Per-feature workflow step 1: full harness suite + before/after benchmark
+(517-before captured on the base commit for both targeted selections).

--- a/ltl
+++ b/ltl
@@ -802,6 +802,7 @@ my $bucket_stats_capture_mode      = undef;   # 'raw' or 'bin' (set before parsi
 my $bucket_duration_stats_demand   = 0;       # per-time-bucket statistics (%log_analysis): timeline latency column, STATS CSV
 my $message_duration_stats_demand  = 0;       # per-message-key statistics (%log_messages): messages-table statistics variant, MESSAGES CSV
 my $bytes_aggregate_demand         = 0;       # bytes_occurrences/bytes_min/bytes_max at both scopes: CSV surfaces and bytes-family sorts (#516)
+my $message_outcomes_demand        = 0;       # per-message success/failure counters: MESSAGES CSV successes/failures columns (#517)
 
 # Statistics-group demand registry (#305): extends the store-level demand
 # above to statistic-group granularity. The 22-statistic duration ladder is
@@ -11733,6 +11734,12 @@ sub adapt_to_command_line_options {
            $write_messages_to_csv
         || $sort_key =~ /^bytes_(?:occurrences|min|mean|max)$/
     ) ) ? 1 : 0;
+    # Per-message outcome-counter demand (#517): the per-message success/failure
+    # counters reach the user only through the MESSAGES CSV successes/failures
+    # columns. The default classification surfaces (summary classified rows,
+    # timeline percentage columns, errRate) read the run totals and
+    # %bucket_outcomes, not this store.
+    $message_outcomes_demand = $write_messages_to_csv ? 1 : 0;
 
     # Statistics-group demand (#305): layer per-group demand on top of the
     # store-level booleans above, from the consumer declarations in
@@ -12670,7 +12677,7 @@ sub read_and_process_logs {
                         if ($is_new_key) {
                             # Build stats source from parsed line values for merge_consolidation_stats()
                             my $stats_source = { occurrences => 1 };
-                            $stats_source->{outcomes}[$line_outcome] = 1 if $line_outcome;
+                            $stats_source->{outcomes}[$line_outcome] = 1 if $message_outcomes_demand && $line_outcome;
                             if ($metrics_observed) {
                                 $stats_source->{total_bytes} = $bytes if defined $bytes;
                                 if (defined $count) {
@@ -12765,7 +12772,7 @@ sub read_and_process_logs {
                         });
 
                         $log_messages{$category}{$log_key}{occurrences}++;
-                        $log_messages{$category}{$log_key}{outcomes}[$line_outcome]++ if $line_outcome;
+                        $log_messages{$category}{$log_key}{outcomes}[$line_outcome]++ if $message_outcomes_demand && $line_outcome;
 
                         # Bytes carries the same aggregate family as count (#432).
                         # bytes_occurrences counts lines that actually carried a
@@ -12924,7 +12931,7 @@ sub read_and_process_logs {
                         }
                     } else {
                         $log_messages{$category}{$log_key}{occurrences}++;
-                        $log_messages{$category}{$log_key}{outcomes}[$line_outcome]++ if $line_outcome;
+                        $log_messages{$category}{$log_key}{outcomes}[$line_outcome]++ if $message_outcomes_demand && $line_outcome;
                     }
                     }  # end: if (!$consolidation_s1_matched)
                 }


### PR DESCRIPTION
Fixes #517 (per-message success/failure counts captured per line although only the MESSAGES CSV reads them).

The three write sites (main capture path, consolidation-absorbed path, per-new-key consolidation stats source) now test `$message_outcomes_demand`, true under `-o`. Default classification surfaces (summary classified rows, timeline percentage columns, errRate) read the run totals and `%bucket_outcomes` and are untouched. Open feature #456 (rendered per-message success/failure indicator) joins the demand terms when it lands — noted in features/517-message-outcomes-demand-gate.md.

Gate evidence (per-feature completion gate):
- Full harness suite: 32/32 exit 0 with assertions confirmed run.
- Before/after benchmark, both targeted selections, same machine: parse/read_files −3.5%; log_messages −46.4 MB (−20.3%), rss_peak −48.4 MB (−12.1%) — the humungous-uniqueness selection returns to its pre-#453 store size.
- MESSAGES/STATS CSV byte-identical before/after under `-o` and `-g -o` on a mixed success/failure fixture; stderr clean of runtime warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpHPe9Hw5rJc1LswLZkd4M