### PR TITLE
#520 An inert sort holds no bytes aggregate-family demand

### DIFF
--- a/features/520-inert-sort-bytes-aggregate-demand.md
+++ b/features/520-inert-sort-bytes-aggregate-demand.md
@@ -69,30 +69,46 @@ commit `b5389e7` before the first code change.
 
 ## Measurement
 
-The gate only changes runs that combine `-n 0` with a bytes-family sort operand and
-no `-o`, so the benchmark case (which is a retaining run) is a no-op by construction
-and measures only that nothing regressed. The effect itself is measured on the store
-it stops filling.
+The gate changes per-line work only on runs that combine `-n 0` with a bytes-family
+sort operand and no `-o`, so that is the shape it is measured on. Same machine, same
+file, five interleaved runs per arm; the before arm is the base commit's `ltl`
+(`b5389e7`) verified byte-identical to `git show b5389e7:ltl`.
 
-Input: `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt`
-(5,000 lines, 5 one-minute buckets), `--disable-progress -ni --terminal-width 200
--bs 1 -mem -V benchmark-data`. `Devel::Size` over identical content is deterministic,
-so these are exact values, not medians.
+Input: `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-07.txt`
+(155 MB, 761,698 lines). Invocation: `--disable-progress -ni --terminal-width 200
+-bs 60 -n 0 -so bytes_min -V benchmark-data`.
 
-| run | `MEMORY log_analysis` before | after |
-|---|---|---|
-| `-n 0` | 363,897 B | 363,897 B |
-| `-n 0 -so bytes_min` | 365,474 B | 363,897 B |
+| metric | before (median) | after (median) | change |
+|---|---|---|---|
+| `parse/read_files` | 7.399 s | 7.302 s | **-97 ms, -1.31%** |
+| `TIMING/total` | 7.501 s | 7.406 s | **-95 ms, -1.27%** |
 
-The 1,577 B the inert sort used to add over five buckets is the per-bucket bytes
-family. After the change the two runs are identical, which is criterion 1; the
-pre-change inequality is its failure proof.
+Ranges: before `parse` 7.365-7.414 s, after 7.226-7.356 s; before `total`
+7.466-7.517 s, after 7.330-7.457 s. **The two distributions do not overlap on either
+metric.** Normalised, the saving is 0.127 s per million lines - the three hash
+operations per bytes-carrying line that the gate now skips.
+
+Memory, from a separate `-mem` run per arm (the structure walk raises RSS, so it is
+not merged with the timing table):
+
+| structure | before | after | change |
+|---|---|---|---|
+| `MEMORY/log_analysis` | 55,259,354 B | 55,254,897 B | -4,457 B |
+| `MEMORY/rss_peak` | 92,651,520 B | 92,372,992 B | -278,528 B |
+
+The store saving is small here because `-bs 60` over one day is 24 buckets, and the
+family costs about 186 B per bucket. It scales with bucket count, not with line
+count; the line-count-proportional saving is the time above.
+
+The same store measurement on a five-bucket slice makes acceptance criterion 1 exact:
+`-n 0 -so bytes_min` sized `%log_analysis` at 365,474 B against 363,897 B for plain
+`-n 0`, and now reports the same 363,897 B.
 
 ## Completion gate
 
 Run on the finished change with `$version_number` restored to `0.18.0`.
 
-**Harness suite — 32 of 32 pass**, every summary line reporting checks actually run:
+**Harness suite - 32 of 32 pass**, every summary line reporting checks actually run:
 `validate-csv-output` 28, `validate-statistics` 21 scenarios, `validate-explain` 154,
 `validate-format-detection` 249, `validate-profile` 106, `validate-statistics-demand`
 95, `validate-heatmap-palette` 85, `validate-histogram-bin-counters` 84,
@@ -115,15 +131,11 @@ failures are the nine #469 cells (one bin-model percentile projection onto the s
 geometry) in `tests/statistics-drift/known-failures.tsv`.
 
 **Benchmark**, `single-day-access-log-standard`, before captured on base commit
-`b5389e7` prior to the first code change, after on the finished change, same machine:
-
-| metric | before | after | change |
-|---|---|---|---|
-| `parse/read_files` | 9.5 s | 9.4 s | -1.6% |
-| `TIMING/total` | 9.7 s | 9.6 s | -1.5% |
-| `MEMORY/rss_peak` | 143.5 MB | 143.9 MB | +0.3% |
-| `MEMORY/log_analysis` | 52.7 MB | 52.7 MB | 0.0% |
-
-Nothing worse by more than 5%. The case is a retaining run with no bytes-family
-sort, so it exercises neither side of the gate — the deltas are run-to-run variation.
-Both TSVs deleted afterwards.
+`b5389e7` prior to the first code change, after on the finished change, one run each:
+`parse/read_files` 9.5 s to 9.4 s (-150 ms), `TIMING/total` 9.7 s to 9.6 s (-143 ms),
+`MEMORY/rss_peak` 143.5 MB to 143.9 MB (+432 KB), `MEMORY/log_analysis` unchanged at
+52.7 MB. **That case passes no options, so the demand flag resolves to 0 on both
+sides and the run never takes the gated path** - the unchanged `log_analysis` is the
+direct evidence. Its deltas are run-to-run variation in both directions and attribute
+nothing to this change; the attributed figures are the interleaved medians under
+§ Measurement. Both TSVs deleted afterwards.

--- a/features/520-inert-sort-bytes-aggregate-demand.md
+++ b/features/520-inert-sort-bytes-aggregate-demand.md
@@ -1,0 +1,129 @@
+# #520 — An inert sort holds no demand
+
+Issue #520 (`-n 0` reports `-so/--sort-on` inert, but its resolved sort key still
+holds the bytes aggregate-family demand alive).
+
+## Requirement
+
+Under `-n 0` no message is retained, so `-so` ranks nothing and is reported inert
+(`features/458-top-messages-zero-no-per-message-retention.md` D3). The resolved sort
+key nevertheless stays in place, and the bytes aggregate-family demand gate
+(`features/516-bytes-aggregate-demand-gate.md` D1) reads it: `-n 0 -so bytes_min`
+with no `-o` captures `bytes_occurrences` / `bytes_min` / `bytes_max` into
+`%log_analysis` on every bytes-carrying line with nothing left to read them.
+
+A sort operand that cannot rank anything creates no demand. The family's other
+consumer — the two CSV surfaces — is `-o`, an independent demand term that is not
+affected.
+
+The per-message half of the family needs no change: its capture site sits inside the
+retention block, so `-n 0` already skips it. Only the per-bucket half is exposed.
+
+## Decisions
+
+### D1 — The sort term of the bytes demand is conditioned on retention
+
+`$bytes_aggregate_demand`'s sort disjunct becomes
+`( $capture_messages && $sort_key =~ /^bytes_(?:occurrences|min|mean|max)$/ )`. The
+`-o` disjunct and the `!$omit_bytes` conjunct are untouched, so every run that can
+produce a bytes-family surface still captures the family.
+
+Conditioning the term rather than clearing `$sort_key` under `-n 0` is deliberate:
+#458 D3 keeps the resolved operand so `-V statistics-demand` can report truthfully
+what the user asked for (`sort_gate: operand=<key> family=<family> observed=n/a
+fallback=none`). Clearing it would make that diagnostic lie.
+
+### D2 — Same shape as the sibling store-level demand flags
+
+`$message_duration_stats_demand` is already `!$omit_durations && $capture_messages`
+for the same reason: its surfaces exist only for retained messages. This change puts
+the bytes family's message-scoped demand term on the same footing. The other two
+flags need no change — `$message_outcomes_demand`'s three write sites all sit inside
+the retention block, so the flag is already inert under `-n 0`.
+
+## Acceptance criteria
+
+1. **The wasted capture stops** (assertable): on a bytes-carrying input,
+   `-n 0 -so bytes_min` and `-n 0` report an identical `MEMORY log_analysis` value
+   in `-V benchmark-data -mem`. Before the change they differ (the delta is the
+   family). `Devel::Size` over the same content is deterministic, so equality is an
+   exact assertion, and the pre-change inequality is the failure proof.
+2. **Nothing rendered changes under `-n 0`** (assertable): the rendered output of
+   `-n 0 -so bytes_min` is byte-identical before/after on the same input.
+3. **The CSV surfaces are unaffected** (assertable): under `-n 0 -so bytes_min -o`
+   the STATS CSV is byte-identical before/after — the `-o` demand term still holds
+   the family alive with no message retained.
+4. **A retaining run is unaffected** (assertable): `-n 25 -so bytes_min` orders and
+   renders the top-messages table identically before/after, and its `-o` CSVs are
+   byte-identical.
+5. **No runtime warnings** (assertable): stderr carries no ` at ltl line N` lines on
+   the criterion 1–4 runs.
+6. **Full suite green** (assertable): every `tests/validate-*.sh` passes on the
+   commit being merged (completion gate).
+
+## Merge gate
+
+Per-feature workflow step 1: the complete harness suite plus a before/after
+benchmark on `single-day-access-log-standard`, the before run captured on the base
+commit `b5389e7` before the first code change.
+
+## Measurement
+
+The gate only changes runs that combine `-n 0` with a bytes-family sort operand and
+no `-o`, so the benchmark case (which is a retaining run) is a no-op by construction
+and measures only that nothing regressed. The effect itself is measured on the store
+it stops filling.
+
+Input: `logs/AccessLogs/localhost_access_log-twx01-twx-thingworx-0.2025-05-05-5k.txt`
+(5,000 lines, 5 one-minute buckets), `--disable-progress -ni --terminal-width 200
+-bs 1 -mem -V benchmark-data`. `Devel::Size` over identical content is deterministic,
+so these are exact values, not medians.
+
+| run | `MEMORY log_analysis` before | after |
+|---|---|---|
+| `-n 0` | 363,897 B | 363,897 B |
+| `-n 0 -so bytes_min` | 365,474 B | 363,897 B |
+
+The 1,577 B the inert sort used to add over five buckets is the per-bucket bytes
+family. After the change the two runs are identical, which is criterion 1; the
+pre-change inequality is its failure proof.
+
+## Completion gate
+
+Run on the finished change with `$version_number` restored to `0.18.0`.
+
+**Harness suite — 32 of 32 pass**, every summary line reporting checks actually run:
+`validate-csv-output` 28, `validate-statistics` 21 scenarios, `validate-explain` 154,
+`validate-format-detection` 249, `validate-profile` 106, `validate-statistics-demand`
+95, `validate-heatmap-palette` 85, `validate-histogram-bin-counters` 84,
+`validate-regression` 74, `validate-index-read-back` 59, `validate-profile-render` 50,
+`validate-doc-examples` 48, `validate-udm-specs` 43,
+`validate-classification-percentages` 41, `validate-summary-contribution-bar` 39,
+`validate-runtime-config` 36, `validate-udm-counting` 28, `validate-outcome-criteria`
+26, `validate-category-names` 26, `validate-progress-line` 24,
+`validate-format-registry` / `validate-recursive-file-selection` 22 each,
+`validate-duration-display` / `validate-histogram-ticks` 21 each,
+`validate-help-content` / `validate-message-control-characters` 11,
+`validate-numeric-criteria-notices` 10, `validate-distribution-shape` 8,
+`validate-log-level-vocabulary` 8, `validate-help-layout` 6,
+`validate-csv-input` / `validate-message-grouping-notices` 4. Zero failures.
+`validate-csv-output.sh` ran before `validate-statistics.sh` for the shared `CI=1`
+cache; `./tests/cleanup-test-artifacts.sh` was run afterwards.
+
+**Statistics drift**: no T3 or T4 failure on any layer. The only registered known
+failures are the nine #469 cells (one bin-model percentile projection onto the shared
+geometry) in `tests/statistics-drift/known-failures.tsv`.
+
+**Benchmark**, `single-day-access-log-standard`, before captured on base commit
+`b5389e7` prior to the first code change, after on the finished change, same machine:
+
+| metric | before | after | change |
+|---|---|---|---|
+| `parse/read_files` | 9.5 s | 9.4 s | -1.6% |
+| `TIMING/total` | 9.7 s | 9.6 s | -1.5% |
+| `MEMORY/rss_peak` | 143.5 MB | 143.9 MB | +0.3% |
+| `MEMORY/log_analysis` | 52.7 MB | 52.7 MB | 0.0% |
+
+Nothing worse by more than 5%. The case is a retaining run with no bytes-family
+sort, so it exercises neither side of the gate — the deltas are run-to-run variation.
+Both TSVs deleted afterwards.

--- a/ltl
+++ b/ltl
@@ -11730,9 +11730,12 @@ sub adapt_to_command_line_options {
     # CSV surfaces and the bytes-family sort operands — nothing is rendered from
     # them (the rendered bytes columns read total_bytes, which stays ungated).
     # A run with no such consumer skips the per-line capture at both scopes.
+    # The sort operand only ranks the top-messages table, so it is a consumer only
+    # while a message is retained: under -n 0 the sort is inert (#458 D3) and holds
+    # no demand, while the CSV term stands on its own.
     $bytes_aggregate_demand = ( !$omit_bytes && (
            $write_messages_to_csv
-        || $sort_key =~ /^bytes_(?:occurrences|min|mean|max)$/
+        || ( $capture_messages && $sort_key =~ /^bytes_(?:occurrences|min|mean|max)$/ )
     ) ) ? 1 : 0;
     # Per-message outcome-counter demand (#517): the per-message success/failure
     # counters reach the user only through the MESSAGES CSV successes/failures


### PR DESCRIPTION
Fixes #520.

Under `-n 0` no message is retained, so `-so/--sort-on` ranks nothing and is reported inert (#458 D3, the inert-option notice) — but its resolved sort key still held the bytes aggregate-family demand gate (#516 D1) true. `-n 0 -so bytes_min` with no `-o` therefore captured `bytes_occurrences`/`bytes_min`/`bytes_max` into `%log_analysis` on every bytes-carrying line with nothing left to read them.

The sort disjunct of `$bytes_aggregate_demand` is now conditioned on `$capture_messages`. The `-o` disjunct and the `!$omit_bytes` conjunct are untouched, so every run that can produce a bytes-family surface still captures the family — including `-n 0 -o`, where the STATS CSV still carries the four family columns. The resolved sort key is deliberately left in place rather than cleared, so `-V statistics-demand` keeps reporting truthfully what the user asked for.

Record: `features/520-inert-sort-bytes-aggregate-demand.md` (D1, D2, acceptance criteria, measurement, completion gate).

**Scope.** The issue was filed naming three further candidates; all three were dismissed on investigation and the issue was reframed to the inert-sort demand alone. The dismissals and their evidence are recorded in the issue body — notably that `%threadpool_activity` has a second, non-message-gated reader (it elects and orders the timeline's threadpool columns), so gating it would have removed those columns under `-tpas -n 0`.

**Performance — measured on the shape the gate changes** (`-n 0 -so bytes_min`, 155 MB / 761,698-line access log, five interleaved runs per arm, before arm = base commit `b5389e7`'s `ltl`):

| metric | before (median) | after (median) | change |
|---|---|---|---|
| `parse/read_files` | 7.399 s | 7.302 s | **−97 ms, −1.31%** |
| `TIMING/total` | 7.501 s | 7.406 s | **−95 ms, −1.27%** |

Ranges do not overlap on either metric (before `parse` 7.365–7.414 s, after 7.226–7.356 s). Normalised: 0.127 s saved per million lines — the three hash operations per bytes-carrying line the gate now skips. `MEMORY/rss_peak` −278,528 B, `MEMORY/log_analysis` −4,457 B over 24 buckets (the store saving scales with bucket count, not line count).

**Correctness.** `MEMORY log_analysis` on a five-bucket slice: `-n 0 -so bytes_min` was 365,474 B against 363,897 B for plain `-n 0`, and now reports the same 363,897 B. Rendered output and STATS/MESSAGES CSVs byte-identical before/after at `-n 0` and `-n 25`, with and without `-o`; no runtime warnings.

**Completion gate.** All 32 `tests/validate-*.sh` exit 0 with assertions actually running, no T3/T4 statistics drift (only the registered #469 known failures). The workflow's `single-day-access-log-standard` benchmark was also run before/after — but that case passes no options, so the demand flag resolves to 0 on both sides and it never takes the gated path (its `MEMORY/log_analysis` is unchanged at 52.7 MB, which is the evidence). Its deltas attribute nothing to this change; the table above is the attributed measurement.