### PR TITLE
#532: progress line shows the file's path, shortened in the middle

### DIFF
--- a/features/446-overall-progress-indicator.md
+++ b/features/446-overall-progress-indicator.md
@@ -110,6 +110,7 @@ Run 2026-08-29 on the merged commit: 30 harnesses, 1,354 assertions passed, 3 fa
 ## Related
 
 - #397 (per-file percentage progress) — the predecessor; its line is what D5 reshapes.
+- #532 (progress line shows the file's path, shortened in the middle) — changes what fills D5's filename slot: the path as given, rendered as the "Processed files" table renders it. Record: `features/532-progress-line-file-path.md`.
 - #420 (`-r`/`--recursive`) and #445 (unquoted glob consumed by the shell) — produce the long lists; the denominator is the *selected* set, never the tree.
 - #181 (buffered read pipeline, on hold) — would change what "bytes consumed" means; D2 states the numerator as bytes processed, which survives it.
 - #412 (notices surface) — progress lines are transient and self-clearing; notices are persistent. No overlap.

--- a/features/532-progress-line-file-path.md
+++ b/features/532-progress-line-file-path.md
@@ -1,0 +1,57 @@
+# Feature: Progress line shows the file's path, shortened in the middle (#532)
+
+## Overview
+
+While logs are being read, the progress line names the file in flight. It has
+shown the bare file name, with the directory removed, since the narrow-terminal
+display fix (#32). The end-of-run "Processed files" table renders the same file
+differently: the path as given, shortened in the middle with an ellipsis when it
+does not fit. This drop makes the progress line render the name the way the
+table does, so the folder being processed stays visible on the left and the end
+of the file name on the right.
+
+## GitHub Issue
+
+#532 — Enhancement: progress line shows the file's path, shortened in the middle like the Processed files table
+
+## Status
+
+In progress (2026-09-04).
+
+## Requirements
+
+- The progress line shows the file's path and name as given on the command
+  line or produced by traversal, rendered by the same rule the "Processed
+  files" table uses: whole when it fits, otherwise shortened in the middle so
+  the start of the path and the end of the file name both remain visible.
+- The line's shape is unchanged: the name is still the last element and still
+  the one that absorbs the fit (`features/446-overall-progress-indicator.md`
+  D5, the filename is the variable-length element that goes last).
+- One resolution surface: the existing shortener is reused, not duplicated.
+
+## Locked decisions
+
+**D1 — The progress line calls the shortener the way the "Processed files"
+table does: on the path as given, with no directory strip.** The strip was the
+only thing that set the two surfaces apart. With it gone the shortener has one
+behaviour for both callers, so its strip-path flag is removed rather than left
+unused: a flag no caller passes is a second behaviour nobody exercises and
+nobody tests.
+
+**D2 — No before benchmark.** The shortener runs only when a frame is painted,
+at most twice a second under the 500 ms repaint gate
+(`features/446-overall-progress-indicator.md` D4); nothing per line changes.
+
+## Acceptance criteria
+
+| # | Criterion | Triage |
+|---|---|---|
+| A1 | With a path that fits, the frame ends with the path exactly as given, directory included | assertable: `tests/validate-progress-line.sh`, scenario `path-in-frame` |
+| A2 | With a path that does not fit, the frame ends with the start of the path, an ellipsis, and the end of the file name, and still fits the row | assertable: same scenario, narrow width |
+| A3 | The numerics ahead of the name are unaffected | assertable: existing `narrow-terminal` scenario assertions continue to hold |
+
+## Related
+
+- #446 (overall progress indicator) — owns the line's shape; D5 there names the
+  filename as the element that absorbs the fit.
+- #32 (narrow terminal display fixes) — where the directory strip was introduced.

--- a/features/532-progress-line-file-path.md
+++ b/features/532-progress-line-file-path.md
@@ -38,9 +38,7 @@ behaviour for both callers, so its strip-path flag is removed rather than left
 unused: a flag no caller passes is a second behaviour nobody exercises and
 nobody tests.
 
-**D2 — No before benchmark.** The shortener runs only when a frame is painted,
-at most twice a second under the 500 ms repaint gate
-(`features/446-overall-progress-indicator.md` D4); nothing per line changes.
+**D2 — The before/after benchmark runs.** An executable line of `ltl` changed, which is the scope table's first row (`docs/process/workflow.md` § 3); the shortener's own cost is not the point, the rule is. The before run is taken on the base commit in a worktree of the release branch.
 
 ## Acceptance criteria
 

--- a/ltl
+++ b/ltl
@@ -60,7 +60,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0";
+my $version_number = "0.18.0-532";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );
@@ -10912,16 +10912,12 @@ sub wrap_text {
     return @lines;
 }
 
-# Shorten filename to fit within max_length, keeping start and end with '...' in middle
-# If $strip_path is true, removes directory path first (keeps only basename)
+# Shorten a file path to fit within max_length, keeping its start and end
+# around a '...' in the middle, so the directory stays visible on the left and
+# the end of the file name on the right. The progress line and the "Processed
+# files" table both render names through this one rule.
 sub shorten_filename {
-    my ($filename, $max_length, $strip_path) = @_;
-
-    # Optionally strip directory path, keeping only the filename
-    if ($strip_path) {
-        $filename =~ s{.*/}{};  # Remove everything up to and including last /
-        $filename =~ s{.*\\}{}; # Also handle Windows backslashes
-    }
+    my ($filename, $max_length) = @_;
 
     return $filename if length($filename) <= $max_length;
     return $filename if $max_length < 10;  # Too short to meaningfully shorten
@@ -11087,7 +11083,7 @@ sub progress_line_text {
     # name back whole, which on this surface would run the line past the width
     # the clear covers. Truncate outright at that point: the numbers are the
     # part that must stay readable.
-    my $shown = shorten_filename( $file, $room, 1 );
+    my $shown = shorten_filename( $file, $room );
     $shown = substr( $shown, 0, $room ) if length($shown) > $room;
 
     return $prefix . $shown;

--- a/ltl
+++ b/ltl
@@ -60,7 +60,7 @@ if ($^O eq 'MSWin32') {            # Change code page to UTF-8 on Windows to sup
 }
 
 ## GLOBALS ##
-my $version_number = "0.18.0-532";
+my $version_number = "0.18.0";
 my $start_time = [gettimeofday];
 my $log_base = 2;
 my ( @ORIGINAL_ARGV, @files_processed );

--- a/tests/validate-progress-line.sh
+++ b/tests/validate-progress-line.sh
@@ -258,7 +258,7 @@ assert_command \
     contract    'features/446-overall-progress-indicator.md D4 — a final frame or the completion line is emitted unconditionally outside the throttle'
 
 assert_command \
-    command     "grep -qE '^Processing +[0-9]+%/[0-9]+% \\(file [0-9]+/3\\) line [0-9.]+[kMB]?[a-z]*, [0-9.]+[kMB]?[a-z]* total(, [0-9.]+[kMB]?[a-z]* lines/sec)?: part-[0-9]+\\.txt\$' '$MULTI'" \
+    command     "grep -qE '^Processing +[0-9]+%/[0-9]+% \\(file [0-9]+/3\\) line [0-9.]+[kMB]?[a-z]*, [0-9.]+[kMB]?[a-z]* total(, [0-9.]+[kMB]?[a-z]* lines/sec)?: [^ ]*part-[0-9]+\\.txt\$' '$MULTI'" \
     label       'the multi-file line carries file%, overall%, the counter, line, total and the filename, in that order' \
     asserts     'With two or more files the line reads: the file percentage over the overall percentage, the file counter, the current line, the run total, optionally the rate, and the filename LAST — the filename is the only variable-length element, so it sits where it cannot shift the numerics as the run moves between files' \
     produced_by 'progress_line_text() in ltl' \
@@ -269,21 +269,21 @@ assert_command \
 # a blend, sizes taken from somewhere other than the selected set — lands on
 # different numbers.
 assert_command \
-    command     "grep -qE '^Processing +0%/0% \\(file 1/3\\) .*: part-1\\.txt\$' '$MULTI'" \
+    command     "grep -qE '^Processing +0%/0% \\(file 1/3\\) .*: [^ ]*part-1\\.txt\$' '$MULTI'" \
     label       'file 1 of 3 opens at 0% overall' \
     asserts     'The overall percentage is bytes of closed files plus the live handle position over the sum of the selected sets sizes; before any file has closed that is 0 of 3160 bytes' \
     produced_by 'progress_line_text() in ltl, from the sweep in size_selected_files_for_progress()' \
     contract    'features/446-overall-progress-indicator.md D1/D2 — bytes own the percentage; the total is taken once over the final selected list'
 
 assert_command \
-    command     "grep -qE '^Processing +0%/25% \\(file 2/3\\) .*: part-2\\.txt\$' '$MULTI'" \
+    command     "grep -qE '^Processing +0%/25% \\(file 2/3\\) .*: [^ ]*part-2\\.txt\$' '$MULTI'" \
     label       'file 2 of 3 opens at 25% overall (790 of 3160 bytes closed)' \
     asserts     'A file credits its whole size to the overall numerator when it closes, so the next file opens at exactly the closed bytes over the total: 790/3160 = 25%' \
     produced_by 'read_and_process_logs() in ltl (the roll from the live position to the full size at close) and progress_line_text()' \
     contract    'features/446-overall-progress-indicator.md D2/D3 — the contribution rolls from tell to the stat size at close, so the figure is monotonic and a skipped file still reaches 100%'
 
 assert_command \
-    command     "grep -qE '^Processing +0%/50% \\(file 3/3\\) .*: part-3\\.txt\$' '$MULTI'" \
+    command     "grep -qE '^Processing +0%/50% \\(file 3/3\\) .*: [^ ]*part-3\\.txt\$' '$MULTI'" \
     label       'file 3 of 3 opens at 50% overall (1580 of 3160 bytes closed)' \
     asserts     'The overall figure accumulates across files: two closed files of 790 bytes each is 1580 of 3160, which is 50% — bytes, not the file count, which would read 66% here' \
     produced_by 'progress_line_text() in ltl' \
@@ -348,7 +348,7 @@ capture_frames "$SINGLE" \
     "$PART3"
 
 assert_command \
-    command     "grep -qE '^Processing +[0-9]+% line [0-9.]+[kMB]?[a-z]*(, [0-9.]+[kMB]?[a-z]* lines/sec)?: part-3\\.txt\$' '$SINGLE'" \
+    command     "grep -qE '^Processing +[0-9]+% line [0-9.]+[kMB]?[a-z]*(, [0-9.]+[kMB]?[a-z]* lines/sec)?: [^ ]*part-3\\.txt\$' '$SINGLE'" \
     label       'the single-file line carries one percentage and the filename' \
     asserts     'With one file the line shows the file percentage, the current line, optionally the rate, and the filename — the same shape as the multi-file line with the overall figure and counter removed' \
     produced_by 'progress_line_text() in ltl' \
@@ -427,6 +427,56 @@ assert_command \
     asserts     'The row the frame fills is the terminal it is painted on: at 60 columns the padding runs to 59, so the same self-covering property holds on a narrow terminal, where the filename shortening makes the line length vary most' \
     produced_by 'paint_progress_line() in ltl (the pad is measured from $terminal_width)' \
     contract    'features/446-overall-progress-indicator.md D8 — the row width is the terminal width the run was given'
+
+# ---------------------------------------------------------------------------
+# Scenario: the frame names the file by its path, shortened in the middle
+#
+# The name is rendered the way the "Processed files" table renders it: the path
+# as given when it fits, otherwise the start of the path, an ellipsis, and the
+# end of the file name. The fixtures are copied under directories inside
+# $TMP_DIR (where capture_frames runs) and passed by relative path, so the
+# expected text is exact and independent of where the repo is checked out.
+# ---------------------------------------------------------------------------
+current_scenario="path-in-frame"
+
+SHORT_DIR="alpha"
+LONG_DIR="a-directory-whose-name-is-long-enough-that-the-frame-cannot-hold-it"
+mkdir -p "$TMP_DIR/$SHORT_DIR" "$TMP_DIR/$LONG_DIR"
+cp "$PART1" "$TMP_DIR/$SHORT_DIR/part-1.txt"
+cp "$PART2" "$TMP_DIR/$SHORT_DIR/part-2.txt"
+cp "$PART1" "$TMP_DIR/$LONG_DIR/part-1.txt"
+cp "$PART2" "$TMP_DIR/$LONG_DIR/part-2.txt"
+
+PATHED="$TMP_DIR/pathed.frames"
+capture_frames "$PATHED" \
+    -ni --terminal-width "$WIDTH" -bs 1440 -oe -n 1 -lf "$ACCESS_FORMAT" \
+    "$SHORT_DIR/part-1.txt" "$SHORT_DIR/part-2.txt"
+
+assert_command \
+    command     "grep -qE '^Processing .*\\(file 1/2\\) .*: $SHORT_DIR/part-1\\.txt\$' '$PATHED'" \
+    label       'a path that fits is shown whole, directory included' \
+    asserts     'The frame ends with the path exactly as it was given, so the reader sees which folder the run is in and not just the file name' \
+    produced_by 'progress_line_text() in ltl (shorten_filename() on the path as given)' \
+    contract    'features/532-progress-line-file-path.md D1 — the progress line calls the shortener on the path as given, with no directory strip'
+
+LONG_PATHED="$TMP_DIR/long-pathed.frames"
+capture_frames "$LONG_PATHED" \
+    -ni --terminal-width "$NARROW_WIDTH" -bs 1440 -oe -n 1 -lf "$ACCESS_FORMAT" \
+    "$LONG_DIR/part-1.txt" "$LONG_DIR/part-2.txt"
+
+assert_command \
+    command     "grep -qE '^Processing .*\\(file 1/2\\) .*: a-d[^ ]*\\.\\.\\.[^ ]*1\\.txt\$' '$LONG_PATHED'" \
+    label       'a path that does not fit keeps its start and the end of the file name around an ellipsis' \
+    asserts     'Shortening removes the middle of the path: the frame ends with the first characters of the directory, an ellipsis, and the tail of the file name, so both the folder and the file remain identifiable' \
+    produced_by 'progress_line_text() in ltl (shorten_filename() keeps the start and the end)' \
+    contract    'features/532-progress-line-file-path.md — requirement: shortened in the middle so the start of the path and the end of the file name both remain visible'
+
+assert_command \
+    command     "! grep '^Processing ' '$LONG_PATHED' | awk -v w=$NARROW_WIDTH 'length(\$0) > w - 1 { print; found = 1 } END { exit !found }'" \
+    label       "no frame with a shortened path exceeds $((NARROW_WIDTH - 1)) characters" \
+    asserts     'Keeping the directory does not change what absorbs the fit: the name is still shortened to the room the numerics leave, and the line never wraps' \
+    produced_by 'progress_line_text() in ltl (the room calculation)' \
+    contract    'features/446-overall-progress-indicator.md D5 — the filename is the variable-length element and is shortened to fit the terminal'
 
 # ---------------------------------------------------------------------------
 # Scenario: an unreadable file keeps the two-percentage shape.


### PR DESCRIPTION
Closes #532.

The progress line named the file in flight by its bare name, with the directory stripped before shortening, while the "Processed files" table rendered the same file by its path as given, shortened in the middle. The line now calls the shortener the way the table does, so the folder being read stays visible on the left and the end of the file name on the right. The shortener's strip-path flag had no other caller and is removed.

- Harness: a `path-in-frame` scenario in `tests/validate-progress-line.sh` asserts a fitting path is shown whole and a long one keeps its start and the file name's tail around an ellipsis inside the row width; the older name-field patterns accept a path in front of the file name.
- Record: `features/532-progress-line-file-path.md`, linked from the #446 record.

Completion gate on 04d4db4: 36 harnesses, all passing; before/after benchmark on the single-day access log, total time +0.2 %, peak memory unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XGAinpJmBtzaZxnmLfvpo
